### PR TITLE
Prioritize tick sync packets

### DIFF
--- a/Arbiter.Net.Tests/Proxy/ProxyConnectionPriorityTests.cs
+++ b/Arbiter.Net.Tests/Proxy/ProxyConnectionPriorityTests.cs
@@ -1,0 +1,55 @@
+using Arbiter.Net.Client;
+using Arbiter.Net.Proxy;
+using Arbiter.Net.Server;
+
+namespace Arbiter.Net.Tests.Proxy;
+
+public class ProxyConnectionPriorityTests
+{
+    [TestCase(ClientCommand.Heartbeat)]
+    [TestCase(ClientCommand.SyncTicks)]
+    public void Should_Prioritize_Client_Heartbeat_And_Tick_Sync_Packets(ClientCommand command)
+    {
+        var packet = new ClientPacket((byte)command, Array.Empty<byte>());
+
+        var priority = ProxyConnection.ResolvePacketPriority(packet);
+
+        Assert.That(priority, Is.EqualTo(NetworkPriority.High));
+    }
+
+    [TestCase(ServerCommand.Heartbeat)]
+    [TestCase(ServerCommand.SyncTicks)]
+    public void Should_Prioritize_Server_Heartbeat_And_Tick_Sync_Packets(ServerCommand command)
+    {
+        var packet = new ServerPacket((byte)command, Array.Empty<byte>());
+
+        var priority = ProxyConnection.ResolvePacketPriority(packet);
+
+        Assert.That(priority, Is.EqualTo(NetworkPriority.High));
+    }
+
+    [Test]
+    public void Should_Not_Prioritize_Normal_Packets()
+    {
+        NetworkPacket[] packets =
+        [
+            new ClientPacket((byte)ClientCommand.Walk, Array.Empty<byte>()),
+            new ServerPacket((byte)ServerCommand.WorldMessage, Array.Empty<byte>())
+        ];
+
+        foreach (var packet in packets)
+        {
+            Assert.That(ProxyConnection.ResolvePacketPriority(packet), Is.EqualTo(NetworkPriority.Normal));
+        }
+    }
+
+    [Test]
+    public void Should_Preserve_Explicit_High_Priority()
+    {
+        var packet = new ClientPacket((byte)ClientCommand.Walk, Array.Empty<byte>());
+
+        var priority = ProxyConnection.ResolvePacketPriority(packet, NetworkPriority.High);
+
+        Assert.That(priority, Is.EqualTo(NetworkPriority.High));
+    }
+}

--- a/Arbiter.Net/Arbiter.Net.csproj
+++ b/Arbiter.Net/Arbiter.Net.csproj
@@ -11,4 +11,8 @@
         <Version>1.2.0</Version>
     </PropertyGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="Arbiter.Net.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/Arbiter.Net/Proxy/ProxyConnection.Enqueue.cs
+++ b/Arbiter.Net/Proxy/ProxyConnection.Enqueue.cs
@@ -24,13 +24,7 @@ public partial class ProxyConnection
     {
         CheckIfDisposed();
 
-        // Prioritize outgoing client heartbeat packets
-        if (packet is ClientPacket { Command: ClientCommand.Heartbeat })
-        {
-            priority = NetworkPriority.High;
-        }
-
-        var writer = priority switch
+        var writer = ResolvePacketPriority(packet, priority) switch
         {
             NetworkPriority.High => _prioritySendQueue.Writer,
             _ => _sendQueue.Writer,
@@ -90,12 +84,6 @@ public partial class ProxyConnection
         {
             message.Serialize(ref builder);
             var packet = builder.ToPacket(NetworkPacketSource.Injected);
-            
-            // Prioritize outgoing client heartbeat packets
-            if (packet is ClientPacket { Command: ClientCommand.Heartbeat })
-            {
-                priority = NetworkPriority.High;
-            }
 
             return EnqueuePacket(packet, priority);
         }
@@ -151,17 +139,22 @@ public partial class ProxyConnection
             message.Serialize(ref builder);
             var packet = builder.ToPacket(NetworkPacketSource.Injected);
 
-            // Prioritize incoming server heartbeat packets
-            if (packet is ServerPacket { Command: ServerCommand.Heartbeat })
-            {
-                priority = NetworkPriority.High;
-            }
-
             return EnqueuePacket(packet, priority);
         }
         finally
         {
             builder.Dispose();
         }
+    }
+
+    internal static NetworkPriority ResolvePacketPriority(NetworkPacket packet,
+        NetworkPriority requestedPriority = NetworkPriority.Normal)
+    {
+        return packet switch
+        {
+            ClientPacket { Command: ClientCommand.Heartbeat or ClientCommand.SyncTicks } => NetworkPriority.High,
+            ServerPacket { Command: ServerCommand.Heartbeat or ServerCommand.SyncTicks } => NetworkPriority.High,
+            _ => requestedPriority,
+        };
     }
 }

--- a/Arbiter.Net/Proxy/ProxyConnection.RecvLoop.cs
+++ b/Arbiter.Net/Proxy/ProxyConnection.RecvLoop.cs
@@ -94,10 +94,12 @@ public partial class ProxyConnection
 
                     if (filterResult.Output is not null)
                     {
-                        // Prioritize server heartbeat packets to the client, and enqueue others normally
                         var output = filterResult.Output;
-                        var isServerHeartbeat = output is ServerPacket { Command: ServerCommand.Heartbeat };
-                        var writer = isServerHeartbeat ? _prioritySendQueue.Writer : _sendQueue.Writer;
+                        var writer = ResolvePacketPriority(output) switch
+                        {
+                            NetworkPriority.High => _prioritySendQueue.Writer,
+                            _ => _sendQueue.Writer,
+                        };
 
                         // Send the decrypted packet to the other end of the connection (it will be re-encrypted)
                         await writer.WriteAsync(output, token).ConfigureAwait(false);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Keep entity collections on the UI thread and queue console and trace updates in UI batches
+- Prioritize heartbeat and tick sync packets in the network send queue
 - Updated Avalonia and supporting packages to their latest compatible patch versions
 
 ## [1.8.1] - 2025-11-14


### PR DESCRIPTION
## What changed

- Route server `0x68` tick sync packets and client `0x75` responses through the priority queue
- Use one priority classifier for forwarded, filtered, and injected heartbeat and tick sync packets
- Add focused coverage for both protocol directions and normal-priority packets

## Why

Tick sync packets can be delayed behind ordinary traffic on a busy connection. Giving the request and response the same treatment as heartbeat traffic keeps the client and server in sync.

## Testing

- `dotnet build Arbiter.sln`
- `dotnet test Arbiter.Net.Tests/Arbiter.Net.Tests.csproj --no-build` (44 passed)