### PR TITLE
feat: settings window and ui revamp

### DIFF
--- a/Arbiter.App/Mappings/Client/ClientMessageMappingProvider.cs
+++ b/Arbiter.App/Mappings/Client/ClientMessageMappingProvider.cs
@@ -199,9 +199,9 @@ public class ClientMessageMappingProvider : IInspectorMappingProvider
             b.Section("Slot")
                 .Property(m => m.Slot, p => p.ToolTip("Slot selected by the user."))
                 .IsExpanded(m => m.Slot.HasValue);
-            b.Section("Text Input")
-                .Property(m => m.TextInputs, p => p.ShowMultiline().ToolTip("Text inputs provided by the user."))
-                .IsExpanded(m => m.TextInputs.Count > 0);
+            b.Section("Argument")
+                .Property(m => m.Arguments, p => p.ShowMultiline().ToolTip("Arguments associated with the dialog menu choice."))
+                .IsExpanded(m => m.Arguments.Count > 0);
         });
     }
 

--- a/Arbiter.App/Mappings/Server/ServerMessageMappingProvider.cs
+++ b/Arbiter.App/Mappings/Server/ServerMessageMappingProvider.cs
@@ -883,7 +883,8 @@ public class ServerMessageMappingProvider : IInspectorMappingProvider
                 .Property(m => m.UserId, p => p.ShowHex().ToolTip("ID of the user."))
                 .Property(m => m.Class, p => p.ToolTip("Base class of the user."));
             b.Section("Movement")
-                .Property(m => m.Direction, p => p.ToolTip("Direction the user is currently facing."));
+                .Property(m => m.Direction, p => p.ToolTip("Direction the user is currently facing."))
+                .Property(m => m.CanMove, p => p.ToolTip("Whether the user is allowed to move."));
             b.Section("Guild")
                 .Property(m => m.HasGuild, p => p.ToolTip("Whether the user is a member of a guild."));
         });

--- a/Arbiter.App/Mappings/Server/ServerMessageMappingProvider.cs
+++ b/Arbiter.App/Mappings/Server/ServerMessageMappingProvider.cs
@@ -631,7 +631,8 @@ public class ServerMessageMappingProvider : IInspectorMappingProvider
                 .Property(m => m.MenuChoices)
                 .IsExpanded(m => m.DialogType is DialogType.Menu or DialogType.CreatureMenu);
             b.Section("Text Input")
-                .Property(m => m.InputPrompt, p => p.ShowMultiline().ToolTip("Prompt displayed in the text input."))
+                .Property(m => m.InputPrompt, p => p.ShowMultiline().ToolTip("Prompt displayed above the text input."))
+                .Property(m => m.InputDescription, p=> p.ShowMultiline().ToolTip("Description displayed below the text input."))
                 .Property(m => m.InputMaxLength, p => p.ToolTip("Maximum length of the text input."))
                 .IsExpanded(m => m.DialogType == DialogType.TextInput);
             b.Section("Navigation")

--- a/Arbiter.App/Mappings/Server/ServerTypeOverridesProvider.cs
+++ b/Arbiter.App/Mappings/Server/ServerTypeOverridesProvider.cs
@@ -51,7 +51,7 @@ public class ServerTypeOverridesProvider : IInspectorMappingProvider
                 .Property(m => m.Name, p => p.ShowMultiline().ToolTip("Display name of the creature."))
                 .Property(m => m.Direction, p => p.ToolTip("Direction the creature is facing."))
                 .Property(m => m.Unknown, p => p.ShowHex())
-                .DisplayName(m => $"Entity {m.Id:X}")
+                .DisplayName(m => m.Name ?? $"Entity {m.Id:X}")
                 .IsExpanded(_ => false);
         });
 

--- a/Arbiter.App/Models/ArbiterSettings.cs
+++ b/Arbiter.App/Models/ArbiterSettings.cs
@@ -14,6 +14,7 @@ public class ArbiterSettings : ICloneable
     public int RemoteServerPort { get; set; } = 2610;
     
     public bool TraceOnStartup { get; set; }
+    public bool TraceAutosave { get; set; }
     public WindowRect? StartupLocation { get; set; } = new();
 
     public object Clone() => new ArbiterSettings
@@ -23,6 +24,7 @@ public class ArbiterSettings : ICloneable
         RemoteServerAddress = RemoteServerAddress,
         RemoteServerPort = RemoteServerPort,
         TraceOnStartup = TraceOnStartup,
+        TraceAutosave = TraceAutosave,
         StartupLocation = StartupLocation?.Clone() as WindowRect
     };
 

--- a/Arbiter.App/Themes/TalgoniteBorder.axaml
+++ b/Arbiter.App/Themes/TalgoniteBorder.axaml
@@ -1,5 +1,24 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Border Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <Border Classes="divider-h" Width="100"/>
+                
+                <Panel Height="100" Width="100">
+                    <Border Classes="sunken-shadow" />
+                    <Border Classes="sunken-highlight" />
+                </Panel>
+                
+                <Panel Height="100" Width="100">
+                    <Border Classes="raised-shadow" />
+                    <Border Classes="raised-highlight" />
+                </Panel>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
     
     <Style Selector="Border.divider-h">
         <Setter Property="Background" Value="{StaticResource Talgonite.Border.DividerBrush}"/>
@@ -33,6 +52,15 @@
     <Style Selector="Border.raised-highlight">
         <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Border.HighlightBrush}"/>
         <Setter Property="BorderThickness" Value="1,1,0,0"/>
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="VerticalAlignment" Value="Stretch"/>
+        <Setter Property="IsHitTestVisible" Value="False"/>
+        <Setter Property="Focusable" Value="False"/>
+    </Style>
+    
+    <Style Selector="Border.raised-shadow">
+        <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Border.ShadowBrush}"/>
+        <Setter Property="BorderThickness" Value="0,0,1,1"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
         <Setter Property="VerticalAlignment" Value="Stretch"/>
         <Setter Property="IsHitTestVisible" Value="False"/>

--- a/Arbiter.App/Themes/TalgoniteButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteButton.axaml
@@ -1,5 +1,29 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Button Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <Button>
+                    Default Button
+                </Button>
+                
+                <Button IsEnabled="False">
+                    Disabled Button
+                </Button>
+                
+                <Button Classes="destructive">
+                    Destructive Button
+                </Button>
+                
+                <Button Classes="toolbar">
+                    Toolbar Button
+                </Button>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="Button">
         <Setter Property="Background" Value="{StaticResource Talgonite.Button.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.Button.Foreground}"/>
@@ -7,6 +31,8 @@
         <Setter Property="BorderThickness" Value="2"/>
         <Setter Property="CornerRadius" Value="4"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="MinWidth" Value="32"/>
+        <Setter Property="MinHeight" Value="32"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Padding" Value="8"/>

--- a/Arbiter.App/Themes/TalgoniteButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteButton.axaml
@@ -6,7 +6,7 @@
                 Padding="20">
             <StackPanel Spacing="16">
                 <Button>
-                    Default Button
+                    Normal Button
                 </Button>
                 
                 <Button IsEnabled="False">
@@ -31,8 +31,8 @@
         <Setter Property="BorderThickness" Value="2"/>
         <Setter Property="CornerRadius" Value="4"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
-        <Setter Property="MinWidth" Value="32"/>
-        <Setter Property="MinHeight" Value="32"/>
+        <Setter Property="MinWidth" Value="16"/>
+        <Setter Property="MinHeight" Value="16"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Padding" Value="8"/>

--- a/Arbiter.App/Themes/TalgoniteButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteButton.axaml
@@ -37,14 +37,6 @@
             <Setter Property="Background" Value="{StaticResource Talgonite.Button.HoverBackground}"/>
             <Setter Property="Foreground" Value="{StaticResource Talgonite.Button.HoverForeground}"/>
         </Style>
-        <Style Selector="^:pointerover /template/ Border">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
         
         <!-- Pressed Style -->
         <Style Selector="^:pressed">
@@ -62,14 +54,6 @@
         <!-- Focus Style -->
         <Style Selector="^:focus">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Button.FocusBorderBrush}"/>
-        </Style>
-        <Style Selector="^:focus /template/ Border">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
         </Style>
         
         <Style Selector="^:focus:pressed">

--- a/Arbiter.App/Themes/TalgoniteComboBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteComboBox.axaml
@@ -107,20 +107,6 @@
         <Style Selector="^:focus">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ComboBox.FocusBorderBrush}"/>
         </Style>
-        <Style Selector="^:focus /template/ Border#Border">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
-        <Style Selector="^:not(:focus) /template/ Border#Border">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
         
         <!-- Pressed Style -->
         <Style Selector="^:pressed /template/ ToggleButton#Toggle">

--- a/Arbiter.App/Themes/TalgoniteComboBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteComboBox.axaml
@@ -1,16 +1,28 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ComboBox Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <ComboBox PlaceholderText="Select..." Width="140"/>
+                
+                <ComboBox PlaceholderText="None" Width="140" IsEnabled="False"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ComboBox">
         <Setter Property="Background" Value="{StaticResource Talgonite.ComboBox.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.ComboBox.Foreground}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="2"/>
-        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="CornerRadius" Value="2"/>
         <Setter Property="Padding" Value="8,4"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="MinWidth" Value="80"/>
-        <Setter Property="MinHeight" Value="24"/>
+        <Setter Property="MinHeight" Value="40"/>
         <Setter Property="Popup.Placement" Value="BottomEdgeAlignedLeft"/>
         <Setter Property="PlaceholderForeground" Value="{StaticResource Talgonite.ComboBox.PlaceholderForeground}"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>

--- a/Arbiter.App/Themes/TalgoniteComboBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteComboBox.axaml
@@ -124,6 +124,7 @@
         </Style>
         <Style Selector="^:disabled /template/ ToggleButton#Toggle">
             <Setter Property="Foreground" Value="{StaticResource Talgonite.ComboBox.CaretDisabledForeground}"/>
+            <Setter Property="Background" Value="{StaticResource Talgonite.Button.DisabledBackground}"/>
         </Style>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteComboBoxItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteComboBoxItem.axaml
@@ -1,5 +1,23 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ComboBoxItem Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel>
+                <ComboBoxItem MinWidth="140">
+                    <TextBlock Text="First Item" Foreground="White" FontSize="16" Padding="8,4"/>
+                </ComboBoxItem>
+                <ComboBoxItem MinWidth="140">
+                    <TextBlock Text="Second Item" Foreground="White" FontSize="16" Padding="8,4"/>
+                </ComboBoxItem>
+                <ComboBoxItem MinWidth="140">
+                    <TextBlock Text="Third Item" Foreground="White" FontSize="16" Padding="8,4"/>
+                </ComboBoxItem>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ComboBoxItem">
         <Setter Property="Background" Value="{StaticResource Talgonite.ComboBoxItem.Background}"/>
         <Setter Property="Margin" Value="0"/>

--- a/Arbiter.App/Themes/TalgoniteContextMenu.axaml
+++ b/Arbiter.App/Themes/TalgoniteContextMenu.axaml
@@ -3,8 +3,8 @@
     <Style Selector="ContextMenu">
         <Setter Property="Background" Value="{StaticResource Talgonite.ContextMenu.Background}"/>
         <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ContextMenu.BorderBrush}"/>
-        <Setter Property="BorderThickness" Value="2"/>
-        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="2"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="TextBlock.FontSize" Value="14"/>

--- a/Arbiter.App/Themes/TalgoniteContextMenu.axaml
+++ b/Arbiter.App/Themes/TalgoniteContextMenu.axaml
@@ -1,5 +1,19 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ContextMenu Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <ContextMenu>
+                <MenuItem Header="First Item"/>
+                <MenuItem Header="Second Item"/>
+                <MenuItem Header="Third Item"/>
+                <Separator/>
+                <MenuItem Header="Last Item"/>
+            </ContextMenu>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ContextMenu">
         <Setter Property="Background" Value="{StaticResource Talgonite.ContextMenu.Background}"/>
         <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ContextMenu.BorderBrush}"/>

--- a/Arbiter.App/Themes/TalgoniteExpander.axaml
+++ b/Arbiter.App/Themes/TalgoniteExpander.axaml
@@ -1,10 +1,28 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Expander Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <Expander Header="Collapsed Section" Width="200" IsExpanded="False"/>
+                
+                <Expander Header="Disabled Section" Width="200" IsExpanded="False" IsEnabled="False"/>
+                
+                <Expander Header="Expanded Section" Width="200" IsExpanded="True">
+                    <TextBlock TextWrapping="Wrap" Foreground="White" FontSize="16" Margin="8">
+                        The quick brown fox jumps over the lazy dog.
+                    </TextBlock>
+                </Expander>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="Expander">
         <Setter Property="Background" Value="{StaticResource Talgonite.Expander.Background}"/>
         <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Expander.BorderBrush}"/>
         <Setter Property="BorderThickness" Value="2"/>
-        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="CornerRadius" Value="4"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="Margin" Value="0,4"/>
         <Setter Property="Padding" Value="4"/>
@@ -27,8 +45,10 @@
                         <ToggleButton Name="PART_Toggle"
                                       Grid.Row="0"
                                       Classes="expander"
+                                      MinHeight="32"
                                       Content="{TemplateBinding Header}"
                                       IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
+                                      IsEnabled="{TemplateBinding IsEnabled}"
                                       HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                                       VerticalAlignment="{TemplateBinding VerticalAlignment}"/>
                         
@@ -44,5 +64,10 @@
                 </Border>
             </ControlTemplate>
         </Setter>
+        
+        <!-- Disabled style -->
+        <Style Selector="^:disabled /template/ ToggleButton#PART_Toggle">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.TextBox.DisabledForeground}"/>
+        </Style>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteGridSplitter.axaml
+++ b/Arbiter.App/Themes/TalgoniteGridSplitter.axaml
@@ -1,5 +1,55 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- GridSplitter Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <Panel Width="100" Height="100">
+            <Grid RowDefinitions="*,*,*" ColumnDefinitions="*,*,*" ShowGridLines="True">
+                <GridSplitter Grid.Row="0" Grid.Column="0"
+                              ResizeDirection="Rows"
+                              HorizontalAlignment="Stretch" VerticalAlignment="Bottom"/>
+                
+                <GridSplitter Grid.Row="1" Grid.Column="0"
+                              ResizeDirection="Rows"
+                              HorizontalAlignment="Stretch" VerticalAlignment="Top"/>
+                
+                <GridSplitter Grid.Row="1" Grid.Column="0"
+                              ResizeDirection="Rows"
+                              HorizontalAlignment="Stretch" VerticalAlignment="Bottom"/>
+                
+                <GridSplitter Grid.Row="2" Grid.Column="0"
+                              ResizeDirection="Rows"
+                              HorizontalAlignment="Stretch" VerticalAlignment="Top"/>
+                
+                <GridSplitter Grid.Row="0" Grid.Column="1"
+                              ResizeDirection="Columns"
+                              HorizontalAlignment="Left" VerticalAlignment="Stretch"/>
+                
+                <GridSplitter Grid.Row="1" Grid.Column="1"
+                              ResizeDirection="Columns"
+                              HorizontalAlignment="Left" VerticalAlignment="Stretch"/>
+                
+                <GridSplitter Grid.Row="2" Grid.Column="1"
+                              ResizeDirection="Columns"
+                              HorizontalAlignment="Left" VerticalAlignment="Stretch"/>
+                
+                <GridSplitter Grid.Row="0" Grid.Column="2"
+                              ResizeDirection="Columns"
+                              HorizontalAlignment="Left" VerticalAlignment="Stretch"/>
+                
+                <GridSplitter Grid.Row="1" Grid.Column="2"
+                              ResizeDirection="Columns"
+                              HorizontalAlignment="Left" VerticalAlignment="Stretch"/>
+                
+                <GridSplitter Grid.Row="2" Grid.Column="2"
+                              ResizeDirection="Columns"
+                              HorizontalAlignment="Left" VerticalAlignment="Stretch"/>
+            </Grid>
+            </Panel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="GridSplitter">
         <Setter Property="Background" Value="{StaticResource Talgonite.GridSplitter.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.GridSplitter.Foreground}"/>

--- a/Arbiter.App/Themes/TalgoniteHyperlinkButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteHyperlinkButton.axaml
@@ -1,0 +1,51 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- HyperlinkButton Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}" Padding="20">
+            <StackPanel Spacing="8">
+                <HyperlinkButton NavigateUri="https://example.com">Normal link</HyperlinkButton>
+                <HyperlinkButton IsEnabled="False">Disabled link</HyperlinkButton>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+
+    <Style Selector="HyperlinkButton">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource Talgonite.Hyperlink.Foreground}"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      RecognizesAccessKey="True"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <!-- Hover style -->
+        <Style Selector="^:pointerover">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.Hyperlink.HoverForeground}"/>
+        </Style>
+
+        <!-- Pressed style -->
+        <Style Selector="^:pressed">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.Hyperlink.PressedForeground}"/>
+        </Style>
+
+        <!-- Disabled style -->
+        <Style Selector="^:disabled">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.Hyperlink.DisabledForeground}"/>
+        </Style>
+    </Style>
+</Styles>

--- a/Arbiter.App/Themes/TalgoniteLabel.axaml
+++ b/Arbiter.App/Themes/TalgoniteLabel.axaml
@@ -1,5 +1,15 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Label Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <Label Content="Label"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="Label">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.Label.Foreground}"/>

--- a/Arbiter.App/Themes/TalgoniteListBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteListBox.axaml
@@ -1,13 +1,37 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ListBox Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <ListBox MinWidth="200" MinHeight="100">
+                <ListBoxItem>
+                    <Border Padding="8,4">
+                        <TextBlock Text="Normal Item" Foreground="White"/>
+                    </Border>
+                </ListBoxItem>
+                <ListBoxItem IsSelected="True" Padding="8,4">
+                    <Border>
+                        <TextBlock Text="Selected Item" Foreground="White"/>
+                    </Border>
+                </ListBoxItem>
+                <ListBoxItem IsEnabled="False" Padding="8,4">
+                    <Border>
+                        <TextBlock Text="Disabled Item" Foreground="White"/>
+                    </Border>
+                </ListBoxItem>
+            </ListBox>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ListBox">
         <Setter Property="Background" Value="{StaticResource Talgonite.ListBox.Background}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="CornerRadius" Value="2"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
         <Setter Property="VerticalAlignment" Value="Stretch"/>
-        <Setter Property="Padding" Value="4"/>
+        <Setter Property="Padding" Value="2"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True"/>

--- a/Arbiter.App/Themes/TalgoniteListBoxItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteListBoxItem.axaml
@@ -1,5 +1,29 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ListBoxItem Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel MinWidth="200">
+                <ListBoxItem>
+                    <Border Padding="8,4">
+                        <TextBlock Text="Normal Item" Foreground="White"/>
+                    </Border>
+                </ListBoxItem>
+                <ListBoxItem IsSelected="True" Padding="8,4">
+                    <Border>
+                        <TextBlock Text="Selected Item" Foreground="White"/>
+                    </Border>
+                </ListBoxItem>
+                <ListBoxItem IsEnabled="False" Padding="8,4">
+                    <Border>
+                        <TextBlock Text="Disabled Item" Foreground="White"/>
+                    </Border>
+                </ListBoxItem>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ListBoxItem">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>

--- a/Arbiter.App/Themes/TalgoniteMenuItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteMenuItem.axaml
@@ -1,6 +1,18 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sys="using:System">
+    <!-- MenuItem Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel MinWidth="200">
+                <MenuItem Header="Normal Item"/>
+                <MenuItem Header="Selected Item" IsSelected="True"/>
+                <MenuItem Header="Disabled Item" IsEnabled="False"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="MenuItem">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.MenuItem.Foreground}"/>

--- a/Arbiter.App/Themes/TalgoniteMenuItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteMenuItem.axaml
@@ -116,7 +116,7 @@
             <Setter Property="IsVisible" Value="True"/>
         </Style>
         <Style Selector="^:toggle /template/ ContentPresenter#PART_IconPresenter, ^:radio /template/ ContentPresenter#PART_IconPresenter">
-            <Setter Property="IsVisible" Value="True"/>        
+            <Setter Property="IsVisible" Value="False"/>        
         </Style>
         
         <Style Selector="^:checked:toggle /template/ ContentControl#PART_ToggleIconPresenter">

--- a/Arbiter.App/Themes/TalgoniteNumericUpDown.axaml
+++ b/Arbiter.App/Themes/TalgoniteNumericUpDown.axaml
@@ -1,11 +1,25 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- NumericUpDown Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <NumericUpDown Watermark="Value?" MinWidth="100"/>
+                <NumericUpDown Value="42" MinWidth="100"/>
+                <NumericUpDown Value="99" ShowButtonSpinner="True" MinWidth="100"/>
+                <NumericUpDown Watermark="Disabled" IsEnabled="False" MinWidth="100"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="NumericUpDown">
         <Setter Property="Background" Value="{StaticResource Talgonite.TextBox.Background}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="2"/>
-        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="CornerRadius" Value="2"/>
         <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="MinHeight" Value="32"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
@@ -35,6 +49,7 @@
                                          Watermark="{TemplateBinding Watermark}"
                                          Background="{TemplateBinding Background}"
                                          BorderThickness="0"
+                                         CornerRadius="{TemplateBinding CornerRadius}"
                                          MinWidth="40"
                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"

--- a/Arbiter.App/Themes/TalgoniteNumericUpDown.axaml
+++ b/Arbiter.App/Themes/TalgoniteNumericUpDown.axaml
@@ -8,7 +8,7 @@
         <Setter Property="Padding" Value="8,4"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
-        <Setter Property="HorizontalContentAlignment" Value="Right"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Template">
             <ControlTemplate>

--- a/Arbiter.App/Themes/TalgonitePath.axaml
+++ b/Arbiter.App/Themes/TalgonitePath.axaml
@@ -1,11 +1,22 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Path Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <Path Width="32" Height="32"
+                  Stroke="White"
+                  Stretch="UniformToFill"
+                  Data="{StaticResource Talgonite.Icon.SaveDisk}"/>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="Path">
         <Setter Property="Width" Value="16"/>
         <Setter Property="Height" Value="16"/>
         <Setter Property="StrokeThickness" Value="2"/>
         <Setter Property="StrokeLineCap" Value="Round"/>
         <Setter Property="StrokeJoin" Value="Round"/>
-        <Setter Property="Stretch" Value="None"/>
+        <Setter Property="Stretch" Value="UniformToFill"/>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgonitePath.axaml
+++ b/Arbiter.App/Themes/TalgonitePath.axaml
@@ -17,6 +17,6 @@
         <Setter Property="StrokeThickness" Value="2"/>
         <Setter Property="StrokeLineCap" Value="Round"/>
         <Setter Property="StrokeJoin" Value="Round"/>
-        <Setter Property="Stretch" Value="UniformToFill"/>
+        <Setter Property="Stretch" Value="None"/>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteProgressBar.axaml
+++ b/Arbiter.App/Themes/TalgoniteProgressBar.axaml
@@ -1,11 +1,26 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ProgressBar Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <ProgressBar MinWidth="200" Minimum="0" Maximum="100" Value="50"/>
+                <ProgressBar MinWidth="200" Minimum="0" Maximum="100" Value="50" ShowProgressText="True"/>
+                <ProgressBar MinWidth="200" Minimum="0" Maximum="100" IsIndeterminate="True"/>
+                <ProgressBar MinWidth="200" Minimum="0" Maximum="100" Value="50" IsEnabled="False"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ProgressBar">
         <Setter Property="Background" Value="{StaticResource Talgonite.ProgressBar.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.ProgressBar.Foreground}"/>
         <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ProgressBar.BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="CornerRadius" Value="2"/>
+        <Setter Property="MinWidth" Value="40"/>
+        <Setter Property="MinHeight" Value="4"/>
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel>
@@ -27,8 +42,19 @@
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
                                             IsVisible="{Binding $parent[ProgressBar].ShowProgressText}">
-                        <TextBlock Foreground="{StaticResource Talgonite.ProgressBar.TextForeground}">
-                            
+                        <!-- Progress Text -->
+                        <TextBlock Foreground="{StaticResource Talgonite.ProgressBar.TextForeground}"
+                                   FontSize="14"
+                                   FontWeight="SemiBold"
+                                   Text="{Binding $parent[ProgressBar].Value, StringFormat={}{0:0}%}"
+                                   VerticalAlignment="Center"
+                                   Margin="4,2">
+                            <TextBlock.Effect>
+                                <DropShadowDirectionEffect
+                                    Direction="180"
+                                    ShadowDepth="0"
+                                    BlurRadius="2"/>
+                            </TextBlock.Effect>
                         </TextBlock>
                     </LayoutTransformControl>
                 </Panel>
@@ -61,6 +87,46 @@
                     <RotateTransform Angle="90"/>
                 </Setter.Value>
             </Setter>
+        </Style>
+        
+        <Style Selector="^:disabled">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.ProgressBar.DisabledForeground}"/>
+        </Style>
+        
+        <!-- Taller Bar when showing ProgressText -->
+        <Style Selector="^[ShowProgressText=True]">
+            <Setter Property="MinHeight" Value="24"/>
+        </Style>
+        
+        <Style Selector="^:horizontal:indeterminate /template/ Border#PART_IndeterminateIndicator">
+            <Style.Animations>
+                <Animation Easing="LinearEasing"
+                           IterationCount="Infinite"
+                           Duration="0:0:2">
+                    <KeyFrame Cue="0%">
+                        <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateStartingOffset}" />
+                    </KeyFrame>
+                    <KeyFrame Cue="100%">
+                        <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateEndingOffset}" />
+                    </KeyFrame>
+                </Animation>
+            </Style.Animations>
+            <Setter Property="Width" Value="{Binding TemplateSettings.ContainerWidth, RelativeSource={RelativeSource TemplatedParent}}" />
+        </Style>
+        <Style Selector="^:vertical:indeterminate /template/ Border#PART_IndeterminateIndicator">
+            <Style.Animations>
+                <Animation Easing="LinearEasing"
+                           IterationCount="Infinite"
+                           Duration="0:0:2">
+                    <KeyFrame Cue="0%">
+                        <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateStartingOffset}" />
+                    </KeyFrame>
+                    <KeyFrame Cue="100%">
+                        <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateEndingOffset}" />
+                    </KeyFrame>
+                </Animation>
+            </Style.Animations>
+            <Setter Property="Height" Value="{Binding TemplateSettings.ContainerWidth, RelativeSource={RelativeSource TemplatedParent}}" />
         </Style>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteRadioButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteRadioButton.axaml
@@ -1,5 +1,18 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- RadioButton Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <RadioButton GroupName="Group">Normal Option</RadioButton>
+                <RadioButton GroupName="Group" IsEnabled="False">Disabled Option</RadioButton>
+                <RadioButton GroupName="Group" IsChecked="True" IsEnabled="False">Disabled Selected Option</RadioButton>
+                <RadioButton GroupName="Group" IsChecked="{x:Null}">Indeterminate Option</RadioButton>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="RadioButton">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.RadioButton.Foreground}"/>
@@ -10,34 +23,44 @@
             <ControlTemplate>
                 <Grid ColumnDefinitions="Auto,*"
                       Background="{TemplateBinding Background}"
-                      ColumnSpacing="4">
-                    <Ellipse Name="Border"
-                             Grid.Column="0"
-                             Width="{StaticResource Talgonite.RadioButton.Width}"
-                             Height="{StaticResource Talgonite.RadioButton.Height}"
-                             Stroke="{TemplateBinding BorderBrush}"
-                             Fill="{StaticResource Talgonite.RadioButton.Background}"
-                             StrokeThickness="2"
-                             VerticalAlignment="Center"/>
+                      ColumnSpacing="6">
+                    <!-- Indicator Box -->
+                    <Border Name="Box"
+                            Grid.Column="0"
+                            Width="{StaticResource Talgonite.RadioButton.Width}"
+                            Height="{StaticResource Talgonite.RadioButton.Height}"
+                            Background="{StaticResource Talgonite.RadioButton.Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="2"
+                            CornerRadius="2"
+                            VerticalAlignment="Center">
+                        <Panel>
+                            <Border Classes="sunken-shadow" CornerRadius="2"/>
+                            <Border Classes="sunken-highlight" CornerRadius="2"/>
+                            
+                            <!-- Checked square mark -->
+                            <Border Name="CheckMark"
+                                    Width="{StaticResource Talgonite.RadioButton.CheckMarkWidth}"
+                                    Height="{StaticResource Talgonite.RadioButton.CheckMarkHeight}"
+                                    Background="{StaticResource Talgonite.RadioButton.PressedForeground}"
+                                    CornerRadius="2"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    IsVisible="False"/>
+                            
+                            <!-- Indeterminate dash mark -->
+                            <Border Name="IndeterminateMark"
+                                    Width="{StaticResource Talgonite.RadioButton.CheckMarkWidth}"
+                                    Height="2"
+                                    Background="{StaticResource Talgonite.RadioButton.PressedForeground}"
+                                    CornerRadius="1"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    IsVisible="False"/>
+                        </Panel>
+                    </Border>
                     
-                    <Ellipse Name="CheckMark"
-                             Grid.Column="0"
-                             Width="{StaticResource Talgonite.RadioButton.CheckMarkWidth}"
-                             Height="{StaticResource Talgonite.RadioButton.CheckMarkHeight}"
-                             Stretch="None"
-                             HorizontalAlignment="Center"
-                             VerticalAlignment="Center"
-                             UseLayoutRounding="False"/>
-                    
-                    <Ellipse Name="IndeterminateMark"
-                             Grid.Column="0"
-                             Width="{StaticResource Talgonite.RadioButton.CheckMarkWidth}"
-                             Height="{StaticResource Talgonite.RadioButton.CheckMarkHeight}"
-                             Stretch="None"
-                             HorizontalAlignment="Center"
-                             VerticalAlignment="Center"
-                             UseLayoutRounding="False"/>
-                    
+                    <!-- Content -->
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Grid.Column="1"
                                       Content="{TemplateBinding Content}"
@@ -48,42 +71,37 @@
             </ControlTemplate>
         </Setter>
         
-        <Style Selector="^ /template/ Ellipse#CheckMark">
-            <Setter Property="Fill" Value="{StaticResource Talgonite.RadioButton.PressedForeground}"/>
-            <Setter Property="IsVisible" Value="False"/>
+        <!-- Hover/Focus border on the box -->
+        <Style Selector="^:pointerover /template/ Border#Box">
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.RadioButton.HoverBorderBrush}"/>
+        </Style>
+        <Style Selector="^:focus /template/ Border#Box">
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.RadioButton.FocusBorderBrush}"/>
         </Style>
         
-        <Style Selector="^ /template/ Ellipse#IndeterminateMark">
-            <Setter Property="IsVisible" Value="False"/>
-        </Style>
-        
-        <Style Selector="^:pointerover /template/ Ellipse#Border">
-            <Setter Property="Stroke" Value="{StaticResource Talgonite.RadioButton.HoverBorderBrush}"/>
-        </Style>
-        
-        <Style Selector="^:indeterminate /template/ Ellipse#IndeterminateMark">
-            <Setter Property="IsVisible" Value="False"/>
-        </Style>
-        
-        <Style Selector="^:focus /template/ Ellipse#Border">
-            <Setter Property="Stroke" Value="{StaticResource Talgonite.RadioButton.FocusBorderBrush}"/>
-        </Style>
-        
-        <Style Selector="^:checked">
-            <Setter Property="Foreground" Value="{StaticResource Talgonite.RadioButton.PressedForeground}"/>
-        </Style>
-        
-        <Style Selector="^:checked /template/ Ellipse#CheckMark">
+        <!-- Checked state -->
+        <Style Selector="^:checked /template/ Border#CheckMark">
             <Setter Property="IsVisible" Value="True"/>
         </Style>
         
-        <Style Selector="^:disabled /template/ Ellipse#CheckMark">
-            <Setter Property="Fill" Value="{StaticResource Talgonite.RadioButton.DisabledForeground}"/>
+        <!-- Indeterminate state shows dash -->
+        <Style Selector="^:indeterminate /template/ Border#IndeterminateMark">
+            <Setter Property="IsVisible" Value="True"/>
         </Style>
         
-        <Style Selector="^:disabled /template/ Ellipse#Border">
-            <Setter Property="Stroke" Value="{StaticResource Talgonite.RadioButton.DisabledBorderBrush}"/>
-            <Setter Property="Fill" Value="{StaticResource Talgonite.RadioButton.DisabledForeground}"/>
+        <!-- Disabled style -->
+        <Style Selector="^:disabled">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.RadioButton.DisabledForeground}"/>
+            <Setter Property="Focusable" Value="False"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#Box">
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.RadioButton.DisabledBorderBrush}"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#CheckMark">
+            <Setter Property="Background" Value="{StaticResource Talgonite.RadioButton.DisabledForeground}"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#IndeterminateMark">
+            <Setter Property="Background" Value="{StaticResource Talgonite.RadioButton.DisabledForeground}"/>
         </Style>
     </Style>
     

--- a/Arbiter.App/Themes/TalgoniteRadioButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteRadioButton.axaml
@@ -122,41 +122,9 @@
         <Style Selector="^:pointerover">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.RadioButton.HoverBorderBrush}"/>
         </Style>
-        <Style Selector="^:pointerover /template/ Border#SelectionBorder">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
-        <Style Selector="^:not(:pointerover) /template/ Border#SelectionBorder">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
         
         <Style Selector="^:focus">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.RadioButton.FocusBorderBrush}"/>
-        </Style>
-        <Style Selector="^:focus /template/ Border#SelectionBorder">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
-        <Style Selector="^:not(:focus) /template/ Border#SelectionBorder">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
         </Style>
         
         <Style Selector="^:checked">

--- a/Arbiter.App/Themes/TalgoniteResizeGrip.axaml
+++ b/Arbiter.App/Themes/TalgoniteResizeGrip.axaml
@@ -1,19 +1,35 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:control="using:Arbiter.App.Controls">
+    <!-- ResizeGrip Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <Grid Classes="resize-grip-container">
+                    <Path Classes="resize-grip"/>
+                </Grid>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="Path.resize-grip">
         <Setter Property="Stroke" Value="{StaticResource Talgonite.ResizeGrip.Foreground}"/>
         <Setter Property="StrokeThickness" Value="2"/>
         <Setter Property="StrokeLineCap" Value="Square"/>
         <Setter Property="Stretch" Value="None"/>
         <Setter Property="Opacity" Value="0.5"/>
+        <Setter Property="Data" Value="M2 14 L14 2 M7 14 L14 7 M12 14 L14 12"/>
     </Style>
     
-    <Style Selector="Grid.resize-grip-container">
+    <Style Selector="Panel.resize-grip-container">
         <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+        <Setter Property="VerticalAlignment" Value="Bottom"/>
+        <Setter Property="Cursor" Value="BottomRightCorner"/>
     </Style>
     
-    <Style Selector="Grid.resize-grip-container:pointerover Path.resize-grip">
+    <Style Selector="Panel.resize-grip-container:pointerover Path.resize-grip">
         <Setter Property="Stroke" Value="{StaticResource Talgonite.ResizeGrip.HoverForeground}"/>
         <Setter Property="Opacity" Value="1.0"/>
     </Style>

--- a/Arbiter.App/Themes/TalgoniteRun.axaml
+++ b/Arbiter.App/Themes/TalgoniteRun.axaml
@@ -1,0 +1,24 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Run Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}" Padding="20">
+            <StackPanel MinWidth="200" Spacing="16">
+                <TextBlock Foreground="{StaticResource Talgonite.TextBlock.DimForeground}">
+                    <Run>The quick brown fox jumps over the lazy dog.</Run>
+                    <LineBreak/>
+                    <Run>Press the</Run>
+                    <Run Classes="hotkey">[SHIFT]</Run>
+                    <Run>key.</Run>
+                </TextBlock>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
+    <Style Selector="Run.hotkey">
+        <Setter Property="Foreground" Value="{StaticResource Talgonite.ToolTip.HotKeyForeground}"/>
+        <Setter Property="FontFamily" Value="{StaticResource Talgonite.ToolTip.HotKeyFont}"/>
+        <Setter Property="FontWeight" Value="Normal"/>
+        <Setter Property="BaselineAlignment" Value="Center"/>
+    </Style>
+</Styles>

--- a/Arbiter.App/Themes/TalgoniteScrollBar.axaml
+++ b/Arbiter.App/Themes/TalgoniteScrollBar.axaml
@@ -1,5 +1,29 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ScrollBar Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <Border BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
+                        BorderThickness="1"
+                        Width="200" MinHeight="40">
+                    <Grid RowDefinitions="*,Auto" ColumnDefinitions="*,Auto">
+                        <ScrollBar Grid.Row="0" Grid.Column="1" Orientation="Vertical"/>
+                        <ScrollBar Grid.Row="1" Grid.Column="0" Orientation="Horizontal"/>
+                        <TextBlock Grid.Row="0" Grid.Column="0"
+                                   TextWrapping="Wrap"
+                                   Foreground="White"
+                                   Margin="8">
+                            The quick brown fox jumps over the lazy dog.
+                            Lorem ipsum.
+                        </TextBlock>
+                    </Grid>
+                </Border>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ScrollBar">
         <Setter Property="Background" Value="{StaticResource Talgonite.ScrollBar.Background}"/>
         <Setter Property="Cursor" Value="Arrow"/>

--- a/Arbiter.App/Themes/TalgoniteScrollViewer.axaml
+++ b/Arbiter.App/Themes/TalgoniteScrollViewer.axaml
@@ -1,5 +1,67 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ScrollViewer Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <Border BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
+                        BorderThickness="1"
+                        Width="200" MinHeight="40">
+                    <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Disabled">
+                        <TextBlock Foreground="White" Margin="8">
+                            The quick brown fox jumps over the lazy dog.
+                        </TextBlock>
+                    </ScrollViewer>
+                </Border>
+                <Border BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
+                        BorderThickness="1"
+                        Width="200"
+                        MaxHeight="200">
+                    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
+                        <TextBlock TextWrapping="Wrap" Foreground="White" Margin="8">
+                            <Run>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                                incididuntut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                            </Run>
+                            <LineBreak/>
+                            <Run>
+                                Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+                                nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+                                officia deserunt mollit anim id est laborum.
+                            </Run>
+                        </TextBlock>
+                    </ScrollViewer>
+                </Border>
+                
+                <Border BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
+                        BorderThickness="1"
+                        Width="200"
+                        MaxHeight="80">
+                    <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible">
+                        <TextBlock TextWrapping="Wrap" Foreground="White" Margin="8">
+                            <Run>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                                incididuntut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                            </Run>
+                            <LineBreak/>
+                            <LineBreak/>
+                            <LineBreak/>
+                            <LineBreak/>
+                            <Run>
+                                Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+                                nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+                                officia deserunt mollit anim id est laborum.
+                            </Run>
+                        </TextBlock>
+                    </ScrollViewer>
+                </Border>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ScrollViewer">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Template">

--- a/Arbiter.App/Themes/TalgoniteSelectableTextBlock.axaml
+++ b/Arbiter.App/Themes/TalgoniteSelectableTextBlock.axaml
@@ -1,5 +1,16 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- SelectableTextBlock Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel Spacing="16">
+                <SelectableTextBlock Text="Selectable Text" Foreground="White"/>
+                <SelectableTextBlock Text="Disabled Selectable Text" Foreground="White" IsEnabled="False"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="SelectableTextBlock">
         <Setter Property="Theme">
             <ControlTheme TargetType="SelectableTextBlock">

--- a/Arbiter.App/Themes/TalgoniteSeparator.axaml
+++ b/Arbiter.App/Themes/TalgoniteSeparator.axaml
@@ -1,0 +1,18 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style Selector="Separator.menu">
+        <Setter Property="Background" Value="{StaticResource Talgonite.Border.DividerBrush}"/>
+        <Setter Property="Height" Value="1"/>
+        <Setter Property="Margin" Value="8,8"/>
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Margin="{TemplateBinding Margin}"/>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+</Styles>

--- a/Arbiter.App/Themes/TalgoniteSeparator.axaml
+++ b/Arbiter.App/Themes/TalgoniteSeparator.axaml
@@ -1,5 +1,17 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Separator Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <StackPanel MinWidth="200">
+                <MenuItem Header="Before Separator"/>
+                <Separator/>
+                <MenuItem Header="After Separator"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="Separator.menu">
         <Setter Property="Background" Value="{StaticResource Talgonite.Border.DividerBrush}"/>
         <Setter Property="Height" Value="1"/>

--- a/Arbiter.App/Themes/TalgoniteStyles.axaml
+++ b/Arbiter.App/Themes/TalgoniteStyles.axaml
@@ -27,6 +27,7 @@
     <StyleInclude Source="./TalgoniteRadioButton.axaml"/>
     <StyleInclude Source="./TalgoniteResizeGrip.axaml"/>
     <StyleInclude Source="./TalgoniteSelectableTextBlock.axaml"/>
+    <StyleInclude Source="./TalgoniteSeparator.axaml"/>
     <StyleInclude Source="./TalgoniteScrollBar.axaml"/>
     <StyleInclude Source="./TalgoniteScrollViewer.axaml"/>
     <StyleInclude Source="./TalgoniteTabControl.axaml"/>

--- a/Arbiter.App/Themes/TalgoniteStyles.axaml
+++ b/Arbiter.App/Themes/TalgoniteStyles.axaml
@@ -26,6 +26,7 @@
     <StyleInclude Source="./TalgonitePopupRoot.axaml"/>
     <StyleInclude Source="./TalgoniteRadioButton.axaml"/>
     <StyleInclude Source="./TalgoniteResizeGrip.axaml"/>
+    <StyleInclude Source="./TalgoniteRun.axaml"/>
     <StyleInclude Source="./TalgoniteSelectableTextBlock.axaml"/>
     <StyleInclude Source="./TalgoniteSeparator.axaml"/>
     <StyleInclude Source="./TalgoniteScrollBar.axaml"/>
@@ -34,7 +35,6 @@
     <StyleInclude Source="./TalgoniteTabItem.axaml"/>
     <StyleInclude Source="./TalgoniteTabStrip.axaml"/>
     <StyleInclude Source="./TalgoniteTabStripItem.axaml"/>
-    <StyleInclude Source="./TalgoniteText.axaml"/>
     <StyleInclude Source="./TalgoniteTextBox.axaml"/>
     <StyleInclude Source="./TalgoniteToggleButton.axaml"/>
     <StyleInclude Source="./TalgoniteToggleSwitch.axaml"/>

--- a/Arbiter.App/Themes/TalgoniteStyles.axaml
+++ b/Arbiter.App/Themes/TalgoniteStyles.axaml
@@ -15,6 +15,7 @@
     <StyleInclude Source="./TalgoniteContextMenu.axaml"/>
     <StyleInclude Source="./TalgoniteExpander.axaml"/>
     <StyleInclude Source="./TalgoniteGridSplitter.axaml"/>
+    <StyleInclude Source="./TalgoniteHyperlinkButton.axaml"/>
     <StyleInclude Source="./TalgoniteItemsControl.axaml"/>
     <StyleInclude Source="./TalgoniteLabel.axaml"/>
     <StyleInclude Source="./TalgoniteListBox.axaml"/>

--- a/Arbiter.App/Themes/TalgoniteTabControl.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabControl.axaml
@@ -1,10 +1,41 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- TabControl Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}"
+                Padding="20">
+            <StackPanel MinWidth="400" Spacing="20">
+                <TabControl Height="150" HorizontalAlignment="Stretch">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+                
+                <TabControl Height="150" HorizontalAlignment="Stretch" TabStripPlacement="Bottom">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+                
+                <TabControl Height="150" HorizontalAlignment="Stretch" TabStripPlacement="Left">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+                
+                <TabControl Height="150" HorizontalAlignment="Stretch" TabStripPlacement="Right">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="TabControl">
         <Setter Property="Background" Value="{StaticResource Talgonite.TabControl.Background}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="CornerRadius" Value="8"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
         <Setter Property="VerticalAlignment" Value="Stretch"/>
         <Setter Property="Padding" Value="4"/>
@@ -20,7 +51,8 @@
                     <DockPanel>
                         <Border Name="ItemsPresenterBorder"
                                 Background="{StaticResource Talgonite.TabStrip.Background}"
-                                CornerRadius="0,8,0,0">
+                                CornerRadius="0,8,0,0"
+                                Padding="0,0,8,0">
                             <ItemsPresenter Name="PART_ItemsPresenter"
                                             ItemsPanel="{TemplateBinding ItemsPanel}"/>
                         </Border>
@@ -44,28 +76,25 @@
         
         <!-- Bottom Tab Placement -->
         <Style Selector="^[TabStripPlacement=Bottom] /template/ Border#ItemsPresenterBorder">
+            <Setter Property="CornerRadius" Value="0,0,8,0"/>
             <Setter Property="DockPanel.Dock" Value="Bottom"/>
         </Style>
         
         <!-- Left Tab Placement -->
-        <Style Selector="^[TabStripPlacement=Left]">
-            <Setter Property="CornerRadius" Value="0"/>
-        </Style>
         <Style Selector="^[TabStripPlacement=Left] /template/ Border#ItemsPresenterBorder">
             <Setter Property="DockPanel.Dock" Value="Left"/>
             <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
         </Style>
         <Style Selector="^[TabStripPlacement=Left] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
             <Setter Property="Orientation" Value="Vertical"/>
         </Style>
         
         <!-- Right Tab Placement -->
-        <Style Selector="^[TabStripPlacement=Right]">
-            <Setter Property="CornerRadius" Value="0"/>
-        </Style>
         <Style Selector="^[TabStripPlacement=Right] /template/ Border#ItemsPresenterBorder">
             <Setter Property="DockPanel.Dock" Value="Right"/>
             <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
         </Style>
         <Style Selector="^[TabStripPlacement=Right] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
             <Setter Property="Orientation" Value="Vertical"/>

--- a/Arbiter.App/Themes/TalgoniteTabControl.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabControl.axaml
@@ -48,16 +48,24 @@
         </Style>
         
         <!-- Left Tab Placement -->
+        <Style Selector="^[TabStripPlacement=Left]">
+            <Setter Property="CornerRadius" Value="0"/>
+        </Style>
         <Style Selector="^[TabStripPlacement=Left] /template/ Border#ItemsPresenterBorder">
             <Setter Property="DockPanel.Dock" Value="Left"/>
+            <Setter Property="CornerRadius" Value="0"/>
         </Style>
         <Style Selector="^[TabStripPlacement=Left] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
             <Setter Property="Orientation" Value="Vertical"/>
         </Style>
         
         <!-- Right Tab Placement -->
+        <Style Selector="^[TabStripPlacement=Right]">
+            <Setter Property="CornerRadius" Value="0"/>
+        </Style>
         <Style Selector="^[TabStripPlacement=Right] /template/ Border#ItemsPresenterBorder">
             <Setter Property="DockPanel.Dock" Value="Right"/>
+            <Setter Property="CornerRadius" Value="0"/>
         </Style>
         <Style Selector="^[TabStripPlacement=Right] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
             <Setter Property="Orientation" Value="Vertical"/>

--- a/Arbiter.App/Themes/TalgoniteTabControl.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabControl.axaml
@@ -36,6 +36,7 @@
         <Setter Property="Background" Value="{StaticResource Talgonite.TabControl.Background}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="CornerRadius" Value="0"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
         <Setter Property="VerticalAlignment" Value="Stretch"/>
         <Setter Property="Padding" Value="4"/>
@@ -51,8 +52,8 @@
                     <DockPanel>
                         <Border Name="ItemsPresenterBorder"
                                 Background="{StaticResource Talgonite.TabStrip.Background}"
-                                CornerRadius="0,8,0,0"
-                                Padding="0,0,8,0">
+                                CornerRadius="0"
+                                Padding="0">
                             <ItemsPresenter Name="PART_ItemsPresenter"
                                             ItemsPanel="{TemplateBinding ItemsPanel}"/>
                         </Border>
@@ -76,7 +77,7 @@
         
         <!-- Bottom Tab Placement -->
         <Style Selector="^[TabStripPlacement=Bottom] /template/ Border#ItemsPresenterBorder">
-            <Setter Property="CornerRadius" Value="0,0,8,0"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="DockPanel.Dock" Value="Bottom"/>
         </Style>
         

--- a/Arbiter.App/Themes/TalgoniteTabItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabItem.axaml
@@ -18,7 +18,7 @@
                         <ContentPresenter Name="PART_ContentPresenter"
                                           Content="{TemplateBinding Header}"
                                           ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                          Background="Transparent"
+                                          Background="{TemplateBinding Background}"
                                           Foreground="{TemplateBinding Foreground}"
                                           BorderBrush="{TemplateBinding BorderBrush}"
                                           BorderThickness="{TemplateBinding BorderThickness}"
@@ -47,9 +47,19 @@
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.TabItem.SelectedHighlight}"/>
         </Style>
         
+        <!-- Left Tab Placement-->
+        <Style Selector="^[TabStripPlacement=Left] /template/ Border#SelectionBorder">
+            <Setter Property="BorderThickness" Value="2,0,0,0"/>
+        </Style>
+        
         <!-- Right Tab Placement -->
         <Style Selector="^[TabStripPlacement=Right]">
             <Setter Property="HorizontalContentAlignment" Value="Right"/>
+        </Style>
+        
+        <!-- Left Tab Placement-->
+        <Style Selector="^[TabStripPlacement=Right] /template/ Border#SelectionBorder">
+            <Setter Property="BorderThickness" Value="0,0,2,0"/>
         </Style>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteTabItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabItem.axaml
@@ -1,5 +1,37 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- TabItem Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}"
+                Padding="20">
+            <StackPanel MinWidth="400" Spacing="20">
+                <TabControl Height="150" HorizontalAlignment="Stretch">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+                
+                <TabControl Height="150" HorizontalAlignment="Stretch" TabStripPlacement="Bottom">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+                
+                <TabControl Height="150" HorizontalAlignment="Stretch" TabStripPlacement="Left">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+                
+                <TabControl Height="150" HorizontalAlignment="Stretch" TabStripPlacement="Right">
+                    <TabItem Header="Normal"/>
+                    <TabItem Header="Selected" IsSelected="True"/>
+                    <TabItem Header="Disabled" IsEnabled="False"/>
+                </TabControl>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="TabItem">
         <Setter Property="Background" Value="{StaticResource Talgonite.TabItem.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.TabItem.Foreground}"/>
@@ -56,17 +88,28 @@
         
         <!-- Left Tab Placement-->
         <Style Selector="^[TabStripPlacement=Left] /template/ Border#SelectionBorder">
-            <Setter Property="BorderThickness" Value="1,0,0,0"/>
+            <Setter Property="BorderThickness" Value="2,0,0,0"/>
         </Style>
         
         <!-- Right Tab Placement -->
         <Style Selector="^[TabStripPlacement=Right]">
+            <Setter Property="BorderThickness" Value="0,0,1,0"/>
             <Setter Property="HorizontalContentAlignment" Value="Right"/>
         </Style>
         
-        <!-- Left Tab Placement-->
+        <!-- Right Tab Placement-->
         <Style Selector="^[TabStripPlacement=Right] /template/ Border#SelectionBorder">
             <Setter Property="BorderThickness" Value="0,0,2,0"/>
+        </Style>
+        
+        <!-- Bottom Tab Placement -->
+        <Style Selector="^[TabStripPlacement=Bottom]">
+            <Setter Property="HorizontalContentAlignment" Value="Right"/>
+        </Style>
+        
+        <!-- Bottom Tab Placement-->
+        <Style Selector="^[TabStripPlacement=Bottom] /template/ Border#SelectionBorder">
+            <Setter Property="BorderThickness" Value="0,0,0,2"/>
         </Style>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteTabItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabItem.axaml
@@ -45,6 +45,7 @@
         </Style>
         <Style Selector="^:selected /template/ Border#SelectionBorder">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.TabItem.SelectedHighlight}"/>
+            <Setter Property="BorderThickness" Value="0,1,0,0"/>
         </Style>
         
         <!-- Disabled Style -->
@@ -55,7 +56,7 @@
         
         <!-- Left Tab Placement-->
         <Style Selector="^[TabStripPlacement=Left] /template/ Border#SelectionBorder">
-            <Setter Property="BorderThickness" Value="2,0,0,0"/>
+            <Setter Property="BorderThickness" Value="1,0,0,0"/>
         </Style>
         
         <!-- Right Tab Placement -->

--- a/Arbiter.App/Themes/TalgoniteTabItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabItem.axaml
@@ -47,6 +47,12 @@
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.TabItem.SelectedHighlight}"/>
         </Style>
         
+        <!-- Disabled Style -->
+        <Style Selector="^:disabled">
+            <Setter Property="Background" Value="{StaticResource Talgonite.TabItem.DisabledBackground}"/>
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.TabItem.DisabledForeground}"/>
+        </Style>
+        
         <!-- Left Tab Placement-->
         <Style Selector="^[TabStripPlacement=Left] /template/ Border#SelectionBorder">
             <Setter Property="BorderThickness" Value="2,0,0,0"/>

--- a/Arbiter.App/Themes/TalgoniteTabStrip.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabStrip.axaml
@@ -1,5 +1,18 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- TabStrip Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}" Padding="20">
+            <StackPanel MinWidth="400" Spacing="16">
+                <TabStrip Height="150" HorizontalAlignment="Stretch">
+                    <TabStripItem>Normal</TabStripItem>
+                    <TabStripItem IsSelected="True">Selected</TabStripItem>
+                    <TabStripItem IsEnabled="False">Disabled</TabStripItem>
+                </TabStrip>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="TabStrip">
         <Setter Property="Background" Value="{StaticResource Talgonite.TabStrip.Background}"/>
         <Setter Property="CornerRadius" Value="0,16,0,0"/>
@@ -14,12 +27,7 @@
         <!-- Tab Items Panel -->
         <Setter Property="ItemsPanel">
             <ItemsPanelTemplate>
-                <Border Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
-                    <WrapPanel/>
-                </Border>
+                <WrapPanel Background="{TemplateBinding Background}"/>
             </ItemsPanelTemplate>
         </Setter>
     </Style>

--- a/Arbiter.App/Themes/TalgoniteTabStripItem.axaml
+++ b/Arbiter.App/Themes/TalgoniteTabStripItem.axaml
@@ -1,7 +1,21 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- TabStripItem Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}" Padding="20">
+            <StackPanel MinWidth="400" Spacing="16">
+                <TabStrip Height="150" HorizontalAlignment="Stretch">
+                    <TabStripItem>Normal</TabStripItem>
+                    <TabStripItem IsSelected="True">Selected</TabStripItem>
+                    <TabStripItem IsEnabled="False">Disabled</TabStripItem>
+                </TabStrip>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="TabStripItem">
         <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource Talgonite.TabStripItem.Foreground}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0,2,0,0"/>
         <Setter Property="Padding" Value="16"/>

--- a/Arbiter.App/Themes/TalgoniteText.axaml
+++ b/Arbiter.App/Themes/TalgoniteText.axaml
@@ -1,9 +1,0 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Style Selector="Run.hotkey">
-        <Setter Property="Foreground" Value="{StaticResource Talgonite.ToolTip.HotKeyForeground}"/>
-        <Setter Property="FontFamily" Value="{StaticResource Talgonite.ToolTip.HotKeyFont}"/>
-        <Setter Property="FontWeight" Value="Normal"/>
-        <Setter Property="BaselineAlignment" Value="Center"/>
-    </Style>
-</Styles>

--- a/Arbiter.App/Themes/TalgoniteTextBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteTextBox.axaml
@@ -1,5 +1,35 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- TextBox Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}" Padding="20">
+            <StackPanel Spacing="16">
+                <TextBox Width="300" Watermark="Enter text..."/>
+                <TextBox Width="300" Text="The quick brown fox jumps over the lazy dog."/>
+                <TextBox Width="300" Text="The quick brown fox jumps over the lazy dog." IsEnabled="False"/>
+                <TextBox Width="300" Text="The quick brown fox jumps over the lazy dog.">
+                    <TextBox.InnerLeftContent>
+                        <Button Height="32" Width="32" Margin="2">
+                            <Path Stroke="{Binding $parent[Button].Foreground}"
+                                  Data="{StaticResource Talgonite.Icon.SearchMagnify}"/>
+                        </Button>
+                    </TextBox.InnerLeftContent>
+                </TextBox>
+                <TextBox Width="300" Text="The quick brown fox jumps over the lazy dog.">
+                    <TextBox.InnerRightContent>
+                        <Button Height="32" Width="32" Margin="2" Classes="destructive">
+                            <Path Stroke="{Binding $parent[Button].Foreground}"
+                                  Data="{StaticResource Talgonite.Icon.CrossX}"/>
+                        </Button>
+                    </TextBox.InnerRightContent>
+                </TextBox>
+                <TextBox Width="300" Height="80" Text="The quick brown fox jumps over the lazy dog.&#x0a;"
+                         HorizontalContentAlignment="Left"
+                         VerticalContentAlignment="Top"/>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="TextBox">
         <Setter Property="Background" Value="{StaticResource Talgonite.TextBox.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.TextBox.Foreground}"/>
@@ -9,8 +39,8 @@
         <Setter Property="SelectionForegroundBrush" Value="{StaticResource Talgonite.TextBox.SelectionForeground}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="2"/>
-        <Setter Property="CornerRadius" Value="4"/>
-        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="CornerRadius" Value="2"/>
+        <Setter Property="Padding" Value="0,4"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True"/>
@@ -28,16 +58,30 @@
                         <Border Classes="sunken-highlight"
                                 CornerRadius="{TemplateBinding CornerRadius}"/>
                         
-                        <DockPanel HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                        <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto,8,*,8,Auto"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            
+                            <!-- Left content -->
+                            <ContentPresenter Grid.Row="1" Grid.Column="0"
+                                              Content="{TemplateBinding InnerLeftContent}"
+                                              VerticalAlignment="Stretch"
+                                              VerticalContentAlignment="Center"/>
+                            
+                            <!-- Left spacer (only when no left content) -->
+                            <Border Grid.Row="0" Grid.Column="1" Grid.RowSpan="2" Width="8">
+                                <Border.IsVisible>
+                                    <Binding Path="$parent[TextBox].InnerLeftContent" Converter="{x:Static ObjectConverters.IsNull}"/>
+                                </Border.IsVisible>
+                            </Border>
                             
                             <!-- Floating Watermark -->
                             <TextBlock Name="FloatingWatermark"
-                                       DockPanel.Dock="Top"
+                                       Grid.Row="0" Grid.Column="2"
                                        Text="{TemplateBinding Watermark}"
                                        Foreground="{StaticResource Talgonite.TextBox.WatermarkForeground}"
                                        FontSize="14"
-                                       Margin="{TemplateBinding Padding}">
+                                       Margin="0,4">
                                 <TextBlock.IsVisible>
                                     <MultiBinding Converter="{x:Static BoolConverters.And}">
                                         <Binding Path="$parent[TextBox].UseFloatingWatermark"/>
@@ -46,73 +90,71 @@
                                 </TextBlock.IsVisible>
                             </TextBlock>
                             
-                            <DataValidationErrors>
-                                <Grid ColumnDefinitions="Auto,*,Auto">
-                                    <!-- Inner Left Content -->
-                                    <ContentPresenter Grid.Column="0"
-                                                      Content="{TemplateBinding InnerLeftContent}"
-                                                      VerticalAlignment="Stretch"
-                                                      VerticalContentAlignment="Center"/>
-                                    
-                                    <!-- Scrollable Text -->
-                                    <ScrollViewer Name="PART_ScrollViewer"
-                                                  Grid.Column="1"
-                                                  AllowAutoHide="{TemplateBinding ScrollViewer.AllowAutoHide}"
-                                                  BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
-                                                  IsScrollChainingEnabled="{TemplateBinding ScrollViewer.IsScrollChainingEnabled}"
-                                                  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                                        <Panel>
-                                            <TextBlock Name="Watermark"
-                                                       Text="{TemplateBinding Watermark}"
+                            <DataValidationErrors Grid.Row="1" Grid.Column="2">
+                                <!-- Scrollable Text -->
+                                <ScrollViewer Name="PART_ScrollViewer"
+                                              AllowAutoHide="{TemplateBinding ScrollViewer.AllowAutoHide}"
+                                              BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+                                              IsScrollChainingEnabled="{TemplateBinding ScrollViewer.IsScrollChainingEnabled}"
+                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                    <Panel>
+                                        <TextBlock Name="Watermark"
+                                                   Text="{TemplateBinding Watermark}"
+                                                   TextAlignment="{TemplateBinding TextAlignment}"
+                                                   TextWrapping="{TemplateBinding TextWrapping}"
+                                                   Foreground="{StaticResource Talgonite.TextBox.WatermarkForeground}"
+                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                   Margin="0,4">
+                                            <TextBlock.IsVisible>
+                                                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                                    <Binding Path="#PART_TextPresenter.PreeditText" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
+                                                    <Binding Path="$parent[TextBox].Text" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
+                                                </MultiBinding>
+                                            </TextBlock.IsVisible>
+                                        </TextBlock>
+                                        
+                                        <TextPresenter Name="PART_TextPresenter"
+                                                       Text="{TemplateBinding Text, Mode=TwoWay}"
                                                        TextAlignment="{TemplateBinding TextAlignment}"
                                                        TextWrapping="{TemplateBinding TextWrapping}"
-                                                       Foreground="{StaticResource Talgonite.TextBox.WatermarkForeground}"
+                                                       LineHeight="{TemplateBinding LineHeight}"
+                                                       CaretBrush="{TemplateBinding CaretBrush}"
+                                                       CaretIndex="{TemplateBinding CaretIndex}"
+                                                       CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                                       SelectionBrush="{TemplateBinding SelectionBrush}"
+                                                       SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                                       SelectionStart="{TemplateBinding SelectionStart}"
+                                                       SelectionEnd="{TemplateBinding SelectionEnd}"
+                                                       RevealPassword="{TemplateBinding RevealPassword}"
+                                                       PasswordChar="{TemplateBinding PasswordChar}"
+                                                       Margin="0,4"
                                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                       Margin="{TemplateBinding Padding}">
-                                                <TextBlock.IsVisible>
-                                                    <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                        <Binding Path="#PART_TextPresenter.PreeditText" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
-                                                        <Binding Path="$parent[TextBox].Text" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
-                                                    </MultiBinding>
-                                                </TextBlock.IsVisible>
-                                            </TextBlock>
-                                            
-                                            <TextPresenter Name="PART_TextPresenter"
-                                                           Text="{TemplateBinding Text, Mode=TwoWay}"
-                                                           TextAlignment="{TemplateBinding TextAlignment}"
-                                                           TextWrapping="{TemplateBinding TextWrapping}"
-                                                           LineHeight="{TemplateBinding LineHeight}"
-                                                           CaretBrush="{TemplateBinding CaretBrush}"
-                                                           CaretIndex="{TemplateBinding CaretIndex}"
-                                                           CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                                           SelectionBrush="{TemplateBinding SelectionBrush}"
-                                                           SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                                           SelectionStart="{TemplateBinding SelectionStart}"
-                                                           SelectionEnd="{TemplateBinding SelectionEnd}"
-                                                           RevealPassword="{TemplateBinding RevealPassword}"
-                                                           PasswordChar="{TemplateBinding PasswordChar}"
-                                                           Margin="{TemplateBinding Padding}"
-                                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                                        </Panel>
-                                        
-                                        <ScrollViewer.Styles>
-                                            <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
-                                                <Setter Property="Cursor" Value="IBeam"/>
-                                            </Style>
-                                        </ScrollViewer.Styles>
-                                    </ScrollViewer>
+                                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    </Panel>
                                     
-                                    <!-- Inner Right Content -->
-                                    <ContentPresenter Grid.Column="2"
-                                                      Content="{TemplateBinding InnerRightContent}"
-                                                      VerticalAlignment="Stretch"
-                                                      VerticalContentAlignment="Center"/>
-                                </Grid>
+                                    <ScrollViewer.Styles>
+                                        <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                                            <Setter Property="Cursor" Value="IBeam"/>
+                                        </Style>
+                                    </ScrollViewer.Styles>
+                                </ScrollViewer>
                             </DataValidationErrors>
-                        </DockPanel>
+                            
+                            <!-- Right spacer (only when no right content) -->
+                            <Border Grid.Row="0" Grid.Column="3" Grid.RowSpan="2" Width="8">
+                                <Border.IsVisible>
+                                    <Binding Path="$parent[TextBox].InnerRightContent" Converter="{x:Static ObjectConverters.IsNull}"/>
+                                </Border.IsVisible>
+                            </Border>
+                            
+                            <!-- Right content -->
+                            <ContentPresenter Grid.Row="1" Grid.Column="4"
+                                              Content="{TemplateBinding InnerRightContent}"
+                                              VerticalAlignment="Stretch"
+                                              VerticalContentAlignment="Center"/>
+                        </Grid>
                     </Panel>
                 </Border>
             </ControlTemplate>
@@ -136,6 +178,11 @@
         
         <Style Selector="^:disabled /template/ Border#Border">
             <Setter Property="BorderBrush" Value="Transparent"/>
+        </Style>
+        
+        <!-- Disabled Foreground -->
+        <Style Selector="^:disabled">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.TextBox.DisabledForeground}"/>
         </Style>
         
     </Style>

--- a/Arbiter.App/Themes/TalgoniteTextBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteTextBox.axaml
@@ -128,34 +128,10 @@
         
         <Style Selector="^:focus /template/ Border#Border">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.TextBox.FocusBorderBrush}"/>
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
-        <Style Selector="^:not(:focus) /template/ Border#Border">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
         </Style>
         
         <Style Selector="^:error /template/ Border#Border">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.TextBox.ErrorBorderBrush}"/>
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
-        <Style Selector="^:not(:error) /template/ Border#Border">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
         </Style>
         
         <Style Selector="^:disabled /template/ Border#Border">

--- a/Arbiter.App/Themes/TalgoniteTheme.axaml
+++ b/Arbiter.App/Themes/TalgoniteTheme.axaml
@@ -72,7 +72,7 @@
             
             <!-- ContextMenu Resources -->
             <SolidColorBrush x:Key="Talgonite.ContextMenu.Background" Color="#373d49"/>
-            <SolidColorBrush x:Key="Talgonite.ContextMenu.BorderBrush" Color="#292d34"/>
+            <SolidColorBrush x:Key="Talgonite.ContextMenu.BorderBrush" Color="#7b7e85"/>
             
             <!-- Control Resources -->
             <SolidColorBrush x:Key="Talgonite.Control.Background" Color="#373d49"/>
@@ -175,6 +175,8 @@
             <SolidColorBrush x:Key="Talgonite.TabItem.Foreground" Color="#717479"/>
             <SolidColorBrush x:Key="Talgonite.TabItem.HoverForeground" Color="#cdcfd2"/>
             <SolidColorBrush x:Key="Talgonite.TabItem.SelectedForeground" Color="#81b8f5"/>
+            <SolidColorBrush x:Key="Talgonite.TabItem.DisabledBackground" Color="#22262d"/>
+            <SolidColorBrush x:Key="Talgonite.TabItem.DisabledForeground" Color="#373d49"/>
             
             <!-- TabStrip Resources -->
             <SolidColorBrush x:Key="Talgonite.TabStrip.Background" Color="#262b33"/>

--- a/Arbiter.App/Themes/TalgoniteTheme.axaml
+++ b/Arbiter.App/Themes/TalgoniteTheme.axaml
@@ -126,7 +126,8 @@
             
             <!-- ProgressBar Resources -->
             <SolidColorBrush x:Key="Talgonite.ProgressBar.Background" Color="#262b33"/>
-            <SolidColorBrush x:Key="Talgonite.ProgressBar.Foreground" Color="#cdcfd2"/>
+            <SolidColorBrush x:Key="Talgonite.ProgressBar.Foreground" Color="#82baf7"/>
+            <SolidColorBrush x:Key="Talgonite.ProgressBar.DisabledForeground" Color="#4d535d"/>
             <SolidColorBrush x:Key="Talgonite.ProgressBar.TextForeground" Color="#cdcfd2"/>
             <SolidColorBrush x:Key="Talgonite.ProgressBar.BorderBrush" Color="#373d49"/>
             

--- a/Arbiter.App/Themes/TalgoniteTheme.axaml
+++ b/Arbiter.App/Themes/TalgoniteTheme.axaml
@@ -231,8 +231,8 @@
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.KnobBorderBrush" Color="#373d49"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.HoverBorderBrush" Color="#4d535d"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.FocusBorderBrush" Color="#81b8f5"/>
-            <sys:Double x:Key="Talgonite.ToggleSwitch.KnobSize">16</sys:Double>
-            <CornerRadius x:Key="Talgonite.ToggleSwitch.KnobCornerRadius">4</CornerRadius>
+            <sys:Double x:Key="Talgonite.ToggleSwitch.KnobSize">28</sys:Double>
+            <CornerRadius x:Key="Talgonite.ToggleSwitch.KnobCornerRadius">2</CornerRadius>
             
             <!-- ToolTip Resources -->
             <SolidColorBrush x:Key="Talgonite.ToolTip.Background" Color="#101215"/>

--- a/Arbiter.App/Themes/TalgoniteTheme.axaml
+++ b/Arbiter.App/Themes/TalgoniteTheme.axaml
@@ -215,7 +215,12 @@
             <!-- ToggleSwitch Resources -->
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.Foreground" Color="#e0e0e0"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.CheckedForeground" Color="#81b8f5"/>
-            <SolidColorBrush x:Key="Talgonite.ToggleSwitch.KnobBackground" Color="#262b33"/>
+            <!-- Track backgrounds -->
+            <SolidColorBrush x:Key="Talgonite.ToggleSwitch.TrackBackground" Color="#262b33"/>
+            <SolidColorBrush x:Key="Talgonite.ToggleSwitch.TrackCheckedBackground" Color="#81b8f5"/>
+            <SolidColorBrush x:Key="Talgonite.ToggleSwitch.TrackDisabledBackground" Color="#222831"/>
+            <!-- Knob visuals -->
+            <SolidColorBrush x:Key="Talgonite.ToggleSwitch.KnobBackground" Color="#373d49"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.KnobCheckedBackground" Color="#222831"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.KnobForeground" Color="#e0e0e0"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.KnobCheckedForeground" Color="#81b8f5"/>
@@ -223,7 +228,7 @@
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.HoverBorderBrush" Color="#4d535d"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.FocusBorderBrush" Color="#81b8f5"/>
             <sys:Double x:Key="Talgonite.ToggleSwitch.KnobSize">16</sys:Double>
-            <CornerRadius x:Key="Talgonite.ToggleSwitch.KnobCornerRadius">16</CornerRadius>
+            <CornerRadius x:Key="Talgonite.ToggleSwitch.KnobCornerRadius">4</CornerRadius>
             
             <!-- ToolTip Resources -->
             <SolidColorBrush x:Key="Talgonite.ToolTip.Background" Color="#101215"/>

--- a/Arbiter.App/Themes/TalgoniteTheme.axaml
+++ b/Arbiter.App/Themes/TalgoniteTheme.axaml
@@ -182,6 +182,9 @@
             <!-- TabStrip Resources -->
             <SolidColorBrush x:Key="Talgonite.TabStrip.Background" Color="#262b33"/>
             
+            <!-- TabStrip Item Resources -->
+            <SolidColorBrush x:Key="Talgonite.TabStripItem.Foreground" Color="#717479"/>
+            
             <!-- TextBlock Resources -->
             <SolidColorBrush x:Key="Talgonite.TextBlock.Foreground" Color="#cdcfd2"/>
             <SolidColorBrush x:Key="Talgonite.TextBlock.DimForeground" Color="#717479"/>

--- a/Arbiter.App/Themes/TalgoniteTheme.axaml
+++ b/Arbiter.App/Themes/TalgoniteTheme.axaml
@@ -95,6 +95,12 @@
             <SolidColorBrush x:Key="Talgonite.GridSplitter.PressedForeground" Color="#82baf7"/>
             <SolidColorBrush x:Key="Talgonite.GridSplitter.DisabledForeground" Color="#373d49"/>
             
+            <!-- HyperlinkButton Resources -->
+            <SolidColorBrush x:Key="Talgonite.Hyperlink.Foreground" Color="#81b8f5"/>
+            <SolidColorBrush x:Key="Talgonite.Hyperlink.HoverForeground" Color="#cdcfd2"/>
+            <SolidColorBrush x:Key="Talgonite.Hyperlink.PressedForeground" Color="#ffffff"/>
+            <SolidColorBrush x:Key="Talgonite.Hyperlink.DisabledForeground" Color="#7b7e85"/>
+            
             <!-- Label Resources -->
             <SolidColorBrush x:Key="Talgonite.Label.Foreground" Color="#a6a7a9"/>
             

--- a/Arbiter.App/Themes/TalgoniteToggleButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleButton.axaml
@@ -1,5 +1,25 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ToggleButton Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}" Padding="20">
+            <StackPanel Spacing="16">
+                <ToggleButton>Normal Toggle</ToggleButton>
+                <ToggleButton IsChecked="True">Checked Toggle</ToggleButton>
+                <ToggleButton IsEnabled="False">Disabled Toggle</ToggleButton>
+                
+                <ToggleButton Classes="outline">Outline Toggle</ToggleButton>
+                <ToggleButton Classes="outline" IsChecked="True">Checked Outline Toggle</ToggleButton>
+                <ToggleButton Classes="outline" IsEnabled="False">Disabled Outline Toggle</ToggleButton>
+                
+                <ToggleButton Classes="glow">Glow Toggle</ToggleButton>
+                <ToggleButton Classes="glow" IsChecked="True">Checked Glow Toggle</ToggleButton>
+                <ToggleButton Classes="glow" IsEnabled="False">Disabled Glow Toggle</ToggleButton>
+                <ToggleButton Classes="glow" IsEnabled="False" IsChecked="True">Disabled Checked Glow Toggle</ToggleButton>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ToggleButton:not(.reveal, .expander)">
         <Setter Property="Background" Value="{StaticResource Talgonite.ToggleButton.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.ToggleButton.Foreground}"/>
@@ -61,9 +81,15 @@
         </Style>
         
         <!-- Disabled Style -->
+        <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.Button.DisabledForeground}"/>
+        </Style>
         <Style Selector="^:disabled">
             <Setter Property="Foreground" Value="{StaticResource Talgonite.Button.DisabledForeground}"/>
             <Setter Property="Background" Value="{StaticResource Talgonite.Button.DisabledBackground}"/>
+        </Style>
+        <Style Selector="^:disabled /template/ Border#SelectionBorder">
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Button.DisabledForeground}"/>
         </Style>
         
         <!-- Outline Button Style -->
@@ -93,6 +119,11 @@
         <Style Selector="^.glow:checked /template/ Border#SelectionBorder">
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleButton.CheckedBackground}"/>
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ToggleButton.CheckedBorderBrush}"/>
+        </Style>
+        
+        <Style Selector="^.glow:disabled /template/ Border#SelectionBorder">
+            <Setter Property="Background" Value="{StaticResource Talgonite.ToggleButton.CheckedBackground}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Button.DisabledForeground}"/>
         </Style>
         
         <!-- Outline Button Focus Style -->

--- a/Arbiter.App/Themes/TalgoniteToggleButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleButton.axaml
@@ -60,6 +60,12 @@
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleButton.CheckedBackground}"/>
         </Style>
         
+        <!-- Disabled Style -->
+        <Style Selector="^:disabled">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.Button.DisabledForeground}"/>
+            <Setter Property="Background" Value="{StaticResource Talgonite.Button.DisabledBackground}"/>
+        </Style>
+        
         <!-- Outline Button Style -->
         <Style Selector="^.outline">
             <Setter Property="BorderThickness" Value="2"/>

--- a/Arbiter.App/Themes/TalgoniteToggleButton.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleButton.axaml
@@ -42,12 +42,6 @@
         </Style>
         <Style Selector="^:pointerover /template/ Border#SelectionBorder">
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleButton.HoverBackground}"/>
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
         </Style>
         
         <!-- Pressed Style -->
@@ -56,12 +50,6 @@
         </Style>
         <Style Selector="^:pressed /template/ Border#SelectionBorder">
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleButton.PressedBackground}"/>
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
         </Style>
         
         <!-- Checked Style -->
@@ -70,12 +58,6 @@
         </Style>
         <Style Selector="^:checked /template/ Border#SelectionBorder">
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleButton.CheckedBackground}"/>
-            <Setter Property="Transitions">
-                <Transitions>
-                    <BrushTransition Property="Background" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                    <BrushTransition Property="BorderBrush" Duration="{StaticResource Talgonite.Transition.Duration}" Easing="CubicEaseInOut"/>
-                </Transitions>
-            </Setter>
         </Style>
         
         <!-- Outline Button Style -->

--- a/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
@@ -175,5 +175,9 @@
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackDisabledBackground}"/>
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ToggleSwitch.KnobBorderBrush}"/>
         </Style>
+        <Style Selector="^:disabled /template/ Border#SwitchTrackFill">
+            <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackDisabledBackground}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ToggleSwitch.KnobBorderBrush}"/>
+        </Style>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
@@ -1,9 +1,15 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- ToggleSwitch Previews -->
     <Design.PreviewWith>
         <Border Background="{StaticResource Talgonite.Control.Background}"
                 Padding="20">
-            <ToggleSwitch IsChecked="True"></ToggleSwitch>
+            <StackPanel Spacing="8">
+                <ToggleSwitch/>
+                <ToggleSwitch IsChecked="True"/>
+                <ToggleSwitch IsEnabled="False"/>
+                <ToggleSwitch IsEnabled="False" IsChecked="True"/>
+            </StackPanel>
         </Border>
     </Design.PreviewWith>
     

--- a/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
@@ -18,10 +18,11 @@
         <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <!-- Keep the slide animation for the knob movement -->
+        <!-- Slide animation for the knob movement -->
         <Setter Property="KnobTransitions">
             <Transitions>
-                <DoubleTransition Property="Canvas.Left" Easing="CubicEaseOut" Duration="{StaticResource Talgonite.Transition.Duration}"/>
+                <DoubleTransition Property="Canvas.Left" Easing="CubicEaseOut" 
+                                  Duration="{StaticResource Talgonite.Transition.Duration}"/>
             </Transitions>
         </Setter>
         <Setter Property="Template">
@@ -48,16 +49,19 @@
                               Background="Transparent"
                               TemplatedControl.IsTemplateFocusTarget="True"/>
                         
-                        <!-- Removed external On/Off content presenters as the knob now contains I/O labels -->
-
                         <Border Name="SwitchKnobBounds"
                                 Grid.Row="1" Grid.Column="0"
-                                Width="48" Height="24"
+                                Width="64" Height="32"
                                 Background="{StaticResource Talgonite.ToggleSwitch.TrackBackground}"
                                 BorderBrush="{StaticResource Talgonite.ToggleSwitch.KnobBorderBrush}"
                                 BorderThickness="2"
                                 CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}">
                             <Panel>
+                                <!-- Inset fill to prevent checked color from peeking under sunken borders -->
+                                <Border Name="SwitchTrackFill"
+                                        Background="{StaticResource Talgonite.ToggleSwitch.TrackBackground}"
+                                        CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"
+                                        Margin="2"/>
                                 <Border Classes="sunken-shadow"
                                         CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
                                 <Border Classes="sunken-highlight"
@@ -67,9 +71,9 @@
                         
                         <Canvas Name="PART_SwitchKnob"
                                 Grid.Row="1" Grid.Column="0"
-                                Width="24"
+                                Width="28"
                                 Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                Margin="4,0,0,0"
+                                Margin="2,0,0,0"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center">
                             
@@ -77,28 +81,39 @@
                                 <Border Name="SwitchKnobOn"
                                         Background="{StaticResource Talgonite.ToggleSwitch.KnobBackground}"
                                         CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"
+                                        BorderBrush="{StaticResource Talgonite.ToggleSwitch.KnobBorderBrush}"
+                                        BorderThickness="2"
                                         Width="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                        Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                        Padding="2,0">
-                                    <TextBlock Text="I"
-                                               Foreground="{StaticResource Talgonite.ToggleSwitch.KnobCheckedForeground}"
-                                               FontWeight="Normal"
-                                               FontSize="12"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"/>
+                                        Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}">
+                                    <Grid>
+                                        <Border Classes="raised-shadow" CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
+                                        <Border Classes="raised-highlight" CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
+                                        <Path Width="12" Height="12"
+                                              Stroke="{StaticResource Talgonite.ToggleSwitch.KnobCheckedForeground}"
+                                              StrokeThickness="2"
+                                              Data="M6,2 L6,10"
+                                              StrokeLineCap="Round"
+                                              HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"/>
+                                    </Grid>
                                 </Border>
                                 <Border Name="SwitchKnobOff"
                                         Background="{StaticResource Talgonite.ToggleSwitch.KnobBackground}"
                                         CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"
+                                        BorderBrush="{StaticResource Talgonite.ToggleSwitch.KnobBorderBrush}"
+                                        BorderThickness="2"
                                         Width="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                        Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                        Padding="2,0">
-                                    <TextBlock Text="O"
-                                               Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
-                                               FontWeight="Normal"
-                                               FontSize="12"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"/>
+                                        Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}">
+                                    <Grid>
+                                        <Border Classes="raised-shadow" CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
+                                        <Border Classes="raised-highlight" CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
+                                        <Path Width="12" Height="12"
+                                              Stroke="{StaticResource Talgonite.TextBlock.DimForeground}"
+                                              StrokeThickness="2"
+                                              Data="M6,2 A4,4 0 1,1 6,10 A4,4 0 1,1 6,2"
+                                              HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"/>
+                                    </Grid>
                                 </Border>
                             </Grid>
                         </Canvas>
@@ -113,7 +128,7 @@
         </Style>
         
         <!-- Checked State -->
-        <Style Selector="^:checked /template/ Border#SwitchKnobBounds">
+        <Style Selector="^:checked /template/ Border#SwitchTrackFill">
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackCheckedBackground}"/>
         </Style>
         
@@ -125,8 +140,12 @@
             <Setter Property="IsVisible" Value="True"/>
         </Style>
         
+        <Style Selector="^:checked /template/ Canvas#PART_SwitchKnob">
+            <Setter Property="Margin" Value="6,0,0,0"/>
+        </Style>
+        
         <!-- Unchecked State -->
-        <Style Selector="^:unchecked /template/ Border#SwitchKnobBounds">
+        <Style Selector="^:unchecked /template/ Border#SwitchTrackFill">
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackBackground}"/>
         </Style>
         

--- a/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
@@ -1,10 +1,18 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Control.Background}"
+                Padding="20">
+            <ToggleSwitch IsChecked="True"></ToggleSwitch>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ToggleSwitch">
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <!-- Keep the slide animation for the knob movement -->
         <Setter Property="KnobTransitions">
             <Transitions>
                 <DoubleTransition Property="Canvas.Left" Easing="CubicEaseOut" Duration="{StaticResource Talgonite.Transition.Duration}"/>
@@ -34,33 +42,22 @@
                               Background="Transparent"
                               TemplatedControl.IsTemplateFocusTarget="True"/>
                         
-                        <ContentPresenter Name="PART_OffContentPresenter"
-                                          Grid.Row="0"
-                                          Grid.Column="2"
-                                          Grid.RowSpan="3"
-                                          Content="{TemplateBinding OffContent}"
-                                          ContentTemplate="{TemplateBinding OffContent}"
-                                          Foreground="{StaticResource Talgonite.ToggleSwitch.Foreground}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                        
-                        <ContentPresenter Name="PART_OnContentPresenter"
-                                          Grid.Row="0"
-                                          Grid.Column="2"
-                                          Grid.RowSpan="3"
-                                          Content="{TemplateBinding OnContent}"
-                                          ContentTemplate="{TemplateBinding OnContent}"
-                                          Foreground="{StaticResource Talgonite.ToggleSwitch.CheckedForeground}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        <!-- Removed external On/Off content presenters as the knob now contains I/O labels -->
 
                         <Border Name="SwitchKnobBounds"
                                 Grid.Row="1" Grid.Column="0"
                                 Width="48" Height="24"
-                                Background="{StaticResource Talgonite.ToggleSwitch.KnobBackground}"
+                                Background="{StaticResource Talgonite.ToggleSwitch.TrackBackground}"
                                 BorderBrush="{StaticResource Talgonite.ToggleSwitch.KnobBorderBrush}"
                                 BorderThickness="2"
-                                CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
+                                CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}">
+                            <Panel>
+                                <Border Classes="sunken-shadow"
+                                        CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
+                                <Border Classes="sunken-highlight"
+                                        CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"/>
+                            </Panel>
+                        </Border>
                         
                         <Canvas Name="PART_SwitchKnob"
                                 Grid.Row="1" Grid.Column="0"
@@ -71,14 +68,32 @@
                                 VerticalAlignment="Center">
                             
                             <Grid Name="PART_MovingKnobs">
-                                <Ellipse Name="SwitchKnobOn"
-                                         Fill="{StaticResource Talgonite.ToggleSwitch.KnobCheckedForeground}"
-                                         Width="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                         Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"/>
-                                <Ellipse Name="SwitchKnobOff"
-                                         Fill="{StaticResource Talgonite.ToggleSwitch.KnobForeground}"
-                                         Width="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                         Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"/>
+                                <Border Name="SwitchKnobOn"
+                                        Background="{StaticResource Talgonite.ToggleSwitch.KnobBackground}"
+                                        CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"
+                                        Width="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
+                                        Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
+                                        Padding="2,0">
+                                    <TextBlock Text="I"
+                                               Foreground="{StaticResource Talgonite.ToggleSwitch.KnobCheckedForeground}"
+                                               FontWeight="Normal"
+                                               FontSize="12"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"/>
+                                </Border>
+                                <Border Name="SwitchKnobOff"
+                                        Background="{StaticResource Talgonite.ToggleSwitch.KnobBackground}"
+                                        CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"
+                                        Width="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
+                                        Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
+                                        Padding="2,0">
+                                    <TextBlock Text="O"
+                                               Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
+                                               FontWeight="Normal"
+                                               FontSize="12"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"/>
+                                </Border>
                             </Grid>
                         </Canvas>
                     </Grid>
@@ -93,31 +108,23 @@
         
         <!-- Checked State -->
         <Style Selector="^:checked /template/ Border#SwitchKnobBounds">
-            <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.KnobCheckedBackground}"/>
+            <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackCheckedBackground}"/>
         </Style>
         
-        <Style Selector="^:checked /template/ Ellipse#SwitchKnobOff">
+        <Style Selector="^:checked /template/ Border#SwitchKnobOff">
             <Setter Property="IsVisible" Value="False"/>
         </Style>
         
-        <Style Selector="^:checked /template/ ContentPresenter#PART_OffContentPresenter">
-            <Setter Property="IsVisible" Value="False"/>
-        </Style>
-        
-        <Style Selector="^:checked /template/ Ellipse#SwitchKnobOn">
-            <Setter Property="IsVisible" Value="True"/>
-        </Style>
-        
-        <Style Selector="^:checked /template/ ContentPresenter#PART_OnContentPresenter">
+        <Style Selector="^:checked /template/ Border#SwitchKnobOn">
             <Setter Property="IsVisible" Value="True"/>
         </Style>
         
         <!-- Unchecked State -->
         <Style Selector="^:unchecked /template/ Border#SwitchKnobBounds">
-            <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.KnobBackground}"/>
+            <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackBackground}"/>
         </Style>
         
-        <Style Selector="^:unchecked /template/ Ellipse#SwitchKnobOff">
+        <Style Selector="^:unchecked /template/ Border#SwitchKnobOff">
             <Setter Property="IsVisible" Value="True"/>
         </Style>
         
@@ -125,7 +132,7 @@
             <Setter Property="IsVisible" Value="True"/>
         </Style>
         
-        <Style Selector="^:unchecked /template/ Ellipse#SwitchKnobOn">
+        <Style Selector="^:unchecked /template/ Border#SwitchKnobOn">
             <Setter Property="IsVisible" Value="False"/>
         </Style>
         
@@ -136,6 +143,12 @@
         <!-- Focus State -->
         <Style Selector="^:focus /template/ Border#SwitchKnobBounds">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ToggleSwitch.FocusBorderBrush}"/>
+        </Style>
+        
+        <!-- Disabled State: track darker like textbox -->
+        <Style Selector="^:disabled /template/ Border#SwitchKnobBounds">
+            <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackDisabledBackground}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ToggleSwitch.KnobBorderBrush}"/>
         </Style>
     </Style>
 </Styles>

--- a/Arbiter.App/Themes/TalgoniteToolTip.axaml
+++ b/Arbiter.App/Themes/TalgoniteToolTip.axaml
@@ -1,6 +1,17 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="using:Arbiter.App.Converters">
+    <!-- ToolTip Previews -->
+    <Design.PreviewWith>
+        <Border Background="{StaticResource Talgonite.Window.Background}" Padding="20">
+            <StackPanel Spacing="16">
+                <ToolTip>
+                    <TextBlock>The quick brown fox jumps over the lazy dog.</TextBlock>
+                </ToolTip>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    
     <Style Selector="ToolTip">
         <Setter Property="Background" Value="{StaticResource Talgonite.ToolTip.Background}"/>
         <Setter Property="Foreground" Value="{StaticResource Talgonite.ToolTip.Foreground}"/>

--- a/Arbiter.App/Themes/TalgoniteWindow.axaml
+++ b/Arbiter.App/Themes/TalgoniteWindow.axaml
@@ -62,6 +62,7 @@
                                             Width="16"
                                             Height="16"
                                             Stroke="{Binding $parent[Button].Foreground}"
+                                            Stretch="None"
                                             Data="{StaticResource Talgonite.Icon.WindowMinimize}" />
                                     </Button>
                                     
@@ -73,6 +74,7 @@
                                             Width="16"
                                             Height="16"
                                             Stroke="{Binding $parent[Button].Foreground}"
+                                            Stretch="None"
                                             Data="{StaticResource Talgonite.Icon.WindowMaximize}" />
                                     </Button>
                                     
@@ -83,6 +85,7 @@
                                             Height="16"
                                             Width="16"
                                             Stroke="{Binding $parent[Button].Foreground}"
+                                            Stretch="None"
                                             Data="{StaticResource Talgonite.Icon.WindowClose}"/>
                                     </Button>
                                 </Grid>
@@ -102,16 +105,12 @@
                            
                             <!-- Resize Grip -->
                             <Panel Name="PART_ResizeGrip"
-                                  Grid.Row="1" 
-                                  Background="Transparent"
+                                  Grid.Row="1"
                                   Classes="resize-grip-container"
-                                  IsVisible="{Binding $parent[Window].CanResize}"
-                                  HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                                  Cursor="BottomRightCorner">
+                                  IsVisible="{Binding $parent[Window].CanResize}">
                                 <Path Width="16" Height="16"
                                       Classes="resize-grip"
-                                      Margin="0,0,4,4"
-                                      Data="M2 14 L14 2 M7 14 L14 7 M12 14 L14 12"/>
+                                      Margin="0,0,4,4"/>
                             </Panel>
                         </Grid>
                         

--- a/Arbiter.App/ViewModels/SendPacketViewModel.cs
+++ b/Arbiter.App/ViewModels/SendPacketViewModel.cs
@@ -105,8 +105,9 @@ public partial class SendPacketViewModel : ViewModelBase
     [
         TimeSpan.Zero,
         TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(200), TimeSpan.FromMilliseconds(300),
-        TimeSpan.FromMilliseconds(400), TimeSpan.FromMilliseconds(500), TimeSpan.FromSeconds(1),
-        TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(4),
+        TimeSpan.FromMilliseconds(400), TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(600),
+        TimeSpan.FromMilliseconds(700), TimeSpan.FromMilliseconds(800), TimeSpan.FromMilliseconds(900),
+        TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(4),
         TimeSpan.FromSeconds(5)
     ];
 

--- a/Arbiter.App/ViewModels/SendPacketViewModel.cs
+++ b/Arbiter.App/ViewModels/SendPacketViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -13,7 +14,6 @@ using Arbiter.Net;
 using Arbiter.Net.Client;
 using Arbiter.Net.Server;
 using Avalonia;
-using Avalonia.Data;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -57,7 +57,7 @@ public partial class SendPacketViewModel : ViewModelBase
 
             if (validationError is not null)
             {
-                throw new DataValidationException(validationError);
+                throw new ValidationException(validationError);
             }
         }
     }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using Arbiter.App.Models;
 using Arbiter.App.Services;
@@ -32,6 +34,15 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     
     [ObservableProperty] private bool _hasChanges;
 
+    public string VersionString
+    {
+        get
+        {
+            var version = Assembly.GetEntryAssembly()!.GetName().Version!;
+            return $"v{version.Major}.{version.Minor}.{version.Build}";
+        }
+    }
+    
     public string ClientExecutablePath
     {
         get => Settings.ClientExecutablePath;
@@ -167,5 +178,11 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     {
         Settings = new ArbiterSettings();
         HasChanges = true;
+    }
+
+    [RelayCommand]
+    private void VisitProjectWebsite()
+    {
+        Process.Start(new ProcessStartInfo("https://github.com/ewrogers/Arbiter") { UseShellExecute = true });
     }
 }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -103,6 +103,17 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         }
     }
 
+    public bool TraceAutosave
+    {
+        get => Settings.TraceAutosave;
+        set
+        {
+            Settings.TraceAutosave = value;
+            OnPropertyChanged();
+            HasChanges = true;
+        }
+    }
+
     public SettingsViewModel(ISettingsService settingsService, IStorageProvider storageProvider)
     {
         _settingsService = settingsService;

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -18,25 +18,19 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         MimeTypes = ["application/octet-stream"],
     };
     
-    private ArbiterSettings _settings = new();
     private readonly ISettingsService _settingsService;
     private readonly IStorageProvider _storageProvider;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ClientExecutablePath))]
+    [NotifyPropertyChangedFor(nameof(LocalPort))]
+    [NotifyPropertyChangedFor(nameof(RemoteServerAddress))]
+    [NotifyPropertyChangedFor(nameof(RemoteServerPort))]
+    [NotifyPropertyChangedFor(nameof(TraceOnStartup))]
+    [NotifyPropertyChangedFor(nameof(TraceAutosave))]
+    private ArbiterSettings _settings = new();
+    
     [ObservableProperty] private bool _hasChanges;
-
-    public ArbiterSettings Settings
-    {
-        get => _settings;
-        set
-        {
-            _settings = value;
-            OnPropertyChanged(nameof(ClientExecutablePath));
-            OnPropertyChanged(nameof(LocalPort));
-            OnPropertyChanged(nameof(RemoteServerAddress));
-            OnPropertyChanged(nameof(RemoteServerPort));
-            OnPropertyChanged(nameof(TraceOnStartup));
-        }
-    }
 
     public string ClientExecutablePath
     {

--- a/Arbiter.App/ViewModels/Tracing/TraceFilterViewModel.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceFilterViewModel.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Arbiter.App.Models;
-using Avalonia.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -33,7 +33,7 @@ public partial class TraceFilterViewModel : ViewModelBase
         {
             if (!string.IsNullOrWhiteSpace(value) && !NameFilterRegex().IsMatch(value))
             {
-                throw new DataValidationException("Invalid name filter");
+                throw new ValidationException("Invalid name filter");
             }
 
             if (!SetProperty(ref _nameFilter, value))
@@ -64,14 +64,14 @@ public partial class TraceFilterViewModel : ViewModelBase
                 var ranges = parsedRanges.ToList();
                 if (ranges.Any(range => range.Min > range.Max))
                 {
-                    throw new DataValidationException("Invalid command filter range");
+                    throw new ValidationException("Invalid command filter range");
                 }
 
                 CommandFilterRanges = ranges;
             }
             catch
             {
-                throw new DataValidationException("Invalid command filter range");
+                throw new ValidationException("Invalid command filter range");
             }
         }
     }

--- a/Arbiter.App/ViewModels/Tracing/TraceSearchViewModel.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceSearchViewModel.cs
@@ -1,5 +1,5 @@
-﻿using System.Globalization;
-using Avalonia.Data;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using CommunityToolkit.Mvvm.Input;
 
 namespace Arbiter.App.ViewModels.Tracing;
@@ -25,7 +25,7 @@ public partial class TraceSearchViewModel : ViewModelBase
 
             if (!byte.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var command))
             {
-                throw new DataValidationException("Invalid command filter");
+                throw new ValidationException("Invalid command filter");
             }
 
             SetProperty(ref _commandFilter, value);

--- a/Arbiter.App/Views/SendPacketView.axaml
+++ b/Arbiter.App/Views/SendPacketView.axaml
@@ -107,6 +107,7 @@
                     <Button Command="{Binding StartSendCommand}"
                             ToolTip.Tip="Starts sending the packets provided in the text box."
                             IsVisible="{Binding !IsSending}"
+                            HotKey="Shift+Enter"
                             Classes="toolbar"
                             MinWidth="120" Height="40"
                             Padding="16,4"

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -25,101 +25,31 @@
         </DockPanel>
     </controls:TalgoniteWindow.TitleBarContent>
     
-    <Grid RowDefinitions="*,Auto">
-        <StackPanel Grid.Row="0"
-                    Spacing="8"
-                    Margin="16">
-            <!-- Client Path Settings -->
-            <Label Content="Client Executable Path:"/>
-            <TextBox Name="ClientPathTextBox" 
-                     Text="{Binding ClientExecutablePath}"
-                     Watermark="Path to game client...">
-                <TextBox.InnerRightContent>
-                    <Button Command="{Binding LocateClientCommand}"
-                            Content="..."
-                            ToolTip.Tip="Opens a file dialog to locate the game client."
-                            MinWidth="40"
-                            Margin="2"
-                            Padding="4,2"/>
-                </TextBox.InnerRightContent>
-            </TextBox>
+    <Grid Margin="1,0">
+        <TabControl TabStripPlacement="Left">
+            <TabItem Header="General">
+                
+            </TabItem>
             
-            <Border BorderBrush="{StaticResource Talgonite.Window.TitleBorderBrush}"
-                    BorderThickness="0,0,0,1"
-                    Margin="0,8"/>
+            <TabItem Header="Game Client">
+                
+            </TabItem>
             
-            <!-- Local Port Settings -->
-            <Grid ColumnDefinitions="Auto,Auto">
-                <Label Grid.Column="0" Content="Local Port:"/>
-                <NumericUpDown Name="LocalPortUpDown"
-                               Grid.Column="1"
-                               Value="{Binding LocalPort}"
-                               Minimum="1"
-                               Maximum="65535"
-                               TextAlignment="Center"
-                               Watermark="1-65535"
-                               Width="100"/>
-            </Grid>
+            <TabItem Header="Tracing">
+                
+            </TabItem>
             
-            <Border BorderBrush="{StaticResource Talgonite.Window.TitleBorderBrush}"
-                    BorderThickness="0,0,0,1"
-                    Margin="0,8"/>
+            <TabItem Header="Filtering">
+                
+            </TabItem>
             
-            <!-- Remote Server Settings -->
-            <Label Content="Remote Server Host:"/>
-            <Grid ColumnDefinitions="*,Auto,Auto">
-                <TextBox Grid.Column="0"
-                         Text="{Binding RemoteServerAddress}"
-                         Watermark="Hostname..."/>
-                <Label Grid.Column="1" Content="_Port:"/>
-                <NumericUpDown Name="RemotePortUpDown"
-                               Grid.Column="2"
-                               Value="{Binding RemoteServerPort}"
-                               Minimum="1"
-                               Maximum="65535"
-                               TextAlignment="Center"
-                               Watermark="1-65535"
-                               Width="100"/>
-            </Grid>
+            <TabItem Header="Debug">
+                
+            </TabItem>
             
-            <Border BorderBrush="{StaticResource Talgonite.Window.TitleBorderBrush}"
-                    BorderThickness="0,0,0,1"
-                    Margin="0,8"/>
-            
-            <!-- Trace on Startup -->
-            <StackPanel Orientation="Horizontal" Spacing="4">
-                <ToggleSwitch IsChecked="{Binding TraceOnStartup}">
-                    <Label Content="Start Trace on Launch"/>
-                </ToggleSwitch>
-            </StackPanel>
-        </StackPanel>
-        
-        <Border Grid.Row="1"
-                Background="Transparent"
-                BorderBrush="{StaticResource Talgonite.Window.TitleBorderBrush}"
-                BorderThickness="0,1,0,0"
-                Padding="8">
-            <UniformGrid Rows="1" ColumnSpacing="8">
-                <Button Command="{Binding HandleOkCommand}"
-                        IsDefault="True">
-                    <TextBlock Text="Apply Changes"/>
-                    <Button.IsEnabled>
-                        <MultiBinding Converter="{x:Static BoolConverters.And}">
-                            <Binding Path="HasChanges"/>
-                            <Binding Path="#ClientPathTextBox.(DataValidationErrors.HasErrors)"
-                                     Converter="{x:Static BoolConverters.Not}"/>
-                            <Binding Path="#LocalPortUpDown.(DataValidationErrors.HasErrors)"
-                                     Converter="{x:Static BoolConverters.Not}"/>
-                            <Binding Path="#RemotePortUpDown.(DataValidationErrors.HasErrors)"
-                                     Converter="{x:Static BoolConverters.Not}"/>
-                        </MultiBinding>
-                    </Button.IsEnabled>
-                </Button>
-                <Button Command="{Binding HandleCancelCommand}"
-                        IsCancel="True">
-                    <TextBlock Text="Cancel"/>
-                </Button>
-            </UniformGrid>
-        </Border>
+            <TabItem Header="About">
+                
+            </TabItem>
+        </TabControl>
     </Grid>
 </controls:TalgoniteWindow>

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -26,11 +26,7 @@
     </controls:TalgoniteWindow.TitleBarContent>
     
     <Grid RowDefinitions="*,Auto" Margin="1,0">
-        <TabControl Grid.Row="0" TabStripPlacement="Left" Padding="8" SelectedIndex="3">
-            <!-- General Settings Tab -->
-            <TabItem Header="General" IsEnabled="False">
-            </TabItem>
-            
+        <TabControl Grid.Row="0" TabStripPlacement="Left" Padding="8">
             <!-- Game Client Settings Tab -->
             <TabItem Header="Game Client">
                 <StackPanel Spacing="4">
@@ -133,7 +129,30 @@
             
             <!-- About Tab -->
             <TabItem Header="About">
-                
+                <StackPanel Spacing="4" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                            Margin="32">
+                    <TextBlock Text="Arbiter"
+                               TextAlignment="Center"
+                               FontSize="48"
+                               FontWeight="Light"/>
+                    <TextBlock Text="Dark Ages Network Analysis Tool"
+                               TextAlignment="Center"
+                               FontSize="18"/>
+                    <TextBlock Text="{Binding VersionString, FallbackValue=v1.x.x}"
+                               TextAlignment="Center"
+                               Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
+                               FontSize="16"/>
+                    <Border Classes="divider-h" Margin="16,8"/>
+                    <TextBlock Text="Erik 'SiLo' Rogers - 2025"
+                               TextAlignment="Center"
+                               FontSize="18"/>
+                    <HyperlinkButton Command="{Binding VisitProjectWebsiteCommand}"
+                                     FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                     Margin="4"
+                                     HorizontalContentAlignment="Center">
+                        View on Github
+                    </HyperlinkButton>
+                </StackPanel>
             </TabItem>
         </TabControl>
         

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -121,7 +121,7 @@
                                Content="Autosave Traces on Quit"
                                ToolTip.Tip="Automatically saves traces when the application exits."/>
                         <ToggleSwitch Grid.Row="1" Grid.Column="1"
-                                      IsChecked="{Binding TraceOnStartup}"/>
+                                      IsChecked="{Binding TraceAutosave}"/>
                     </Grid>
                 </StackPanel>
             </TabItem>

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -25,31 +25,140 @@
         </DockPanel>
     </controls:TalgoniteWindow.TitleBarContent>
     
-    <Grid Margin="1,0">
-        <TabControl TabStripPlacement="Left">
-            <TabItem Header="General">
-                
+    <Grid RowDefinitions="*,Auto" Margin="1,0">
+        <TabControl Grid.Row="0" TabStripPlacement="Left" Padding="8" SelectedIndex="3">
+            <!-- General Settings Tab -->
+            <TabItem Header="General" IsEnabled="False">
             </TabItem>
             
+            <!-- Game Client Settings Tab -->
             <TabItem Header="Game Client">
-                
+                <StackPanel Spacing="4">
+                    <Label Content="Game Client Path"
+                           ToolTip.Tip="Path to the game executable."/>
+                    <TextBox Name="ClientPathTextBox"
+                             Text="{Binding ClientExecutablePath}"
+                             FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                             Watermark="Path to game client..."
+                             FontSize="14"
+                             Height="40">
+                        <TextBox.InnerRightContent>
+                            <Button Command="{Binding LocateClientCommand}"
+                                    Content="..."
+                                    FontFamily="{StaticResource Talgonite.Font.InterfaceFont}"
+                                    FontWeight="Bold"
+                                    FontSize="16"
+                                    Classes="outline"
+                                    MinWidth="40"
+                                    Margin="2"
+                                    Padding="2"
+                                    Cursor="Hand"/>
+                        </TextBox.InnerRightContent>
+                    </TextBox>
+                </StackPanel>
             </TabItem>
             
+            <!-- Network Settings Tab -->
+            <TabItem Header="Network">
+                <StackPanel Spacing="4">
+                    <!-- Remote Server -->
+                    <Label Content="Remote Server Host"
+                           ToolTip.Tip="Hostname of the remote game server."/>
+                    <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="4">
+                        <TextBox Grid.Column="0"
+                                   Text="{Binding RemoteServerAddress}"
+                                   FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                   Watermark="Enter a hostname..."
+                                   Height="40"/>
+                        
+                        <Label Grid.Column="1"
+                               Content="Port"
+                               ToolTip.Tip="Port of the remote game server."/>
+                        
+                        <NumericUpDown Grid.Column="2"
+                                       Value="{Binding RemoteServerPort}"
+                                       Minimum="1"
+                                       Maximum="65535"
+                                       Watermark="1-65535"
+                                       TextAlignment="Center"
+                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                       Width="100"
+                                       Height="40"/>
+                    </Grid>
+                    
+                    <Border Classes="divider-h" Margin="4,8"/>
+                    
+                    <!-- Local Server Port -->
+                    <Grid ColumnDefinitions="Auto,Auto" ColumnSpacing="4">
+                        <Label Grid.Column="0" Content="Local Port"
+                               ToolTip.Tip="Port to listen on for local client connections."/>
+                        <NumericUpDown Grid.Column="1"
+                                       Value="{Binding LocalPort}"
+                                       Minimum="1"
+                                       Maximum="65535"
+                                       Watermark="1-65535"
+                                       TextAlignment="Center"
+                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                       Width="100"
+                                       Height="40"/>
+                    </Grid>
+                </StackPanel>
+            </TabItem>
+            
+            <!-- Tracing Settings Tab -->
             <TabItem Header="Tracing">
-                
+                <StackPanel Spacing="4">
+                    <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto" Margin="8,4">
+                        <!-- Start Tracing on Startup -->
+                        <Label Grid.Row="0" Grid.Column="0"
+                               Content="Start Trace on Startup"
+                               ToolTip.Tip="Begins a trace automatically when the application starts up."/>
+                        <ToggleSwitch Grid.Row="0" Grid.Column="1"
+                                      IsChecked="{Binding TraceOnStartup}"/>
+                        
+                        <!-- Start Tracing on Startup -->
+                        <Label Grid.Row="1" Grid.Column="0"
+                               Content="Autosave Traces on Quit"
+                               ToolTip.Tip="Automatically saves traces when the application exits."/>
+                        <ToggleSwitch Grid.Row="1" Grid.Column="1"
+                                      IsChecked="{Binding TraceOnStartup}"/>
+                    </Grid>
+                </StackPanel>
             </TabItem>
             
-            <TabItem Header="Filtering">
-                
-            </TabItem>
-            
+            <!-- Debug Settings Tab -->
             <TabItem Header="Debug">
                 
             </TabItem>
             
+            <!-- About Tab -->
             <TabItem Header="About">
                 
             </TabItem>
         </TabControl>
+        
+        <!-- Accept/Cancel Button Area -->
+        <Border Grid.Row="1"
+                BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
+                BorderThickness="0,2,0,0"
+                Padding="16,8">
+            <UniformGrid Columns="2" ColumnSpacing="8" Margin="0,0,0,0">
+                <!-- OK button -->
+                <Button Command="{Binding HandleOkCommand}" IsDefault="True">
+                    <Button.IsEnabled>
+                        <MultiBinding Converter="{x:Static BoolConverters.And}">
+                            <Binding Path="HasChanges"/>
+                            <Binding Path="#ClientPathTextBox.(DataValidationErrors.HasErrors)"
+                                     Converter="{x:Static BoolConverters.Not}"/>
+                        </MultiBinding>
+                    </Button.IsEnabled>
+                    <TextBlock Text="Apply"></TextBlock>
+                </Button>
+                <!-- Cancel Button -->
+                <Button Command="{Binding HandleCancelCommand}" IsCancel="True">
+                    <TextBlock Text="Cancel"></TextBlock>
+                </Button>
+            </UniformGrid>
+        </Border>
     </Grid>
 </controls:TalgoniteWindow>

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -26,7 +26,7 @@
     </controls:TalgoniteWindow.TitleBarContent>
     
     <Grid RowDefinitions="*,Auto" Margin="1,0">
-        <TabControl Grid.Row="0" TabStripPlacement="Left" Padding="8">
+        <TabControl Grid.Row="0" TabStripPlacement="Left" Padding="8" SelectedIndex="4">
             <!-- Game Client Settings Tab -->
             <TabItem Header="Game Client">
                 <StackPanel Spacing="4">
@@ -149,8 +149,10 @@
                     <HyperlinkButton Command="{Binding VisitProjectWebsiteCommand}"
                                      FontFamily="{StaticResource Talgonite.Font.Monospace}"
                                      Margin="4"
-                                     HorizontalContentAlignment="Center">
-                        View on Github
+                                     HorizontalAlignment="Stretch">
+                        <TextBlock TextAlignment="Center">
+                            View on Github
+                        </TextBlock>
                     </HyperlinkButton>
                 </StackPanel>
             </TabItem>

--- a/Arbiter.App/Views/TraceView.axaml
+++ b/Arbiter.App/Views/TraceView.axaml
@@ -162,8 +162,9 @@
         <Border Grid.Row="1" IsVisible="{Binding ShowFilterBar}"
                 BorderBrush="{StaticResource Talgonite.Window.TitleBorderBrush}"
                 BorderThickness="0,1,0,0"
-                Padding="0,8">
-            <WrapPanel ItemSpacing="4">
+                Padding="0,4"
+                Height="50">
+            <WrapPanel ItemSpacing="4" VerticalAlignment="Center">
                 <!-- Bar Icon -->
                 <Border Padding="12,4"
                         BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
@@ -192,7 +193,6 @@
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
                                 <Border BorderBrush="{StaticResource Talgonite.ComboBox.BorderBrush}"
-                                        BorderThickness="0,0,0,1"
                                         Padding="4">
                                     <TextBlock Text="{Binding .}"
                                                Padding="8,2" />
@@ -250,8 +250,9 @@
         <Border Grid.Row="2" IsVisible="{Binding ShowSearchBar}"
                 BorderBrush="{StaticResource Talgonite.Window.TitleBorderBrush}"
                 BorderThickness="0,1,0,0"
-                Padding="0,8">
-            <WrapPanel ItemSpacing="4">
+                Padding="0,4"
+                Height="50">
+            <WrapPanel ItemSpacing="4" VerticalAlignment="Center">
                 <!-- Bar Icon -->
                 <Border Padding="12,4"
                         BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
@@ -282,7 +283,8 @@
                 </TextBox>
                 
                 <StackPanel Orientation="Horizontal" Spacing="4"
-                            IsVisible="{Binding FormattedSearchResultsText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                            IsVisible="{Binding FormattedSearchResultsText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                            Height="40">
                     <!-- Result count -->
                     <TextBlock Text="{Binding FormattedSearchResultsText, FallbackValue=no matches}"
                                TextAlignment="Center"
@@ -290,7 +292,7 @@
                                FontSize="14"
                                VerticalAlignment="Center"
                                MinWidth="40"
-                               Margin="8,4"/>
+                               Margin="8,0"/>
                     
                     <!-- Navigation Buttons -->
                     <StackPanel Orientation="Horizontal"
@@ -314,10 +316,6 @@
                         </Button>
                     </StackPanel>
                 </StackPanel>
-  
-                
-                
-                
             </WrapPanel>
         </Border>
 

--- a/Arbiter.App/Views/TraceView.axaml
+++ b/Arbiter.App/Views/TraceView.axaml
@@ -230,7 +230,7 @@
                            VerticalAlignment="Center" />
                     <TextBox Text="{Binding FilterParameters.CommandFilter}"
                              FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                             Width="100"
+                             Width="120"
                              Height="36">
                         <TextBox.InnerRightContent>
                             <Button Command="{Binding FilterParameters.ClearCommandFilterCommand}"

--- a/Arbiter.Net/Client/Messages/ClientDialogMenuChoiceMessage.cs
+++ b/Arbiter.Net/Client/Messages/ClientDialogMenuChoiceMessage.cs
@@ -11,7 +11,7 @@ public class ClientDialogMenuChoiceMessage : ClientMessage
     public uint EntityId { get; set; }
     public ushort PursuitId { get; set; }
     public byte? Slot { get; set; }
-    public List<string> TextInputs { get; set; } = [];
+    public List<string> Arguments { get; set; } = [];
 
     public override void Deserialize(INetworkPacketReader reader)
     {
@@ -27,7 +27,7 @@ public class ClientDialogMenuChoiceMessage : ClientMessage
         }
         else
         {
-            TextInputs = reader.ReadStringArgs8().ToList();
+            Arguments = reader.ReadStringArgs8().ToList();
         }
     }
 

--- a/Arbiter.Net/Server/Messages/ServerShowDialogMessage.cs
+++ b/Arbiter.Net/Server/Messages/ServerShowDialogMessage.cs
@@ -22,6 +22,7 @@ public class ServerShowDialogMessage : ServerMessage
     public List<string> MenuChoices { get; set; } = [];
     public string? InputPrompt { get; set; }
     public byte? InputMaxLength { get; set; }
+    public string? InputDescription { get; set; }
     public byte? Unknown1 { get; set; }
     public byte? Unknown2 { get; set; }
 
@@ -79,6 +80,7 @@ public class ServerShowDialogMessage : ServerMessage
         {
             InputPrompt = reader.ReadString8();
             InputMaxLength = reader.ReadByte();
+            InputDescription = reader.ReadString8();
         }
     }
 

--- a/Arbiter.Net/Server/Messages/ServerUserIdMessage.cs
+++ b/Arbiter.Net/Server/Messages/ServerUserIdMessage.cs
@@ -11,6 +11,7 @@ public class ServerUserIdMessage : ServerMessage
     public WorldDirection Direction { get; set; }
     public bool HasGuild { get; set; }
     public CharacterClass Class { get; set; }
+    public bool CanMove { get; set; }
 
     public override void Deserialize(INetworkPacketReader reader)
     {
@@ -22,6 +23,7 @@ public class ServerUserIdMessage : ServerMessage
         HasGuild = reader.ReadBoolean();
 
         Class = (CharacterClass)reader.ReadByte();
+        CanMove = (reader.ReadByte() & 1) == 0; // seems to be a bit flag but not sure what else it affects
     }
 
     public override void Serialize(INetworkPacketBuilder builder)

--- a/Arbiter.Net/Types/EntityTypeFlags.cs
+++ b/Arbiter.Net/Types/EntityTypeFlags.cs
@@ -6,5 +6,5 @@ public enum EntityTypeFlags : byte
     None = 0,
     Creature = 0x1,
     Item = 0x2,
-    Aisling = 0x4
+    Reactor = 0x4
 }

--- a/Arbiter.Net/Types/InterfacePane.cs
+++ b/Arbiter.Net/Types/InterfacePane.cs
@@ -3,8 +3,8 @@
 public enum InterfacePane : byte
 {
     Inventory = 0,
-    Spells = 1,
-    Skills = 2,
-    Equipment = 3,
-    Attributes = 4
+    Skills = 1,
+    Spells = 2,
+    Chat = 3,
+    Stats = 4
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Additional sub-second rates for sending packets
+- `Shift+Enter` hotkey for sending packets in the send window
 
 ### Changed
 
 - Rename `Aisling` to `Reactor` for dialog entity type
 - Rename `TextInput` to `Arguments` for `ClientDialogMenuChoiceMessage` message
 - Increase command filter box width slightly
-- `Pane` enum values
+- Fixed `InterfacePane` enum values
 
 ## [0.9.4b] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase command filter box width slightly
 - Fixed `InterfacePane` enum values
 - Display `Name` for entities in Inspector
+- Remove most transition animations in the UI (need to re-standardize them)
 
 ## [0.9.4b] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display `Name` for entities in Inspector
 - Remove most transition animations in the UI (need to re-standardize them)
 - Selected tab background color
-- Fix spacing in search bar
+- Fix spacing in search and filter bars
+- Fix disable style for `ComboBox` dropdown button
 
 ## [0.9.4b] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Additional sub-second rates for sending packets
 - `Shift+Enter` hotkey for sending packets in the send window
+- `InputDescription` for `ServerShowDialogMessage` packet
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `TextInput` to `Arguments` for `ClientDialogMenuChoiceMessage` message
 - Increase command filter box width slightly
 - Fixed `InterfacePane` enum values
+- Display `Name` for entities in Inspector
 
 ## [0.9.4b] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Shift+Enter` hotkey for sending packets in the send window
 - `InputDescription` for `ServerShowDialogMessage` packet
 - Redesigned settings window
+- `CanMove` property for `ServerUserIdMessage` packet
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `Aisling` to `Reactor` for dialog entity type
 - Rename `TextInput` to `Arguments` for `ClientDialogMenuChoiceMessage` message
 - Increase command filter box width slightly
+- `Pane` enum values
 
 ## [0.9.4b] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional sub-second rates for sending packets
 - `Shift+Enter` hotkey for sending packets in the send window
 - `InputDescription` for `ServerShowDialogMessage` packet
+- Redesigned settings window
 
 ### Changed
 
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `InterfacePane` enum values
 - Display `Name` for entities in Inspector
 - Remove most transition animations in the UI (need to re-standardize them)
+- Selected tab background color
+- Fix spacing in search bar
 
 ## [0.9.4b] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selected tab background color
 - Fix spacing in search and filter bars
 - Fix disable style for `ComboBox` dropdown button
+- Reduce corner radius on input controls
 
 ## [0.9.4b] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Additional sub-second rates for sending packets
+
+### Changed
+
+- Rename `Aisling` to `Reactor` for dialog entity type
+- Rename `TextInput` to `Arguments` for `ClientDialogMenuChoiceMessage` message
+- Increase command filter box width slightly
+
 ## [0.9.4b] - 2025-09-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ TBD
 - [x] Find by Command (Next/Prev)
 - [x] Delete Trace Packets
 - [x] Save/Load Traces
-- [ ] Raw Packet Injection
+- [x] Raw Packet Injection
   - [x] To Client
   - [x] To Server
-- [ ] Revamp Settings UI
+- [x] Revamp Settings UI
 
 ### v1.1
 


### PR DESCRIPTION
### Added

- Additional sub-second rates for sending packets
- `Shift+Enter` hotkey for sending packets in the send window
- `InputDescription` for `ServerShowDialogMessage` packet
- Redesigned settings window
- `CanMove` property for `ServerUserIdMessage` packet

### Changed

- Rename `Aisling` to `Reactor` for dialog entity type
- Rename `TextInput` to `Arguments` for `ClientDialogMenuChoiceMessage` message
- Increase command filter box width slightly
- Fixed `InterfacePane` enum values
- Display `Name` for entities in Inspector
- Remove most transition animations in the UI (need to re-standardize them)
- Selected tab background color
- Fix spacing in search and filter bars
- Fix disable style for `ComboBox` dropdown button
- Reduce corner radius on input controls