### PR TITLE
Fix/send things

### DIFF
--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -9,8 +9,8 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <Company>Erik 'SiLo' Rogers</Company>
         <Product>Arbiter</Product>
-        <AssemblyVersion>0.9.4</AssemblyVersion>
-        <FileVersion>0.9.4</FileVersion>
+        <AssemblyVersion>0.9.4.1</AssemblyVersion>
+        <FileVersion>0.9.4.1</FileVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Arbiter.App/Themes/TalgoniteTextBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteTextBox.axaml
@@ -202,8 +202,8 @@
     <Style Selector="TextBox Button.clear">
         <Setter Property="Width" Value="24"/>
         <Setter Property="Height" Value="24"/>
-        <Setter Property="Padding" Value="4"/>
-        <Setter Property="Margin" Value="0,0,8,0"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="Margin" Value="0,0,2,0"/>
     </Style>
     
     <!-- Reveal Style -->

--- a/Arbiter.App/ViewModels/Tracing/TracePacketViewModel.cs
+++ b/Arbiter.App/ViewModels/Tracing/TracePacketViewModel.cs
@@ -25,7 +25,7 @@ public partial class TracePacketViewModel(
     [ObservableProperty] private string? _clientName = clientName;
 
     [ObservableProperty]
-    private PacketDirection _direction = encrypted is ClientPacket ? PacketDirection.Client : PacketDirection.Server;
+    private PacketDirection _direction = decrypted is ClientPacket ? PacketDirection.Client : PacketDirection.Server;
     
     [ObservableProperty] private byte _command = encrypted.Command;
     

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.ContextMenu.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.ContextMenu.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Arbiter.App.Extensions;
 using Arbiter.App.Models;
+using Arbiter.Net.Client;
 using Avalonia;
 using CommunityToolkit.Mvvm.Input;
 
@@ -23,7 +24,8 @@ public partial class TraceViewModel
 
         var packetStrings = SelectedPackets.Select(vm => vm.DisplayMode switch
         {
-            PacketDisplayMode.Decrypted => $"{vm.Command:X2} {vm.FormattedDecrypted}",
+            PacketDisplayMode.Decrypted =>
+                $"{(vm.DecryptedPacket is ClientPacket ? ">" : "<")} {vm.Command:X2} {vm.FormattedDecrypted}",
             _ => vm.FormattedEncrypted,
         });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.4b] - 2025-09-20
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `ClientExitRequestMessage` now has optional `Reason` field (it is not always provided)
+- Clear text field button size
+- Copying a decrypted packet now includes `<` or `>` direction for `Send` window convenience
+- Send syntax allows spacing between `>`/`<` and command code
+
 ## [0.9.4] - 2025-09-20
 
 ### Added


### PR DESCRIPTION
### Changed

- `ClientExitRequestMessage` now has optional `Reason` field (it is not always provided)
- Clear text field button size
- Copying a decrypted packet now includes `<` or `>` direction for `Send` window convenience
- Send syntax allows spacing between `>`/`<` and command code