### PR TITLE
Add trace query search

### DIFF
--- a/Arbiter.App.Tests/Arbiter.App.Tests.csproj
+++ b/Arbiter.App.Tests/Arbiter.App.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Arbiter.App\Arbiter.App.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Arbiter.App.Tests/Models/Tracing/Queries/TraceQueryParserTests.cs
+++ b/Arbiter.App.Tests/Models/Tracing/Queries/TraceQueryParserTests.cs
@@ -1,0 +1,374 @@
+using System.Text;
+using Arbiter.App.Models.Tracing;
+using Arbiter.App.Models.Tracing.Queries;
+using Arbiter.App.ViewModels.Tracing;
+
+namespace Arbiter.App.Tests.Models.Tracing.Queries;
+
+public class TraceQueryParserTests
+{
+    [Test]
+    public void Should_Combine_Client_And_Server_Commands_As_Alternatives()
+    {
+        var query = Parse("server=13, client=45-47");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x46)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x44)).IsMatch, Is.False);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x46)).IsMatch, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Accept_Comma_Separated_Commands_And_Whitespace_Separated_Clauses()
+    {
+        const string text = "server=05,15 client=12";
+        var query = Parse(text);
+        var keywords = TraceQuerySyntax.GetKeywordSpans(text)
+            .Select(span => text.Substring(span.Start, span.Length));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x05)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x15)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x12)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x12)).IsMatch, Is.False);
+            Assert.That(keywords, Is.EqualTo(new[] { "server", "client" }));
+        });
+    }
+
+    [Test]
+    public void Should_Mix_Individual_Commands_And_Ascending_Ranges_In_Implicit_Queries()
+    {
+        var query = Parse("server=05, 12-15,19 client=45-47, text=Test");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x05, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x19, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x46, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x16, "Test")).IsMatch, Is.False);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x46, "test")).IsMatch, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Apply_And_Before_Or()
+    {
+        var query = Parse("server=13 or server=15 and text=Test");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x15, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x15, "test")).IsMatch, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Respect_Parenthesized_Expressions()
+    {
+        var query = Parse("(server=13 OR client=45) AND text=Test");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45, "test")).IsMatch, Is.False);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x14, "Test")).IsMatch, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Support_Not_And_Not_Equals()
+    {
+        var notQuery = Parse("NOT (server=12 OR text=error)");
+        var notEqualsQuery = Parse("server!=12");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(notQuery.Match(Context(PacketDirection.Server, 0x13, "okay")).IsMatch, Is.True);
+            Assert.That(notQuery.Match(Context(PacketDirection.Server, 0x12, "okay")).IsMatch, Is.False);
+            Assert.That(notQuery.Match(Context(PacketDirection.Client, 0x45, "error")).IsMatch, Is.False);
+            Assert.That(notEqualsQuery.Match(Context(PacketDirection.Server, 0x13)).IsMatch, Is.True);
+            Assert.That(notEqualsQuery.Match(Context(PacketDirection.Server, 0x12)).IsMatch, Is.False);
+            Assert.That(notEqualsQuery.Match(Context(PacketDirection.Client, 0x12)).IsMatch, Is.True);
+        });
+    }
+
+    [Test]
+    public void Should_Allow_Unquoted_Single_Token_Strings()
+    {
+        var query = Parse("text=Test AND name=SiLo");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13, "Test", "silo")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13, "test", "SILO")).IsMatch, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Preserve_Implicit_Directional_Alternatives_Around_Other_Predicates()
+    {
+        var query = Parse("server=13 text=Test client=45");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45, "test")).IsMatch, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Accept_Command_Names_And_Hexadecimal_Lists()
+    {
+        var query = Parse("server=HealthBar|29, client=Heartbeat");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x29)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45)).IsMatch, Is.True);
+        });
+    }
+
+    [Test]
+    public void Should_Require_Every_Non_Directional_Clause()
+    {
+        var query = Parse("server=13, text=\"Test\", data=54 65");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13, "Test")).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x13, "test")).IsMatch, Is.False);
+            Assert.That(query.Match(Context(PacketDirection.Server, 0x14, "Test")).IsMatch, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Search_Text_Case_Sensitively_And_Return_Byte_Ranges()
+    {
+        var query = Parse("text=\"Test\"");
+        var match = query.Match(Context(PacketDirection.Server, 0x13, "xxTesttest"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(match.IsMatch, Is.True);
+            Assert.That(match.Highlights, Is.EqualTo(
+                new[] { new TraceQueryHighlight(2, 4, TraceQueryHighlightSource.Data) }));
+        });
+    }
+
+    [Test]
+    public void Should_Toggle_Case_Sensitivity_For_Text_And_Text_Regex_Searches()
+    {
+        var literal = Parse("text=Test", isTextCaseSensitive: false);
+        var regex = Parse("text=/error/", isTextCaseSensitive: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(literal.Match(Context(PacketDirection.Server, 0x13, "xxTESTxx")).Highlights,
+                Is.EqualTo(new[] { new TraceQueryHighlight(2, 4, TraceQueryHighlightSource.Data) }));
+            Assert.That(regex.Match(Context(PacketDirection.Server, 0x13, "ERROR")).IsMatch, Is.True);
+        });
+    }
+
+    [Test]
+    public void Should_Default_The_Search_View_Model_To_Case_Sensitive_Text()
+    {
+        var search = new TraceSearchViewModel { QueryText = "text=Test" };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(search.IsTextCaseSensitive, Is.True);
+            Assert.That(search.Query.Match(Context(PacketDirection.Server, 0x13, "test")).IsMatch, Is.False);
+        });
+
+        search.IsTextCaseSensitive = false;
+
+        Assert.That(search.Query.Match(Context(PacketDirection.Server, 0x13, "test")).IsMatch, Is.True);
+    }
+
+    [Test]
+    public void Should_Keep_The_Last_Valid_Query_When_Validation_Fails()
+    {
+        var search = new TraceSearchViewModel { QueryText = "server=13" };
+        var validQuery = search.Query;
+
+        search.QueryText = "server=GG";
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(search.HasQueryError, Is.True);
+            Assert.That(search.Query, Is.SameAs(validQuery));
+            Assert.That(search.Query.Match(Context(PacketDirection.Server, 0x13)).IsMatch, Is.True);
+        });
+    }
+
+    [Test]
+    public void Should_Search_Character_Names_Case_Insensitively()
+    {
+        var literal = Parse("name=\"SiLo\"", isTextCaseSensitive: false);
+        var regex = Parse("name=/^silo$/", isTextCaseSensitive: true);
+        var context = Context(PacketDirection.Server, 0x13, name: "SILO");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(literal.Match(context).IsMatch, Is.True);
+            Assert.That(regex.Match(context).IsMatch, Is.True);
+        });
+    }
+
+    [Test]
+    public void Should_Return_All_Text_Regex_Highlights()
+    {
+        var query = Parse("text=/error|warning/");
+        var match = query.Match(Context(PacketDirection.Server, 0x13, "error warning"));
+
+        Assert.That(match.Highlights, Is.EqualTo(new[]
+        {
+            new TraceQueryHighlight(0, 5, TraceQueryHighlightSource.Data),
+            new TraceQueryHighlight(6, 7, TraceQueryHighlightSource.Data)
+        }));
+    }
+
+    [Test]
+    public void Should_Merge_Overlapping_Byte_Highlights()
+    {
+        var query = Parse("data=65 65");
+        var match = query.Match(Context(PacketDirection.Server, 0x13, [0x65, 0x65, 0x65]));
+
+        Assert.That(match.Highlights, Is.EqualTo(
+            new[] { new TraceQueryHighlight(0, 3, TraceQueryHighlightSource.Data) }));
+    }
+
+    [Test]
+    public void Should_Distinguish_Raw_And_Data_Highlights()
+    {
+        var query = Parse("raw=AA 00, data=65 01");
+        var context = Context(
+            PacketDirection.Server,
+            0x13,
+            [0x65, 0x01],
+            raw: [0xAA, 0x00, 0x02, 0x13]);
+        var match = query.Match(context);
+
+        Assert.That(match.Highlights, Is.EqualTo(new[]
+        {
+            new TraceQueryHighlight(0, 2, TraceQueryHighlightSource.Data),
+            new TraceQueryHighlight(0, 2, TraceQueryHighlightSource.Raw)
+        }));
+    }
+
+    [Test]
+    public void Should_Support_Sequence_Values_And_Ranges()
+    {
+        var query = Parse("sequence=02|04-06");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45, sequence: 0x02)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45, sequence: 0x05)).IsMatch, Is.True);
+            Assert.That(query.Match(Context(PacketDirection.Client, 0x45, sequence: 0x03)).IsMatch, Is.False);
+        });
+    }
+
+    [TestCase("data=65 0", "Invalid data byte")]
+    [TestCase("server=47-45", "Range start")]
+    [TestCase("server=17-11", "Range start")]
+    [TestCase("text=\"missing", "Missing closing quote")]
+    [TestCase("payload=65", "Did you mean 'data'")]
+    [TestCase("text=/test/i", "Regex flags are not supported")]
+    [TestCase("text=/(?=test)/", "Unsupported regular expression")]
+    [TestCase("text=\"café\"", "ASCII characters only")]
+    [TestCase("(server=13", "Missing closing parenthesis")]
+    [TestCase("server=13 AND", "after 'AND'")]
+    [TestCase("NOT", "after 'NOT'")]
+    public void Should_Return_Actionable_Validation_Diagnostics(string text, string expectedMessage)
+    {
+        var result = TraceQueryParser.Parse(text);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.Diagnostic?.Message, Does.Contain(expectedMessage));
+            Assert.That(result.Diagnostic?.Position, Is.GreaterThanOrEqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Should_Allow_Commas_Inside_Quoted_And_Regex_Values()
+    {
+        var quoted = Parse("text=\"hello, world\"");
+        var regex = Parse("text=/hello, world/");
+        var context = Context(PacketDirection.Server, 0x13, "hello, world");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(quoted.Match(context).IsMatch, Is.True);
+            Assert.That(regex.Match(context).IsMatch, Is.True);
+        });
+    }
+
+    [Test]
+    public void Should_Identify_Only_Supported_Query_Keywords()
+    {
+        const string text = "server=13, unknown=1, text=/name=foo/, name=\"client=x\"";
+        var spans = TraceQuerySyntax.GetKeywordSpans(text);
+        var keywords = spans.Select(span => text.Substring(span.Start, span.Length));
+
+        Assert.That(keywords, Is.EqualTo(new[] { "server", "text", "name" }));
+    }
+
+    [Test]
+    public void Should_Identify_Boolean_Keywords_And_Grouping_Syntax()
+    {
+        const string text = "(server=13 OR NOT client!=12) AND text=\"Test Value\" OR name=/silo/";
+        var syntax = TraceQuerySyntax.GetSpans(text)
+            .Select(span => (text.Substring(span.Start, span.Length), span.Kind));
+
+        Assert.That(syntax, Is.EqualTo(new[]
+        {
+            ("(", TraceQuerySyntaxKind.Grouping),
+            ("server", TraceQuerySyntaxKind.Keyword),
+            ("OR", TraceQuerySyntaxKind.Keyword),
+            ("NOT", TraceQuerySyntaxKind.Keyword),
+            ("client", TraceQuerySyntaxKind.Keyword),
+            (")", TraceQuerySyntaxKind.Grouping),
+            ("AND", TraceQuerySyntaxKind.Keyword),
+            ("text", TraceQuerySyntaxKind.Keyword),
+            ("OR", TraceQuerySyntaxKind.Keyword),
+            ("name", TraceQuerySyntaxKind.Keyword)
+        }));
+    }
+
+    private static TraceQuery Parse(string text, bool isTextCaseSensitive = true)
+    {
+        var result = TraceQueryParser.Parse(text, isTextCaseSensitive);
+        Assert.That(result.Diagnostic, Is.Null, result.Diagnostic?.Message);
+        return result.Query!;
+    }
+
+    private static TraceQueryContext Context(
+        PacketDirection direction,
+        byte command,
+        string data = "",
+        string? name = null,
+        byte? sequence = null,
+        byte[]? raw = null) =>
+        Context(direction, command, Encoding.ASCII.GetBytes(data), name, sequence, raw);
+
+    private static TraceQueryContext Context(
+        PacketDirection direction,
+        byte command,
+        byte[] data,
+        string? name = null,
+        byte? sequence = null,
+        byte[]? raw = null) =>
+        new(direction, command, name, sequence, data, raw ?? []);
+}

--- a/Arbiter.App/Controls/HighlightedHexTextBlock.cs
+++ b/Arbiter.App/Controls/HighlightedHexTextBlock.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Arbiter.App.Models.Tracing.Queries;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+namespace Arbiter.App.Controls;
+
+public class HighlightedHexTextBlock : TextBlock
+{
+    public static readonly StyledProperty<string?> SourceTextProperty =
+        AvaloniaProperty.Register<HighlightedHexTextBlock, string?>(nameof(SourceText));
+
+    public static readonly StyledProperty<IReadOnlyList<TraceQueryHighlight>?> HighlightsProperty =
+        AvaloniaProperty.Register<HighlightedHexTextBlock, IReadOnlyList<TraceQueryHighlight>?>(nameof(Highlights));
+
+    public static readonly StyledProperty<IBrush?> HighlightBackgroundProperty =
+        AvaloniaProperty.Register<HighlightedHexTextBlock, IBrush?>(nameof(HighlightBackground));
+
+    public static readonly StyledProperty<IBrush?> HighlightForegroundProperty =
+        AvaloniaProperty.Register<HighlightedHexTextBlock, IBrush?>(nameof(HighlightForeground));
+
+    public string? SourceText
+    {
+        get => GetValue(SourceTextProperty);
+        set => SetValue(SourceTextProperty, value);
+    }
+
+    public IReadOnlyList<TraceQueryHighlight>? Highlights
+    {
+        get => GetValue(HighlightsProperty);
+        set => SetValue(HighlightsProperty, value);
+    }
+
+    public IBrush? HighlightBackground
+    {
+        get => GetValue(HighlightBackgroundProperty);
+        set => SetValue(HighlightBackgroundProperty, value);
+    }
+
+    public IBrush? HighlightForeground
+    {
+        get => GetValue(HighlightForegroundProperty);
+        set => SetValue(HighlightForegroundProperty, value);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == SourceTextProperty ||
+            change.Property == HighlightsProperty ||
+            change.Property == HighlightBackgroundProperty ||
+            change.Property == HighlightForegroundProperty)
+        {
+            RebuildInlines();
+        }
+    }
+
+    private void RebuildInlines()
+    {
+        var text = SourceText ?? string.Empty;
+        Inlines?.Clear();
+
+        var ranges = GetCharacterRanges(text, Highlights);
+        if (ranges.Count == 0)
+        {
+            Inlines?.Add(new Run(text));
+            return;
+        }
+
+        var position = 0;
+        foreach (var range in ranges)
+        {
+            if (range.Start > position)
+            {
+                Inlines?.Add(new Run(text[position..range.Start]));
+            }
+
+            Inlines?.Add(new Run(text.Substring(range.Start, range.Length))
+            {
+                Background = HighlightBackground,
+                Foreground = HighlightForeground
+            });
+            position = range.Start + range.Length;
+        }
+
+        if (position < text.Length)
+        {
+            Inlines?.Add(new Run(text[position..]));
+        }
+    }
+
+    private static IReadOnlyList<CharacterRange> GetCharacterRanges(
+        string text,
+        IReadOnlyList<TraceQueryHighlight>? highlights)
+    {
+        if (string.IsNullOrEmpty(text) || highlights is not { Count: > 0 })
+        {
+            return [];
+        }
+
+        var byteCount = (text.Length + 1) / 3;
+        return highlights
+            .Where(highlight => highlight.Offset >= 0 && highlight.Length > 0 && highlight.Offset < byteCount)
+            .Select(highlight =>
+            {
+                var byteLength = Math.Min(highlight.Length, byteCount - highlight.Offset);
+                var start = highlight.Offset * 3;
+                var length = Math.Min(byteLength * 3 - 1, text.Length - start);
+                return new CharacterRange(start, length);
+            })
+            .Where(range => range.Length > 0)
+            .ToList();
+    }
+
+    private readonly record struct CharacterRange(int Start, int Length);
+}

--- a/Arbiter.App/Controls/QuerySyntaxTextPresenter.cs
+++ b/Arbiter.App/Controls/QuerySyntaxTextPresenter.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using Arbiter.App.Models.Tracing.Queries;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Utilities;
+
+namespace Arbiter.App.Controls;
+
+public sealed class QuerySyntax
+{
+    public static readonly AttachedProperty<bool> IsEnabledProperty =
+        AvaloniaProperty.RegisterAttached<QuerySyntax, TextBox, bool>("IsEnabled");
+
+    public static bool GetIsEnabled(TextBox textBox) => textBox.GetValue(IsEnabledProperty);
+    public static void SetIsEnabled(TextBox textBox, bool value) => textBox.SetValue(IsEnabledProperty, value);
+}
+
+public class QuerySyntaxTextPresenter : TextPresenter
+{
+    public static readonly StyledProperty<bool> IsQuerySyntaxEnabledProperty =
+        AvaloniaProperty.Register<QuerySyntaxTextPresenter, bool>(nameof(IsQuerySyntaxEnabled));
+
+    public static readonly StyledProperty<IBrush?> KeywordBrushProperty =
+        AvaloniaProperty.Register<QuerySyntaxTextPresenter, IBrush?>(nameof(KeywordBrush));
+
+    public static readonly StyledProperty<IBrush?> GroupingBrushProperty =
+        AvaloniaProperty.Register<QuerySyntaxTextPresenter, IBrush?>(nameof(GroupingBrush));
+
+    public bool IsQuerySyntaxEnabled
+    {
+        get => GetValue(IsQuerySyntaxEnabledProperty);
+        set => SetValue(IsQuerySyntaxEnabledProperty, value);
+    }
+
+    public IBrush? KeywordBrush
+    {
+        get => GetValue(KeywordBrushProperty);
+        set => SetValue(KeywordBrushProperty, value);
+    }
+
+    public IBrush? GroupingBrush
+    {
+        get => GetValue(GroupingBrushProperty);
+        set => SetValue(GroupingBrushProperty, value);
+    }
+
+    protected override TextLayout CreateTextLayout()
+    {
+        if (!IsQuerySyntaxEnabled || KeywordBrush is null || !string.IsNullOrEmpty(PreeditText) ||
+            PasswordChar != default && !RevealPassword)
+        {
+            return base.CreateTextLayout();
+        }
+
+        var text = Text ?? string.Empty;
+        var textBox = TemplatedParent as TextBox;
+        var fontFamily = textBox?.FontFamily ?? FontFamily;
+        var fontSize = textBox?.FontSize ?? FontSize;
+        var fontStyle = textBox?.FontStyle ?? FontStyle;
+        var fontWeight = textBox?.FontWeight ?? FontWeight;
+        var fontStretch = textBox?.FontStretch ?? FontStretch;
+        var foreground = textBox?.Foreground ?? Foreground;
+        var typeface = new Typeface(fontFamily, fontStyle, fontWeight, fontStretch);
+        var overrides = new List<ValueSpan<TextRunProperties>>();
+
+        foreach (var span in TraceQuerySyntax.GetSpans(text))
+        {
+            var brush = span.Kind == TraceQuerySyntaxKind.Grouping ? GroupingBrush : KeywordBrush;
+            if (brush is null)
+            {
+                continue;
+            }
+
+            overrides.Add(new ValueSpan<TextRunProperties>(
+                span.Start,
+                span.Length,
+                new GenericTextRunProperties(
+                    typeface,
+                    FontFeatures,
+                    fontSize,
+                    foregroundBrush: brush)));
+        }
+
+        var selectionStart = Math.Min(SelectionStart, SelectionEnd);
+        var selectionLength = Math.Abs(SelectionEnd - SelectionStart);
+        if (ShowSelectionHighlight && selectionLength > 0 && SelectionForegroundBrush is not null)
+        {
+            overrides.Add(new ValueSpan<TextRunProperties>(
+                selectionStart,
+                selectionLength,
+                new GenericTextRunProperties(
+                    typeface,
+                    FontFeatures,
+                    fontSize,
+                    foregroundBrush: SelectionForegroundBrush)));
+        }
+
+        return new TextLayout(
+            text,
+            typeface,
+            FontFeatures,
+            fontSize,
+            foreground,
+            TextAlignment,
+            TextWrapping,
+            maxWidth: double.PositiveInfinity,
+            maxHeight: double.PositiveInfinity,
+            textStyleOverrides: overrides,
+            flowDirection: FlowDirection,
+            lineHeight: LineHeight,
+            letterSpacing: LetterSpacing);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == IsQuerySyntaxEnabledProperty ||
+            change.Property == KeywordBrushProperty ||
+            change.Property == GroupingBrushProperty)
+        {
+            InvalidateTextLayout();
+        }
+    }
+}

--- a/Arbiter.App/Models/Tracing/Queries/TraceQuery.cs
+++ b/Arbiter.App/Models/Tracing/Queries/TraceQuery.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Arbiter.App.Models.Tracing.Queries;
+
+public sealed class TraceQuery
+{
+    private readonly HashSet<byte>? _clientCommands;
+    private readonly HashSet<byte>? _serverCommands;
+    private readonly IReadOnlyList<ITraceQueryClause> _clauses;
+    private readonly TraceQuery? _left;
+    private readonly TraceQuery? _right;
+    private readonly TraceQueryOperation _operation;
+
+    internal TraceQuery(
+        HashSet<byte>? clientCommands,
+        HashSet<byte>? serverCommands,
+        IReadOnlyList<ITraceQueryClause> clauses)
+    {
+        _clientCommands = clientCommands;
+        _serverCommands = serverCommands;
+        _clauses = clauses;
+        _operation = TraceQueryOperation.Predicate;
+    }
+
+    private TraceQuery(TraceQueryOperation operation, TraceQuery left, TraceQuery? right = null)
+    {
+        _clientCommands = null;
+        _serverCommands = null;
+        _clauses = [];
+        _left = left;
+        _right = right;
+        _operation = operation;
+    }
+
+    public static TraceQuery Empty { get; } = new(null, null, []);
+
+    public bool IsEmpty => _operation == TraceQueryOperation.Predicate &&
+                           _clientCommands is null &&
+                           _serverCommands is null &&
+                           _clauses.Count == 0;
+
+    internal bool IsDirectionalGroup => _operation switch
+    {
+        TraceQueryOperation.Predicate =>
+            (_clientCommands is not null || _serverCommands is not null) && _clauses.Count == 0,
+        TraceQueryOperation.Or => _left!.IsDirectionalGroup && _right!.IsDirectionalGroup,
+        _ => false
+    };
+
+    internal static TraceQuery And(TraceQuery left, TraceQuery right) =>
+        new(TraceQueryOperation.And, left, right);
+
+    internal static TraceQuery Or(TraceQuery left, TraceQuery right) =>
+        new(TraceQueryOperation.Or, left, right);
+
+    internal static TraceQuery Not(TraceQuery operand) =>
+        new(TraceQueryOperation.Not, operand);
+
+    internal static TraceQuery CombineImplicit(TraceQuery left, TraceQuery right)
+    {
+        if (right.IsDirectionalGroup && left.TryMergeDirectionalGroup(right, out var merged))
+        {
+            return merged;
+        }
+
+        return new TraceQuery(TraceQueryOperation.ImplicitAnd, left, right);
+    }
+
+    public TraceQueryMatch Match(TraceQueryContext context)
+    {
+        if (_operation != TraceQueryOperation.Predicate)
+        {
+            return MatchExpression(context);
+        }
+
+        if (!MatchesCommand(context))
+        {
+            return TraceQueryMatch.NoMatch;
+        }
+
+        List<TraceQueryHighlight>? highlights = null;
+        foreach (var clause in _clauses)
+        {
+            highlights ??= [];
+            if (!clause.TryMatch(context, highlights))
+            {
+                return TraceQueryMatch.NoMatch;
+            }
+        }
+
+        return highlights is { Count: > 0 }
+            ? new TraceQueryMatch(true, MergeHighlights(highlights))
+            : TraceQueryMatch.MatchWithoutHighlights;
+    }
+
+    private TraceQueryMatch MatchExpression(TraceQueryContext context)
+    {
+        var leftMatch = _left!.Match(context);
+        if (_operation == TraceQueryOperation.Not)
+        {
+            return leftMatch.IsMatch ? TraceQueryMatch.NoMatch : TraceQueryMatch.MatchWithoutHighlights;
+        }
+
+        if (_operation is TraceQueryOperation.And or TraceQueryOperation.ImplicitAnd && !leftMatch.IsMatch)
+        {
+            return TraceQueryMatch.NoMatch;
+        }
+
+        var rightMatch = _right!.Match(context);
+        if (_operation is TraceQueryOperation.And or TraceQueryOperation.ImplicitAnd && !rightMatch.IsMatch ||
+            _operation == TraceQueryOperation.Or && !leftMatch.IsMatch && !rightMatch.IsMatch)
+        {
+            return TraceQueryMatch.NoMatch;
+        }
+
+        var highlights = new List<TraceQueryHighlight>();
+        if (leftMatch.IsMatch)
+        {
+            highlights.AddRange(leftMatch.Highlights);
+        }
+
+        if (rightMatch.IsMatch)
+        {
+            highlights.AddRange(rightMatch.Highlights);
+        }
+
+        return highlights.Count > 0
+            ? new TraceQueryMatch(true, MergeHighlights(highlights))
+            : TraceQueryMatch.MatchWithoutHighlights;
+    }
+
+    private bool TryMergeDirectionalGroup(TraceQuery direction, out TraceQuery merged)
+    {
+        if (IsDirectionalGroup)
+        {
+            merged = Or(this, direction);
+            return true;
+        }
+
+        if (_operation == TraceQueryOperation.ImplicitAnd &&
+            _left!.TryMergeDirectionalGroup(direction, out var mergedLeft))
+        {
+            merged = new TraceQuery(TraceQueryOperation.ImplicitAnd, mergedLeft, _right);
+            return true;
+        }
+
+        if (_operation == TraceQueryOperation.ImplicitAnd &&
+            _right!.TryMergeDirectionalGroup(direction, out var mergedRight))
+        {
+            merged = new TraceQuery(TraceQueryOperation.ImplicitAnd, _left!, mergedRight);
+            return true;
+        }
+
+        merged = null!;
+        return false;
+    }
+
+    private bool MatchesCommand(TraceQueryContext context)
+    {
+        if (_clientCommands is null && _serverCommands is null)
+        {
+            return true;
+        }
+
+        return context.Direction switch
+        {
+            PacketDirection.Client => _clientCommands?.Contains(context.Command) == true,
+            PacketDirection.Server => _serverCommands?.Contains(context.Command) == true,
+            _ => false
+        };
+    }
+
+    private static IReadOnlyList<TraceQueryHighlight> MergeHighlights(List<TraceQueryHighlight> highlights)
+    {
+        var ordered = highlights
+            .Where(highlight => highlight is { Offset: >= 0, Length: > 0 })
+            .OrderBy(highlight => highlight.Source)
+            .ThenBy(highlight => highlight.Offset)
+            .ToList();
+
+        if (ordered.Count < 2)
+        {
+            return ordered;
+        }
+
+        var merged = new List<TraceQueryHighlight>(ordered.Count);
+        var current = ordered[0];
+
+        for (var i = 1; i < ordered.Count; i++)
+        {
+            var next = ordered[i];
+            var currentEnd = current.Offset + current.Length;
+            if (next.Source == current.Source && next.Offset <= currentEnd)
+            {
+                var nextEnd = next.Offset + next.Length;
+                current = current with { Length = Math.Max(currentEnd, nextEnd) - current.Offset };
+                continue;
+            }
+
+            merged.Add(current);
+            current = next;
+        }
+
+        merged.Add(current);
+        return merged;
+    }
+}
+
+internal enum TraceQueryOperation
+{
+    Predicate,
+    And,
+    ImplicitAnd,
+    Or,
+    Not
+}
+
+internal interface ITraceQueryClause
+{
+    bool TryMatch(TraceQueryContext context, List<TraceQueryHighlight> highlights);
+}
+
+internal sealed class SequenceQueryClause(HashSet<byte> sequences) : ITraceQueryClause
+{
+    public bool TryMatch(TraceQueryContext context, List<TraceQueryHighlight> highlights) =>
+        context.Sequence is byte sequence && sequences.Contains(sequence);
+}
+
+internal sealed class NameQueryClause(string value) : ITraceQueryClause
+{
+    public bool TryMatch(TraceQueryContext context, List<TraceQueryHighlight> highlights) =>
+        string.Equals(context.ClientName ?? string.Empty, value, StringComparison.OrdinalIgnoreCase);
+}
+
+internal sealed class NameRegexQueryClause(Regex regex) : ITraceQueryClause
+{
+    public bool TryMatch(TraceQueryContext context, List<TraceQueryHighlight> highlights)
+    {
+        try
+        {
+            return regex.IsMatch(context.ClientName ?? string.Empty);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+}
+
+internal sealed class ByteSequenceQueryClause(
+    byte[] value,
+    TraceQueryHighlightSource source) : ITraceQueryClause
+{
+    public bool TryMatch(TraceQueryContext context, List<TraceQueryHighlight> highlights)
+    {
+        var data = source == TraceQueryHighlightSource.Data ? context.Data.Span : context.Raw.Span;
+        return QueryMatchHelper.FindByteMatches(data, value, source, highlights);
+    }
+}
+
+internal sealed class TextQueryClause(byte[] value, bool ignoreCase) : ITraceQueryClause
+{
+    public bool TryMatch(TraceQueryContext context, List<TraceQueryHighlight> highlights) =>
+        QueryMatchHelper.FindByteMatches(
+            context.Data.Span,
+            value,
+            TraceQueryHighlightSource.Data,
+            highlights,
+            ignoreAsciiCase: ignoreCase);
+}
+
+internal sealed class TextRegexQueryClause(Regex regex) : ITraceQueryClause
+{
+    public bool TryMatch(TraceQueryContext context, List<TraceQueryHighlight> highlights)
+    {
+        var data = context.Data.Span;
+        var characters = new char[data.Length];
+        for (var i = 0; i < data.Length; i++)
+        {
+            characters[i] = (char)data[i];
+        }
+
+        try
+        {
+            var matches = regex.Matches(new string(characters));
+            if (matches.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (Match match in matches)
+            {
+                if (match.Length > 0)
+                {
+                    highlights.Add(new TraceQueryHighlight(
+                        match.Index,
+                        match.Length,
+                        TraceQueryHighlightSource.Data));
+                }
+            }
+
+            return true;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+}
+
+internal static class QueryMatchHelper
+{
+    public static bool FindByteMatches(
+        ReadOnlySpan<byte> data,
+        ReadOnlySpan<byte> value,
+        TraceQueryHighlightSource source,
+        List<TraceQueryHighlight> highlights,
+        bool ignoreAsciiCase = false)
+    {
+        if (value.Length == 0 || value.Length > data.Length)
+        {
+            return false;
+        }
+
+        var found = false;
+        for (var offset = 0; offset <= data.Length - value.Length; offset++)
+        {
+            var candidate = data.Slice(offset, value.Length);
+            if (ignoreAsciiCase
+                    ? !EqualsIgnoringAsciiCase(candidate, value)
+                    : !candidate.SequenceEqual(value))
+            {
+                continue;
+            }
+
+            highlights.Add(new TraceQueryHighlight(offset, value.Length, source));
+            found = true;
+        }
+
+        return found;
+    }
+
+    private static bool EqualsIgnoringAsciiCase(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+    {
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (ToUpperAscii(left[i]) != ToUpperAscii(right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static byte ToUpperAscii(byte value) =>
+        value is >= (byte)'a' and <= (byte)'z' ? (byte)(value - 32) : value;
+}

--- a/Arbiter.App/Models/Tracing/Queries/TraceQueryModels.cs
+++ b/Arbiter.App/Models/Tracing/Queries/TraceQueryModels.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Arbiter.App.Models.Tracing.Queries;
+
+public enum TraceQueryHighlightSource
+{
+    Data,
+    Raw
+}
+
+public readonly record struct TraceQueryHighlight(
+    int Offset,
+    int Length,
+    TraceQueryHighlightSource Source);
+
+public sealed record TraceQueryDiagnostic(string Message, int Position, int Length = 1);
+
+public sealed record TraceQueryContext(
+    PacketDirection Direction,
+    byte Command,
+    string? ClientName,
+    byte? Sequence,
+    ReadOnlyMemory<byte> Data,
+    ReadOnlyMemory<byte> Raw);
+
+public sealed record TraceQueryMatch(bool IsMatch, IReadOnlyList<TraceQueryHighlight> Highlights)
+{
+    public static TraceQueryMatch NoMatch { get; } = new(false, []);
+    public static TraceQueryMatch MatchWithoutHighlights { get; } = new(true, []);
+}
+
+public sealed record TraceQueryParseResult(TraceQuery? Query, TraceQueryDiagnostic? Diagnostic)
+{
+    public bool IsValid => Query is not null && Diagnostic is null;
+}

--- a/Arbiter.App/Models/Tracing/Queries/TraceQueryParser.cs
+++ b/Arbiter.App/Models/Tracing/Queries/TraceQueryParser.cs
@@ -1,0 +1,1268 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Arbiter.Net.Client;
+using Arbiter.Net.Server;
+
+namespace Arbiter.App.Models.Tracing.Queries;
+
+public static class TraceQueryParser
+{
+    private const int MaxQueryLength = 2048;
+    private const int MaxRegexLength = 256;
+
+    private static readonly string[] SupportedFields =
+        ["server", "client", "text", "data", "raw", "name", "sequence", "seq"];
+
+    public static TraceQueryParseResult Parse(string? queryText, bool isTextCaseSensitive = true)
+    {
+        var query = queryText ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return new TraceQueryParseResult(TraceQuery.Empty, null);
+        }
+
+        if (query.Length > MaxQueryLength)
+        {
+            return Invalid($"Queries cannot exceed {MaxQueryLength} characters.", MaxQueryLength, query.Length - MaxQueryLength);
+        }
+
+        return new ExpressionParser(query, isTextCaseSensitive).Parse();
+    }
+
+    private static TraceQueryParseResult ParseSimple(string query, bool isTextCaseSensitive)
+    {
+
+        if (!TrySplitClauses(query, out var clauseSpans, out var splitDiagnostic))
+        {
+            return new TraceQueryParseResult(null, splitDiagnostic);
+        }
+
+        HashSet<byte>? clientCommands = null;
+        HashSet<byte>? serverCommands = null;
+        var clauses = new List<ITraceQueryClause>();
+        var negatePredicate = false;
+
+        foreach (var clauseSpan in clauseSpans)
+        {
+            var start = clauseSpan.Start;
+            var length = clauseSpan.Length;
+            Trim(query, ref start, ref length);
+            if (length == 0)
+            {
+                return Invalid("Expected a query clause after the comma.", clauseSpan.Start);
+            }
+
+            var clauseText = query.AsSpan(start, length);
+            var equalsOffset = clauseText.IndexOf('=');
+            if (equalsOffset < 0)
+            {
+                return Invalid("Expected '=' after the field name.", start + length, 0);
+            }
+
+            var isNotEquals = equalsOffset > 0 && clauseText[equalsOffset - 1] == '!';
+            var fieldStart = start;
+            var fieldLength = equalsOffset - (isNotEquals ? 1 : 0);
+            Trim(query, ref fieldStart, ref fieldLength);
+            if (fieldLength == 0)
+            {
+                return Invalid("Expected a field name before '='.", start, Math.Max(1, equalsOffset));
+            }
+
+            var field = query.Substring(fieldStart, fieldLength).ToLowerInvariant();
+            var valueStart = start + equalsOffset + 1;
+            var valueLength = start + length - valueStart;
+            Trim(query, ref valueStart, ref valueLength);
+            if (valueLength == 0)
+            {
+                return Invalid($"Expected a value for '{field}'.", valueStart, 0);
+            }
+
+            var value = query.Substring(valueStart, valueLength);
+            TraceQueryDiagnostic? diagnostic;
+            negatePredicate = isNotEquals;
+
+            switch (field)
+            {
+                case "client":
+                    clientCommands ??= [];
+                    if (!TryParseCommandSet<ClientCommand>(value, valueStart, out var parsedClientCommands, out diagnostic))
+                    {
+                        return new TraceQueryParseResult(null, diagnostic);
+                    }
+                    clientCommands.UnionWith(parsedClientCommands);
+                    break;
+
+                case "server":
+                    serverCommands ??= [];
+                    if (!TryParseCommandSet<ServerCommand>(value, valueStart, out var parsedServerCommands, out diagnostic))
+                    {
+                        return new TraceQueryParseResult(null, diagnostic);
+                    }
+                    serverCommands.UnionWith(parsedServerCommands);
+                    break;
+
+                case "sequence":
+                case "seq":
+                    if (!TryParseHexSet(value, valueStart, out var sequences, out diagnostic))
+                    {
+                        return new TraceQueryParseResult(null, diagnostic);
+                    }
+                    clauses.Add(new SequenceQueryClause(sequences));
+                    break;
+
+                case "data":
+                case "raw":
+                    if (!TryParseByteSequence(value, valueStart, out var bytes, out diagnostic))
+                    {
+                        return new TraceQueryParseResult(null, diagnostic);
+                    }
+                    clauses.Add(new ByteSequenceQueryClause(
+                        bytes,
+                        field == "data" ? TraceQueryHighlightSource.Data : TraceQueryHighlightSource.Raw));
+                    break;
+
+                case "text":
+                    if (!TryParseTextClause(
+                            value,
+                            valueStart,
+                            isTextCaseSensitive,
+                            out var textClause,
+                            out diagnostic))
+                    {
+                        return new TraceQueryParseResult(null, diagnostic);
+                    }
+                    clauses.Add(textClause);
+                    break;
+
+                case "name":
+                    if (!TryParseNameClause(value, valueStart, out var nameClause, out diagnostic))
+                    {
+                        return new TraceQueryParseResult(null, diagnostic);
+                    }
+                    clauses.Add(nameClause);
+                    break;
+
+                default:
+                    var suggestion = GetFieldSuggestion(field);
+                    var message = suggestion is null
+                        ? $"Unknown query field '{field}'."
+                        : $"Unknown query field '{field}'. Did you mean '{suggestion}'?";
+                    return Invalid(message, fieldStart, fieldLength);
+            }
+        }
+
+        var queryResult = new TraceQuery(clientCommands, serverCommands, clauses);
+        return new TraceQueryParseResult(negatePredicate ? TraceQuery.Not(queryResult) : queryResult, null);
+    }
+
+    private static bool TryParseTextClause(
+        string value,
+        int position,
+        bool isCaseSensitive,
+        out ITraceQueryClause clause,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        if (value.StartsWith('/'))
+        {
+            if (!TryCompileRegex(value, position, ignoreCase: !isCaseSensitive, out var regex, out diagnostic))
+            {
+                clause = null!;
+                return false;
+            }
+
+            clause = new TextRegexQueryClause(regex);
+            return true;
+        }
+
+        string text;
+        if (value.StartsWith('"'))
+        {
+            if (!TryParseQuotedString(value, position, out text, out diagnostic))
+            {
+                clause = null!;
+                return false;
+            }
+        }
+        else
+        {
+            text = value.Trim();
+            diagnostic = null;
+        }
+
+        if (text.Length == 0)
+        {
+            clause = null!;
+            diagnostic = new TraceQueryDiagnostic("Text values cannot be empty.", position, value.Length);
+            return false;
+        }
+
+        if (text.Any(character => character > 0x7F))
+        {
+            clause = null!;
+            diagnostic = new TraceQueryDiagnostic("Text searches support ASCII characters only.", position, value.Length);
+            return false;
+        }
+
+        clause = new TextQueryClause(Encoding.ASCII.GetBytes(text), ignoreCase: !isCaseSensitive);
+        return true;
+    }
+
+    private static bool TryParseNameClause(
+        string value,
+        int position,
+        out ITraceQueryClause clause,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        if (value.StartsWith('/'))
+        {
+            if (!TryCompileRegex(value, position, ignoreCase: true, out var regex, out diagnostic))
+            {
+                clause = null!;
+                return false;
+            }
+
+            clause = new NameRegexQueryClause(regex);
+            return true;
+        }
+
+        string name;
+        if (value.StartsWith('"'))
+        {
+            if (!TryParseQuotedString(value, position, out name, out diagnostic))
+            {
+                clause = null!;
+                return false;
+            }
+        }
+        else
+        {
+            name = value.Trim();
+            diagnostic = null;
+        }
+
+        clause = new NameQueryClause(name);
+        return true;
+    }
+
+    private static bool TryCompileRegex(
+        string value,
+        int position,
+        bool ignoreCase,
+        out Regex regex,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        regex = null!;
+        diagnostic = null;
+
+        if (!TryReadRegex(value, position, out var pattern, out diagnostic))
+        {
+            return false;
+        }
+
+        if (pattern.Length == 0)
+        {
+            diagnostic = new TraceQueryDiagnostic("Regular expressions cannot be empty.", position, value.Length);
+            return false;
+        }
+
+        if (pattern.Length > MaxRegexLength)
+        {
+            diagnostic = new TraceQueryDiagnostic(
+                $"Regular expressions cannot exceed {MaxRegexLength} characters.",
+                position + 1 + MaxRegexLength,
+                pattern.Length - MaxRegexLength);
+            return false;
+        }
+
+        var options = RegexOptions.CultureInvariant | RegexOptions.NonBacktracking;
+        if (ignoreCase)
+        {
+            options |= RegexOptions.IgnoreCase;
+        }
+
+        try
+        {
+            regex = new Regex(pattern, options, TimeSpan.FromMilliseconds(100));
+            return true;
+        }
+        catch (RegexParseException ex)
+        {
+            diagnostic = new TraceQueryDiagnostic(
+                $"Invalid regular expression: {ex.Message}",
+                position + 1 + Math.Max(0, ex.Offset),
+                1);
+            return false;
+        }
+        catch (NotSupportedException ex)
+        {
+            diagnostic = new TraceQueryDiagnostic(
+                $"Unsupported regular expression: {ex.Message}",
+                position,
+                value.Length);
+            return false;
+        }
+        catch (ArgumentException ex)
+        {
+            diagnostic = new TraceQueryDiagnostic(
+                $"Invalid regular expression: {ex.Message}",
+                position,
+                value.Length);
+            return false;
+        }
+    }
+
+    private static bool TryReadRegex(
+        string value,
+        int position,
+        out string pattern,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        var builder = new StringBuilder();
+        var escaped = false;
+
+        for (var i = 1; i < value.Length; i++)
+        {
+            var character = value[i];
+            if (escaped)
+            {
+                if (character == '/')
+                {
+                    builder.Append('/');
+                }
+                else
+                {
+                    builder.Append('\\');
+                    builder.Append(character);
+                }
+                escaped = false;
+                continue;
+            }
+
+            if (character == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (character != '/')
+            {
+                builder.Append(character);
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(value[(i + 1)..]))
+            {
+                pattern = string.Empty;
+                diagnostic = new TraceQueryDiagnostic(
+                    "Regex flags are not supported. Casing is determined by the field.",
+                    position + i + 1,
+                    value.Length - i - 1);
+                return false;
+            }
+
+            pattern = builder.ToString();
+            diagnostic = null;
+            return true;
+        }
+
+        pattern = string.Empty;
+        diagnostic = new TraceQueryDiagnostic("Missing closing '/' for the regular expression.", position, value.Length);
+        return false;
+    }
+
+    private static bool TryParseQuotedString(
+        string value,
+        int position,
+        out string result,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        result = string.Empty;
+        diagnostic = null;
+        if (!value.StartsWith('"'))
+        {
+            return false;
+        }
+
+        var builder = new StringBuilder();
+        for (var i = 1; i < value.Length; i++)
+        {
+            var character = value[i];
+            if (character == '"')
+            {
+                if (!string.IsNullOrWhiteSpace(value[(i + 1)..]))
+                {
+                    diagnostic = new TraceQueryDiagnostic(
+                        "Unexpected characters after the closing quote.",
+                        position + i + 1,
+                        value.Length - i - 1);
+                    return false;
+                }
+
+                result = builder.ToString();
+                return true;
+            }
+
+            if (character != '\\')
+            {
+                builder.Append(character);
+                continue;
+            }
+
+            if (++i >= value.Length)
+            {
+                diagnostic = new TraceQueryDiagnostic("Incomplete escape sequence.", position + i - 1);
+                return false;
+            }
+
+            var escaped = value[i];
+            builder.Append(escaped switch
+            {
+                '"' => '"',
+                '\\' => '\\',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                _ => escaped
+            });
+        }
+
+        diagnostic = new TraceQueryDiagnostic("Missing closing quote.", position, value.Length);
+        return false;
+    }
+
+    private static bool TryParseByteSequence(
+        string value,
+        int position,
+        out byte[] bytes,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        var parsed = new List<byte>();
+        var offset = 0;
+
+        while (offset < value.Length)
+        {
+            while (offset < value.Length && char.IsWhiteSpace(value[offset]))
+            {
+                offset++;
+            }
+
+            if (offset >= value.Length)
+            {
+                break;
+            }
+
+            var tokenStart = offset;
+            while (offset < value.Length && !char.IsWhiteSpace(value[offset]))
+            {
+                offset++;
+            }
+
+            var token = value[tokenStart..offset];
+            if (!TryParseHexByte(token, requireTwoDigits: true, out var parsedByte))
+            {
+                bytes = [];
+                diagnostic = new TraceQueryDiagnostic(
+                    $"Invalid data byte '{token}'. Expected a two-digit hexadecimal byte.",
+                    position + tokenStart,
+                    token.Length);
+                return false;
+            }
+
+            parsed.Add(parsedByte);
+        }
+
+        if (parsed.Count == 0)
+        {
+            bytes = [];
+            diagnostic = new TraceQueryDiagnostic("Expected at least one hexadecimal byte.", position, value.Length);
+            return false;
+        }
+
+        bytes = [.. parsed];
+        diagnostic = null;
+        return true;
+    }
+
+    private static bool TryParseHexSet(
+        string value,
+        int position,
+        out HashSet<byte> values,
+        out TraceQueryDiagnostic? diagnostic) =>
+        TryParseValueSet(value, position, null, out values, out diagnostic);
+
+    private static bool TryParseCommandSet<TCommand>(
+        string value,
+        int position,
+        out HashSet<byte> values,
+        out TraceQueryDiagnostic? diagnostic)
+        where TCommand : struct, Enum
+    {
+        bool TryParseName(string token, out byte parsed)
+        {
+            if (Enum.TryParse<TCommand>(token, ignoreCase: true, out var command) && Enum.IsDefined(command))
+            {
+                parsed = Convert.ToByte(command, CultureInfo.InvariantCulture);
+                return true;
+            }
+
+            parsed = 0;
+            return false;
+        }
+
+        return TryParseValueSet(value, position, TryParseName, out values, out diagnostic);
+    }
+
+    private static bool TryParseValueSet(
+        string value,
+        int position,
+        TryParseNamedValue? tryParseNamedValue,
+        out HashSet<byte> values,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        values = [];
+        diagnostic = null;
+        var segmentStart = 0;
+
+        while (segmentStart <= value.Length)
+        {
+            var separator = FindNextValueSeparator(value, segmentStart);
+            var segmentEnd = separator >= 0 ? separator : value.Length;
+            var tokenStart = segmentStart;
+            var tokenLength = segmentEnd - segmentStart;
+            Trim(value, ref tokenStart, ref tokenLength);
+
+            if (tokenLength == 0)
+            {
+                diagnostic = new TraceQueryDiagnostic(
+                    "Expected a value between command separators.",
+                    position + segmentStart,
+                    1);
+                return false;
+            }
+
+            var token = value.Substring(tokenStart, tokenLength);
+            var rangeSeparator = token.IndexOf('-');
+            if (rangeSeparator >= 0)
+            {
+                if (rangeSeparator == 0 || rangeSeparator == token.Length - 1 ||
+                    token.IndexOf('-', rangeSeparator + 1) >= 0)
+                {
+                    diagnostic = new TraceQueryDiagnostic(
+                        $"Invalid hexadecimal range '{token}'.",
+                        position + tokenStart,
+                        tokenLength);
+                    return false;
+                }
+
+                var startToken = token[..rangeSeparator].Trim();
+                var endToken = token[(rangeSeparator + 1)..].Trim();
+                if (!TryParseHexByte(startToken, requireTwoDigits: false, out var startValue) ||
+                    !TryParseHexByte(endToken, requireTwoDigits: false, out var endValue))
+                {
+                    diagnostic = new TraceQueryDiagnostic(
+                        $"Invalid hexadecimal range '{token}'.",
+                        position + tokenStart,
+                        tokenLength);
+                    return false;
+                }
+
+                if (startValue > endValue)
+                {
+                    diagnostic = new TraceQueryDiagnostic(
+                        "Range start must not exceed range end.",
+                        position + tokenStart,
+                        tokenLength);
+                    return false;
+                }
+
+                for (var current = (int)startValue; current <= endValue; current++)
+                {
+                    values.Add((byte)current);
+                }
+            }
+            else if (TryParseHexByte(token, requireTwoDigits: false, out var parsedValue) ||
+                     tryParseNamedValue?.Invoke(token, out parsedValue) == true)
+            {
+                values.Add(parsedValue);
+            }
+            else
+            {
+                diagnostic = new TraceQueryDiagnostic(
+                    $"Invalid hexadecimal value or command name '{token}'.",
+                    position + tokenStart,
+                    tokenLength);
+                return false;
+            }
+
+            if (separator < 0)
+            {
+                break;
+            }
+
+            segmentStart = separator + 1;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseHexByte(string value, bool requireTwoDigits, out byte parsed)
+    {
+        var token = value.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? value[2..] : value;
+        if (token.Length is 0 or > 2 || requireTwoDigits && token.Length != 2)
+        {
+            parsed = 0;
+            return false;
+        }
+
+        return byte.TryParse(token, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out parsed);
+    }
+
+    private static int FindNextValueSeparator(string value, int start)
+    {
+        var pipe = value.IndexOf('|', start);
+        var comma = value.IndexOf(',', start);
+
+        return (pipe, comma) switch
+        {
+            (< 0, < 0) => -1,
+            (< 0, _) => comma,
+            (_, < 0) => pipe,
+            _ => Math.Min(pipe, comma)
+        };
+    }
+
+    private static bool TrySplitClauses(
+        string query,
+        out List<QuerySpan> clauses,
+        out TraceQueryDiagnostic? diagnostic)
+    {
+        clauses = [];
+        diagnostic = null;
+        var start = 0;
+        var openingPosition = -1;
+        var seenEquals = false;
+        var valueStarted = false;
+        var inQuote = false;
+        var inRegex = false;
+        var escaped = false;
+
+        for (var i = 0; i < query.Length; i++)
+        {
+            var character = query[i];
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if (inQuote)
+            {
+                if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else if (character == '"')
+                {
+                    inQuote = false;
+                }
+                continue;
+            }
+
+            if (inRegex)
+            {
+                if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else if (character == '/')
+                {
+                    inRegex = false;
+                }
+                continue;
+            }
+
+            if (!seenEquals)
+            {
+                if (character == '=')
+                {
+                    seenEquals = true;
+                }
+            }
+            else if (!valueStarted && !char.IsWhiteSpace(character))
+            {
+                valueStarted = true;
+                if (character == '"')
+                {
+                    inQuote = true;
+                    openingPosition = i;
+                }
+                else if (character == '/')
+                {
+                    inRegex = true;
+                    openingPosition = i;
+                }
+            }
+
+            if (!seenEquals || !valueStarted)
+            {
+                continue;
+            }
+
+            var next = i + 1;
+            if (character == ',')
+            {
+                while (next < query.Length && char.IsWhiteSpace(query[next]))
+                {
+                    next++;
+                }
+
+                if (!LooksLikeClauseStart(query, next))
+                {
+                    continue;
+                }
+            }
+            else if (char.IsWhiteSpace(character))
+            {
+                while (next < query.Length && char.IsWhiteSpace(query[next]))
+                {
+                    next++;
+                }
+
+                if (!LooksLikeClauseStart(query, next))
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                continue;
+            }
+
+            clauses.Add(new QuerySpan(start, i - start));
+            start = next;
+            seenEquals = false;
+            valueStarted = false;
+            openingPosition = -1;
+            i = next - 1;
+        }
+
+        if (inQuote)
+        {
+            diagnostic = new TraceQueryDiagnostic("Missing closing quote.", openingPosition, query.Length - openingPosition);
+            return false;
+        }
+
+        if (inRegex)
+        {
+            diagnostic = new TraceQueryDiagnostic(
+                "Missing closing '/' for the regular expression.",
+                openingPosition,
+                query.Length - openingPosition);
+            return false;
+        }
+
+        clauses.Add(new QuerySpan(start, query.Length - start));
+        return true;
+    }
+
+    private static bool LooksLikeClauseStart(string query, int start)
+    {
+        if (start >= query.Length || !char.IsLetter(query[start]))
+        {
+            return false;
+        }
+
+        var position = start + 1;
+        while (position < query.Length && char.IsLetter(query[position]))
+        {
+            position++;
+        }
+
+        while (position < query.Length && char.IsWhiteSpace(query[position]))
+        {
+            position++;
+        }
+
+        return position < query.Length &&
+               (query[position] == '=' ||
+                position + 1 < query.Length && query[position] == '!' && query[position + 1] == '=');
+    }
+
+    private static string? GetFieldSuggestion(string field)
+    {
+        var commonSuggestion = field switch
+        {
+            "payload" => "data",
+            "character" or "clientname" => "name",
+            "servercommand" => "server",
+            "clientcommand" => "client",
+            _ => null
+        };
+        if (commonSuggestion is not null)
+        {
+            return commonSuggestion;
+        }
+
+        var suggestion = SupportedFields
+            .Select(candidate => (Candidate: candidate, Distance: GetEditDistance(field, candidate)))
+            .OrderBy(result => result.Distance)
+            .First();
+
+        return suggestion.Distance <= 3 ? suggestion.Candidate : null;
+    }
+
+    private static int GetEditDistance(string left, string right)
+    {
+        var previous = new int[right.Length + 1];
+        var current = new int[right.Length + 1];
+        for (var i = 0; i <= right.Length; i++)
+        {
+            previous[i] = i;
+        }
+
+        for (var leftIndex = 1; leftIndex <= left.Length; leftIndex++)
+        {
+            current[0] = leftIndex;
+            for (var rightIndex = 1; rightIndex <= right.Length; rightIndex++)
+            {
+                var cost = left[leftIndex - 1] == right[rightIndex - 1] ? 0 : 1;
+                current[rightIndex] = Math.Min(
+                    Math.Min(current[rightIndex - 1] + 1, previous[rightIndex] + 1),
+                    previous[rightIndex - 1] + cost);
+            }
+
+            (previous, current) = (current, previous);
+        }
+
+        return previous[right.Length];
+    }
+
+    private static void Trim(string value, ref int start, ref int length)
+    {
+        while (length > 0 && char.IsWhiteSpace(value[start]))
+        {
+            start++;
+            length--;
+        }
+
+        while (length > 0 && char.IsWhiteSpace(value[start + length - 1]))
+        {
+            length--;
+        }
+    }
+
+    private static TraceQueryParseResult Invalid(string message, int position, int length = 1) =>
+        new(null, new TraceQueryDiagnostic(message, position, length));
+
+    private sealed class ExpressionParser(string text, bool isTextCaseSensitive)
+    {
+        private TraceQueryDiagnostic? _diagnostic;
+        private int _position;
+
+        public TraceQueryParseResult Parse()
+        {
+            SkipWhitespace();
+            if (_position >= text.Length)
+            {
+                return new TraceQueryParseResult(TraceQuery.Empty, null);
+            }
+
+            var query = ParseOr();
+            if (_diagnostic is not null)
+            {
+                return new TraceQueryParseResult(null, _diagnostic);
+            }
+
+            SkipWhitespace();
+            if (_position < text.Length)
+            {
+                var message = text[_position] == ')'
+                    ? "Unexpected closing parenthesis."
+                    : $"Unexpected token '{ReadUnexpectedToken()}'.";
+                return Invalid(message, _position);
+            }
+
+            return new TraceQueryParseResult(query, null);
+        }
+
+        private TraceQuery? ParseOr()
+        {
+            var left = ParseAnd();
+            while (_diagnostic is null)
+            {
+                SkipWhitespace();
+                if (!TryConsumeKeyword("OR"))
+                {
+                    return left;
+                }
+
+                var operatorPosition = _position - 2;
+                SkipWhitespace();
+                if (!CanStartUnary(_position))
+                {
+                    SetDiagnostic("Expected a query expression after 'OR'.", operatorPosition, 2);
+                    return null;
+                }
+
+                var right = ParseAnd();
+                if (right is null)
+                {
+                    return null;
+                }
+
+                left = TraceQuery.Or(left!, right);
+            }
+
+            return null;
+        }
+
+        private TraceQuery? ParseAnd()
+        {
+            var left = ParseUnary();
+            while (_diagnostic is null)
+            {
+                SkipWhitespace();
+                if (_position >= text.Length || text[_position] == ')' || IsKeywordAt(_position, "OR"))
+                {
+                    return left;
+                }
+
+                if (TryConsumeKeyword("AND"))
+                {
+                    var operatorPosition = _position - 3;
+                    SkipWhitespace();
+                    if (!CanStartUnary(_position))
+                    {
+                        SetDiagnostic("Expected a query expression after 'AND'.", operatorPosition, 3);
+                        return null;
+                    }
+
+                    var right = ParseUnary();
+                    if (right is null)
+                    {
+                        return null;
+                    }
+
+                    left = TraceQuery.And(left!, right);
+                    continue;
+                }
+
+                if (text[_position] == ',')
+                {
+                    var commaPosition = _position++;
+                    SkipWhitespace();
+                    if (!CanStartUnary(_position))
+                    {
+                        SetDiagnostic("Expected a query expression after the comma.", commaPosition);
+                        return null;
+                    }
+                }
+                else if (!CanStartUnary(_position))
+                {
+                    SetDiagnostic($"Unexpected token '{ReadUnexpectedToken()}'.", _position);
+                    return null;
+                }
+
+                var implicitRight = ParseUnary();
+                if (implicitRight is null)
+                {
+                    return null;
+                }
+
+                left = TraceQuery.CombineImplicit(left!, implicitRight);
+            }
+
+            return null;
+        }
+
+        private TraceQuery? ParseUnary()
+        {
+            SkipWhitespace();
+            if (!TryConsumeKeyword("NOT"))
+            {
+                return ParsePrimary();
+            }
+
+            var operatorPosition = _position - 3;
+            SkipWhitespace();
+            if (!CanStartUnary(_position))
+            {
+                SetDiagnostic("Expected a query expression after 'NOT'.", operatorPosition, 3);
+                return null;
+            }
+
+            var operand = ParseUnary();
+            return operand is null ? null : TraceQuery.Not(operand);
+        }
+
+        private TraceQuery? ParsePrimary()
+        {
+            SkipWhitespace();
+            if (_position >= text.Length)
+            {
+                SetDiagnostic("Expected a query expression.", _position, 0);
+                return null;
+            }
+
+            if (text[_position] != '(')
+            {
+                return ParsePredicate();
+            }
+
+            var openingPosition = _position++;
+            SkipWhitespace();
+            if (_position < text.Length && text[_position] == ')')
+            {
+                SetDiagnostic("Parentheses cannot be empty.", openingPosition, 2);
+                return null;
+            }
+
+            var expression = ParseOr();
+            if (_diagnostic is not null)
+            {
+                return null;
+            }
+
+            SkipWhitespace();
+            if (_position >= text.Length || text[_position] != ')')
+            {
+                SetDiagnostic("Missing closing parenthesis.", openingPosition, text.Length - openingPosition);
+                return null;
+            }
+
+            _position++;
+            return expression;
+        }
+
+        private TraceQuery? ParsePredicate()
+        {
+            var predicateStart = _position;
+            if (!char.IsLetter(text[_position]))
+            {
+                SetDiagnostic("Expected a query field or '('.", _position);
+                return null;
+            }
+
+            while (_position < text.Length && char.IsLetter(text[_position]))
+            {
+                _position++;
+            }
+
+            var field = text[predicateStart.._position].ToLowerInvariant();
+            SkipWhitespace();
+            if (_position + 1 < text.Length && text[_position] == '!' && text[_position + 1] == '=')
+            {
+                _position += 2;
+            }
+            else if (_position < text.Length && text[_position] == '=')
+            {
+                _position++;
+            }
+            else
+            {
+                SetDiagnostic("Expected '=' or '!=' after the field name.", _position, 0);
+                return null;
+            }
+
+            SkipWhitespace();
+            if (_position >= text.Length || text[_position] == ')' || text[_position] == ',')
+            {
+                SetDiagnostic($"Expected a value for '{field}'.", _position, 0);
+                return null;
+            }
+
+            if (text[_position] == '"')
+            {
+                ReadDelimitedValue('"');
+            }
+            else if (text[_position] == '/')
+            {
+                ReadDelimitedValue('/');
+                while (_position < text.Length &&
+                       !char.IsWhiteSpace(text[_position]) &&
+                       text[_position] is not ',' and not ')')
+                {
+                    _position++;
+                }
+            }
+            else
+            {
+                ReadUnquotedValue(field is "text" or "name");
+            }
+
+            var predicateEnd = _position;
+            while (predicateEnd > predicateStart && char.IsWhiteSpace(text[predicateEnd - 1]))
+            {
+                predicateEnd--;
+            }
+
+            var result = ParseSimple(text[predicateStart..predicateEnd], isTextCaseSensitive);
+            if (result.Diagnostic is not null)
+            {
+                _diagnostic = result.Diagnostic with
+                {
+                    Position = predicateStart + result.Diagnostic.Position
+                };
+                return null;
+            }
+
+            return result.Query;
+        }
+
+        private void ReadDelimitedValue(char delimiter)
+        {
+            var escaped = false;
+            _position++;
+            while (_position < text.Length)
+            {
+                var character = text[_position++];
+                if (escaped)
+                {
+                    escaped = false;
+                }
+                else if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else if (character == delimiter)
+                {
+                    return;
+                }
+            }
+        }
+
+        private void ReadUnquotedValue(bool stopAtWhitespace)
+        {
+            while (_position < text.Length)
+            {
+                if (text[_position] == ')')
+                {
+                    return;
+                }
+
+                if (text[_position] == ',')
+                {
+                    var afterComma = SkipWhitespace(_position + 1);
+                    if (CanStartUnary(afterComma))
+                    {
+                        return;
+                    }
+                }
+
+                if (char.IsWhiteSpace(text[_position]))
+                {
+                    var afterWhitespace = SkipWhitespace(_position);
+                    if (stopAtWhitespace || afterWhitespace >= text.Length ||
+                        text[afterWhitespace] == ')' ||
+                        IsKeywordAt(afterWhitespace, "AND") ||
+                        IsKeywordAt(afterWhitespace, "OR") ||
+                        CanStartUnary(afterWhitespace))
+                    {
+                        return;
+                    }
+
+                    _position = afterWhitespace;
+                    continue;
+                }
+
+                _position++;
+            }
+        }
+
+        private bool CanStartUnary(int position) =>
+            position < text.Length &&
+            (text[position] == '(' || IsKeywordAt(position, "NOT") || LooksLikePredicate(position));
+
+        private bool LooksLikePredicate(int position)
+        {
+            if (position >= text.Length || !char.IsLetter(text[position]))
+            {
+                return false;
+            }
+
+            while (position < text.Length && char.IsLetter(text[position]))
+            {
+                position++;
+            }
+
+            position = SkipWhitespace(position);
+            return position < text.Length &&
+                   (text[position] == '=' ||
+                    position + 1 < text.Length && text[position] == '!' && text[position + 1] == '=');
+        }
+
+        private bool TryConsumeKeyword(string keyword)
+        {
+            if (!IsKeywordAt(_position, keyword))
+            {
+                return false;
+            }
+
+            _position += keyword.Length;
+            return true;
+        }
+
+        private bool IsKeywordAt(int position, string keyword)
+        {
+            if (position + keyword.Length > text.Length ||
+                !text.AsSpan(position, keyword.Length).Equals(keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var beforeIsWord = position > 0 && IsWordCharacter(text[position - 1]);
+            var after = position + keyword.Length;
+            var afterIsWord = after < text.Length && IsWordCharacter(text[after]);
+            return !beforeIsWord && !afterIsWord;
+        }
+
+        private void SkipWhitespace()
+        {
+            _position = SkipWhitespace(_position);
+        }
+
+        private int SkipWhitespace(int position)
+        {
+            while (position < text.Length && char.IsWhiteSpace(text[position]))
+            {
+                position++;
+            }
+
+            return position;
+        }
+
+        private string ReadUnexpectedToken()
+        {
+            var start = _position;
+            while (_position < text.Length &&
+                   !char.IsWhiteSpace(text[_position]) &&
+                   text[_position] is not '(' and not ')' and not ',')
+            {
+                _position++;
+            }
+
+            if (_position == start && _position < text.Length)
+            {
+                _position++;
+            }
+
+            return text[start.._position];
+        }
+
+        private void SetDiagnostic(string message, int position, int length = 1)
+        {
+            _diagnostic ??= new TraceQueryDiagnostic(message, position, length);
+        }
+
+        private static bool IsWordCharacter(char character) =>
+            char.IsLetterOrDigit(character) || character == '_';
+    }
+
+    private delegate bool TryParseNamedValue(string value, out byte parsed);
+
+    private readonly record struct QuerySpan(int Start, int Length);
+}

--- a/Arbiter.App/Models/Tracing/Queries/TraceQuerySyntax.cs
+++ b/Arbiter.App/Models/Tracing/Queries/TraceQuerySyntax.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Arbiter.App.Models.Tracing.Queries;
+
+public static class TraceQuerySyntax
+{
+    private static readonly HashSet<string> FieldKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "server",
+        "client",
+        "text",
+        "data",
+        "raw",
+        "name",
+        "sequence",
+        "seq"
+    };
+
+    private static readonly HashSet<string> BooleanKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "AND",
+        "OR",
+        "NOT"
+    };
+
+    public static IReadOnlyList<TraceQuerySyntaxSpan> GetSpans(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return [];
+        }
+
+        var spans = new List<TraceQuerySyntaxSpan>();
+        var inQuote = false;
+        var inRegex = false;
+        var escaped = false;
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var character = text[i];
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if ((inQuote || inRegex) && character == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (inQuote)
+            {
+                if (character == '"')
+                {
+                    inQuote = false;
+                }
+                continue;
+            }
+
+            if (inRegex)
+            {
+                if (character == '/')
+                {
+                    inRegex = false;
+                }
+                continue;
+            }
+
+            if (character == '"')
+            {
+                inQuote = true;
+                continue;
+            }
+
+            if (character == '/')
+            {
+                inRegex = true;
+                continue;
+            }
+
+            if (character is '(' or ')')
+            {
+                spans.Add(new TraceQuerySyntaxSpan(i, 1, TraceQuerySyntaxKind.Grouping));
+                continue;
+            }
+
+            if (!char.IsLetter(character) || i > 0 && IsWordCharacter(text[i - 1]))
+            {
+                continue;
+            }
+
+            var wordEnd = i + 1;
+            while (wordEnd < text.Length && char.IsLetter(text[wordEnd]))
+            {
+                wordEnd++;
+            }
+
+            var word = text.Substring(i, wordEnd - i);
+            if (IsFieldKeyword(text, wordEnd, word) || IsBooleanKeyword(text, i, word))
+            {
+                spans.Add(new TraceQuerySyntaxSpan(i, wordEnd - i, TraceQuerySyntaxKind.Keyword));
+            }
+
+            i = wordEnd - 1;
+        }
+
+        return spans;
+    }
+
+    public static IReadOnlyList<TraceQuerySyntaxSpan> GetKeywordSpans(string text) =>
+        GetSpans(text).Where(span => span.Kind == TraceQuerySyntaxKind.Keyword).ToList();
+
+    private static bool IsFieldKeyword(string text, int wordEnd, string word)
+    {
+        if (!FieldKeywords.Contains(word))
+        {
+            return false;
+        }
+
+        var operatorPosition = wordEnd;
+        while (operatorPosition < text.Length && char.IsWhiteSpace(text[operatorPosition]))
+        {
+            operatorPosition++;
+        }
+
+        return operatorPosition < text.Length &&
+               (text[operatorPosition] == '=' ||
+                operatorPosition + 1 < text.Length &&
+                text[operatorPosition] == '!' &&
+                text[operatorPosition + 1] == '=');
+    }
+
+    private static bool IsBooleanKeyword(string text, int start, string word)
+    {
+        if (!BooleanKeywords.Contains(word))
+        {
+            return false;
+        }
+
+        var previous = start - 1;
+        while (previous >= 0 && char.IsWhiteSpace(text[previous]))
+        {
+            previous--;
+        }
+
+        return previous < 0 || text[previous] is not '=' and not '!';
+    }
+
+    private static bool IsWordCharacter(char character) =>
+        char.IsLetterOrDigit(character) || character == '_';
+}
+
+public enum TraceQuerySyntaxKind
+{
+    Keyword,
+    Grouping
+}
+
+public readonly record struct TraceQuerySyntaxSpan(
+    int Start,
+    int Length,
+    TraceQuerySyntaxKind Kind);

--- a/Arbiter.App/Themes/TalgoniteComboBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteComboBox.axaml
@@ -18,7 +18,7 @@
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="2"/>
         <Setter Property="CornerRadius" Value="2"/>
-        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="Padding" Value="8,5,8,3"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="MinWidth" Value="80"/>

--- a/Arbiter.App/Themes/TalgoniteIcons.axaml
+++ b/Arbiter.App/Themes/TalgoniteIcons.axaml
@@ -146,6 +146,12 @@
     <Geometry x:Key="Talgonite.Icon.InfoLevel">
         M1,1 L15,1 L15,15 L1,15 Z
     </Geometry>
+
+    <!-- Information Glyph -->
+    <Geometry x:Key="Talgonite.Icon.Information">
+        M7,2 L9,2 L9,4 L7,4 Z
+        M7,6 L9,6 L9,14 L7,14 Z
+    </Geometry>
     
     <!-- Debug Diamond Icon -->
     <Geometry x:Key="Talgonite.Icon.DebugLevel">

--- a/Arbiter.App/Themes/TalgoniteTextBox.axaml
+++ b/Arbiter.App/Themes/TalgoniteTextBox.axaml
@@ -1,5 +1,6 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="using:Arbiter.App.Controls">
     <!-- TextBox Previews -->
     <Design.PreviewWith>
         <Border Background="{StaticResource Talgonite.Window.Background}" Padding="20">
@@ -40,7 +41,7 @@
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="2"/>
         <Setter Property="CornerRadius" Value="2"/>
-        <Setter Property="Padding" Value="0,4"/>
+        <Setter Property="Padding" Value="0,5,0,3"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True"/>
@@ -65,7 +66,7 @@
                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                             
                             <!-- Left content -->
-                            <ContentPresenter Grid.Row="1" Grid.Column="0"
+                            <ContentPresenter Grid.Row="0" Grid.RowSpan="2" Grid.Column="0"
                                               Content="{TemplateBinding InnerLeftContent}"
                                               VerticalAlignment="Stretch"
                                               VerticalContentAlignment="Center"/>
@@ -83,7 +84,7 @@
                                        Text="{TemplateBinding Watermark}"
                                        Foreground="{StaticResource Talgonite.TextBox.WatermarkForeground}"
                                        FontSize="14"
-                                       Margin="0,4">
+                                       Margin="0,5,0,3">
                                 <TextBlock.IsVisible>
                                     <MultiBinding Converter="{x:Static BoolConverters.And}">
                                         <Binding Path="$parent[TextBox].UseFloatingWatermark"/>
@@ -108,7 +109,7 @@
                                                    Foreground="{StaticResource Talgonite.TextBox.WatermarkForeground}"
                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                   Margin="0,4">
+                                                   Margin="0,5,0,3">
                                             <TextBlock.IsVisible>
                                                 <MultiBinding Converter="{x:Static BoolConverters.And}">
                                                     <Binding Path="#PART_TextPresenter.PreeditText" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
@@ -117,23 +118,26 @@
                                             </TextBlock.IsVisible>
                                         </TextBlock>
                                         
-                                        <TextPresenter Name="PART_TextPresenter"
-                                                       Text="{TemplateBinding Text, Mode=TwoWay}"
-                                                       TextAlignment="{TemplateBinding TextAlignment}"
-                                                       TextWrapping="{TemplateBinding TextWrapping}"
-                                                       LineHeight="{TemplateBinding LineHeight}"
-                                                       CaretBrush="{TemplateBinding CaretBrush}"
-                                                       CaretIndex="{TemplateBinding CaretIndex}"
-                                                       CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                                       SelectionBrush="{TemplateBinding SelectionBrush}"
-                                                       SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                                       SelectionStart="{TemplateBinding SelectionStart}"
-                                                       SelectionEnd="{TemplateBinding SelectionEnd}"
-                                                       RevealPassword="{TemplateBinding RevealPassword}"
-                                                       PasswordChar="{TemplateBinding PasswordChar}"
-                                                       Margin="0,4"
-                                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                        <controls:QuerySyntaxTextPresenter Name="PART_TextPresenter"
+                                                                           Text="{TemplateBinding Text, Mode=TwoWay}"
+                                                                           TextAlignment="{TemplateBinding TextAlignment}"
+                                                                           TextWrapping="{TemplateBinding TextWrapping}"
+                                                                           LineHeight="{TemplateBinding LineHeight}"
+                                                                           CaretBrush="{TemplateBinding CaretBrush}"
+                                                                           CaretIndex="{TemplateBinding CaretIndex}"
+                                                                           CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                                                           SelectionBrush="{TemplateBinding SelectionBrush}"
+                                                                           SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                                                           SelectionStart="{TemplateBinding SelectionStart}"
+                                                                           SelectionEnd="{TemplateBinding SelectionEnd}"
+                                                                           RevealPassword="{TemplateBinding RevealPassword}"
+                                                                           PasswordChar="{TemplateBinding PasswordChar}"
+                                                                           IsQuerySyntaxEnabled="{Binding $parent[TextBox].(controls:QuerySyntax.IsEnabled)}"
+                                                                           KeywordBrush="{StaticResource Talgonite.Color.LightBlue}"
+                                                                           GroupingBrush="{StaticResource Talgonite.Color.LightGray}"
+                                                                           Margin="0,5,0,3"
+                                                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                                     </Panel>
                                     
                                     <ScrollViewer.Styles>
@@ -152,7 +156,7 @@
                             </Border>
                             
                             <!-- Right content -->
-                            <ContentPresenter Grid.Row="1" Grid.Column="4"
+                            <ContentPresenter Grid.Row="0" Grid.RowSpan="2" Grid.Column="4"
                                               Content="{TemplateBinding InnerRightContent}"
                                               VerticalAlignment="Stretch"
                                               VerticalContentAlignment="Center"/>
@@ -269,8 +273,22 @@
     <Style Selector="TextBox Button.clear">
         <Setter Property="Width" Value="24"/>
         <Setter Property="Height" Value="24"/>
-        <Setter Property="Padding" Value="8,4"/>
-        <Setter Property="Margin" Value="0,0,2,0"/>
+        <Setter Property="Padding" Value="6"/>
+        <Setter Property="Margin" Value="2"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource Talgonite.TextBlock.DimForeground}"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="CornerRadius" Value="2"/>
+    </Style>
+
+    <Style Selector="TextBox Button.clear:pointerover">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource Talgonite.Color.LightRed}"/>
+    </Style>
+
+    <Style Selector="TextBox Button.clear:pressed">
+        <Setter Property="Background" Value="{StaticResource Talgonite.Button.PressedBackground}"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
     </Style>
     
     <!-- Reveal Style -->

--- a/Arbiter.App/ViewModels/Tracing/TracePacketViewModel.cs
+++ b/Arbiter.App/ViewModels/Tracing/TracePacketViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Arbiter.App.Models.Tracing;
+using Arbiter.App.Models.Tracing.Queries;
 using Arbiter.Net;
 using Arbiter.Net.Client;
 using Arbiter.Net.Filters;
@@ -19,10 +21,16 @@ public partial class TracePacketViewModel(
 
     [ObservableProperty] private long _index;
 
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(DisplayValue))]
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DisplayValue))]
+    [NotifyPropertyChangedFor(nameof(DisplaySearchHighlights))]
     private PacketDisplayMode _displayMode = PacketDisplayMode.Decrypted;
 
     [ObservableProperty] private double _opacity = 1;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DisplaySearchHighlights))]
+    private IReadOnlyList<TraceQueryHighlight> _searchHighlights = [];
 
     [ObservableProperty] private string? _clientName = clientName;
 
@@ -55,6 +63,7 @@ public partial class TracePacketViewModel(
     public DateTime Timestamp { get; private init; } = DateTime.Now;
     public NetworkPacket EncryptedPacket { get; } = encrypted;
     public NetworkPacket DecryptedPacket { get; } = decrypted;
+    public byte[] RawData { get; } = encrypted.ToArray();
 
     public NetworkPacket? FilteredPacket { get; } = filterResult?.Output;
     public NetworkFilterAction FilterAction { get; } = filterResult?.Action ?? NetworkFilterAction.Allow;
@@ -66,6 +75,12 @@ public partial class TracePacketViewModel(
         PacketDisplayMode.Decrypted => WasReplaced && FormattedFiltered is not null ? FormattedFiltered : FormattedDecrypted,
         _ => FormattedEncrypted
     };
+
+    public IReadOnlyList<TraceQueryHighlight> DisplaySearchHighlights => SearchHighlights
+        .Where(highlight => highlight.Source == (DisplayMode == PacketDisplayMode.Raw
+            ? TraceQueryHighlightSource.Raw
+            : TraceQueryHighlightSource.Data))
+        .ToList();
 
     public bool IsClient => DecryptedPacket is ClientPacket;
     public bool IsServer => DecryptedPacket is ServerPacket;

--- a/Arbiter.App/ViewModels/Tracing/TraceSearchViewModel.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceSearchViewModel.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.ObjectModel;
-using System.Linq;
 using Arbiter.App.Models.Tracing;
-using Arbiter.Net.Client;
-using Arbiter.Net.Server;
+using Arbiter.App.Models.Tracing.Queries;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -11,68 +7,60 @@ namespace Arbiter.App.ViewModels.Tracing;
 
 public partial class TraceSearchViewModel : ViewModelBase
 {
-    [ObservableProperty] private CommandFilterViewModel? _selectedCommand;
+    private TraceQuery _query = TraceQuery.Empty;
 
-    public ObservableCollection<CommandFilterViewModel> Commands { get; } =
-    [
-        // Placeholder 'None' command
-        new(PacketDirection.Auto, "None", null)
-    ];
-    
-    public TraceSearchViewModel()
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasQueryText))]
+    private string _queryText = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasQueryError))]
+    [NotifyPropertyChangedFor(nameof(QueryErrorText))]
+    private TraceQueryDiagnostic? _queryError;
+
+    [ObservableProperty]
+    private bool _isTextCaseSensitive = true;
+
+    public TraceQuery Query
     {
-        InitializeCommands();
-        Clear();
+        get => _query;
+        private set => SetProperty(ref _query, value);
     }
 
-    public void SelectCommand(ClientCommand command)
-    {
-        var matching = Commands.FirstOrDefault(c =>
-            c.Direction == PacketDirection.Client && c.Value == (byte)command);
+    public bool HasQueryError => QueryError is not null;
+    public bool HasQueryText => !string.IsNullOrWhiteSpace(QueryText);
+    public string? QueryErrorText => QueryError?.Message;
 
-        if (matching is not null)
+    partial void OnQueryTextChanged(string value)
+    {
+        ParseQuery(value);
+    }
+
+    partial void OnIsTextCaseSensitiveChanged(bool value)
+    {
+        ParseQuery(QueryText);
+    }
+
+    private void ParseQuery(string value)
+    {
+        var result = TraceQueryParser.Parse(value, IsTextCaseSensitive);
+        QueryError = result.Diagnostic;
+
+        if (result.Query is not null)
         {
-            SelectedCommand = matching;
+            Query = result.Query;
         }
     }
 
-    public void SelectCommand(ServerCommand command)
+    public void SetCommand(PacketDirection direction, byte command)
     {
-        var matching = Commands.FirstOrDefault(c =>
-            c.Direction == PacketDirection.Server && c.Value == (byte)command);
-
-        if (matching is not null)
-        {
-            SelectedCommand = matching;
-        }
+        var field = direction == PacketDirection.Client ? "client" : "server";
+        QueryText = $"{field}={command:X2}";
     }
-    
+
     [RelayCommand]
     public void Clear()
     {
-        SelectedCommand = Commands.FirstOrDefault(command => command.Value is null);
-    }
-
-    private void InitializeCommands()
-    {
-        var clientCommandModels = Enum.GetValues<ClientCommand>()
-            .OrderBy(cmd => cmd == ClientCommand.Unknown ? 1 : 0)
-            .ThenBy(cmd => cmd.ToString())
-            .Select(cmd => new CommandFilterViewModel(cmd));
-
-        var serverCommandModels = Enum.GetValues<ServerCommand>()
-            .OrderBy(cmd => cmd == ServerCommand.Unknown ? 1 : 0)
-            .ThenBy(cmd => cmd.ToString())
-            .Select(cmd => new CommandFilterViewModel(cmd));
-
-        foreach (var vm in clientCommandModels)
-        {
-            Commands.Add(vm);
-        }
-
-        foreach (var vm in serverCommandModels)
-        {
-            Commands.Add(vm);
-        }
+        QueryText = string.Empty;
     }
 }

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.ContextMenu.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.ContextMenu.cs
@@ -94,17 +94,8 @@ public partial class TraceViewModel
             return;
         }
 
-        var packet = SelectedPackets[0].DecryptedPacket;
-        
-        switch (packet)
-        {
-            case ClientPacket clientPacket:
-                SearchParameters.SelectCommand(clientPacket.Command);
-                break;
-            case ServerPacket serverPacket:
-                SearchParameters.SelectCommand(serverPacket.Command);
-                break;
-        }
+        var packet = SelectedPackets[0];
+        SearchParameters.SetCommand(packet.Direction, packet.Command);
 
         ShowSearchBar = true;
     }

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.Filter.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.Filter.cs
@@ -43,7 +43,11 @@ public partial class TraceViewModel
     private void RequestFilterRefresh()
     {
         // This is debounced to avoid excessive refreshing when multiple changes are made rapidly
-        _filterRefreshDebouncer.Execute(() => { FilteredPackets.Refresh(); });
+        _filterRefreshDebouncer.Execute(() =>
+        {
+            FilteredPackets.Refresh();
+            RefreshSearchResults();
+        });
     }
 
     private bool MatchesFilter(TracePacketViewModel vm)

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.Search.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.Search.cs
@@ -1,10 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Arbiter.App.Models.Tracing;
+using Arbiter.App.Models.Tracing.Queries;
 using Arbiter.App.Threading;
-using Arbiter.Net.Client;
-using Arbiter.Net.Server;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -32,12 +30,12 @@ public partial class TraceViewModel
     public TraceSearchViewModel SearchParameters { get; } = new();
 
     public string? FormattedSearchResultsText =>
-        SearchParameters.SelectedCommand is not null
+        !SearchParameters.Query.IsEmpty
             ? SearchResultCount > 0 ? $"{Math.Max(1, SelectedSearchIndex)} of {SearchResultCount}" : "no matches"
             : null;
 
     public bool HasSearchResults => SearchResultCount > 0;
-    public bool IsSearchActive => SearchParameters.SelectedCommand?.Value is not null;
+    public bool IsSearchActive => !SearchParameters.Query.IsEmpty;
 
     [RelayCommand]
     private void ToggleSearchBar()
@@ -47,20 +45,20 @@ public partial class TraceViewModel
 
     private void OnSearchParametersChanged(object? sender, PropertyChangedEventArgs e)
     {
-        OnPropertyChanged(nameof(IsSearchActive));
-
-        // Do not filter on this, wait for actual command byte to change
-        if (e.PropertyName == nameof(SearchParameters.SelectedCommand))
+        if (e.PropertyName != nameof(TraceSearchViewModel.Query))
         {
-
+            return;
         }
 
+        OnPropertyChanged(nameof(IsSearchActive));
+        OnPropertyChanged(nameof(FormattedSearchResultsText));
         RefreshSearchResults();
     }
 
     private void RefreshSearchResults()
     {
         ShowSearchResults = false;
+        var query = SearchParameters.Query;
         
         _searchRefreshDebouncer.Execute(() =>
         {
@@ -70,17 +68,16 @@ public partial class TraceViewModel
             for (var i = 0; i < FilteredPackets.Count; i++)
             {
                 var packet = FilteredPackets[i];
-                var isMatch = MatchesSearch(packet);
-                if (isMatch)
+                var match = MatchSearch(packet, query);
+                ApplySearchMatch(packet, match);
+                if (match.IsMatch && !query.IsEmpty)
                 {
                     AddSearchResultIndex(i);
                 }
-
-                packet.Opacity = isMatch ? 1 : 0.5;
             }
 
             SelectedSearchIndex = 0;
-            ShowSearchResults = SearchParameters.SelectedCommand?.Value is not null;
+            ShowSearchResults = !query.IsEmpty;
         });
     }
 
@@ -90,31 +87,30 @@ public partial class TraceViewModel
         SearchResultCount = _searchResultIndexes.Count;
     }
 
-    private bool MatchesSearch(TracePacketViewModel vm)
+    private static TraceQueryMatch MatchSearch(TracePacketViewModel vm, TraceQuery query)
     {
-        if (SearchParameters.SelectedCommand?.Value is null)
+        if (query.IsEmpty)
         {
-            return true;
+            return TraceQueryMatch.MatchWithoutHighlights;
         }
 
-        if (vm.Direction != SearchParameters.SelectedCommand.Direction)
-        {
-            return false;
-        }
+        var data = vm.WasReplaced && vm.FilteredPacket is not null
+            ? vm.FilteredPacket.Data
+            : vm.DecryptedPacket.Data;
 
-        if (vm.Direction == PacketDirection.Client)
-        {
-            var command = (ClientCommand)vm.DecryptedPacket.Command;
-            return (byte)command == SearchParameters.SelectedCommand.Value;
-        }
+        return query.Match(new TraceQueryContext(
+            vm.Direction,
+            vm.Command,
+            vm.ClientName,
+            vm.Sequence,
+            data,
+            vm.RawData));
+    }
 
-        if (vm.Direction == PacketDirection.Server)
-        {
-            var command = (ServerCommand)vm.DecryptedPacket.Command;
-            return (byte)command == SearchParameters.SelectedCommand.Value;
-        }
-
-        return false;
+    private static void ApplySearchMatch(TracePacketViewModel vm, TraceQueryMatch match)
+    {
+        vm.SearchHighlights = match.Highlights;
+        vm.Opacity = match.IsMatch ? 1 : 0.5;
     }
 
     [RelayCommand]

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.cs
@@ -156,6 +156,7 @@ public partial class TraceViewModel : ViewModelBase
         if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Reset)
         {
             PruneClientsNotInPackets();
+            RefreshSearchResults();
         }
     }
 
@@ -175,15 +176,19 @@ public partial class TraceViewModel : ViewModelBase
         var nextIndex = Interlocked.Increment(ref _indexCounter);
         vm.Index = nextIndex;
 
-        var matchesSearch = MatchesSearch(vm);
-        if (matchesSearch)
-        {
-            AddSearchResultIndex(_allPackets.Count);
-        }
-
-        vm.Opacity = matchesSearch ? 1 : 0.5;
+        var query = SearchParameters.Query;
+        var searchMatch = MatchSearch(vm, query);
+        ApplySearchMatch(vm, searchMatch);
 
         _allPackets.Add(vm);
+        if (!query.IsEmpty && searchMatch.IsMatch)
+        {
+            var filteredIndex = FilteredPackets.IndexOf(vm);
+            if (filteredIndex >= 0)
+            {
+                AddSearchResultIndex(filteredIndex);
+            }
+        }
         FilterParameters.TryAddClient(vm.ClientName ?? string.Empty);
         IsDirty = true;
 

--- a/Arbiter.App/Views/TracePacketView.axaml
+++ b/Arbiter.App/Views/TracePacketView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="using:Arbiter.App.Controls"
              xmlns:converters="using:Arbiter.App.Converters"
              xmlns:vm="using:Arbiter.App.ViewModels.Tracing"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -10,6 +11,8 @@
     <UserControl.Resources>
         <SolidColorBrush x:Key="Talgonite.TracePacket.TimestampForeground" Color="#717479"/>
         <SolidColorBrush x:Key="Talgonite.TracePacket.ClientNameForeground" Color="#e0e0e0"/>
+        <SolidColorBrush x:Key="Talgonite.TracePacket.SearchHighlightBackground" Color="#806893c2"/>
+        <SolidColorBrush x:Key="Talgonite.TracePacket.SearchHighlightForeground" Color="#ffffff"/>
     
         <Geometry x:Key="Talgonite.TracePacket.LeftCaret">M 6,1 L 2,4 L 6,7 Z</Geometry>
         <Geometry x:Key="Talgonite.TracePacket.RightCaret">M 2,1 L 6,4 L 2,7 Z</Geometry>
@@ -73,12 +76,16 @@
                                FontFamily="{StaticResource Talgonite.Font.Monospace}"
                                Foreground="{Binding #CommandNameText.Foreground}"/>
                     
-                    <TextBlock Grid.Column="1" Name="PayloadText"
-                               Text="{Binding DisplayValue}"
-                               TextWrapping="NoWrap"
-                               TextTrimming="CharacterEllipsis"
-                               FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                               Foreground="{Binding FilterAction, Converter={x:Static converters:PacketFilterColorConverter.Converter}}"/>
+                    <controls:HighlightedHexTextBlock Grid.Column="1"
+                                                      Name="PayloadText"
+                                                      SourceText="{Binding DisplayValue}"
+                                                      Highlights="{Binding DisplaySearchHighlights}"
+                                                      HighlightBackground="{StaticResource Talgonite.TracePacket.SearchHighlightBackground}"
+                                                      HighlightForeground="{StaticResource Talgonite.TracePacket.SearchHighlightForeground}"
+                                                      TextWrapping="NoWrap"
+                                                      TextTrimming="CharacterEllipsis"
+                                                      FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                                      Foreground="{Binding FilterAction, Converter={x:Static converters:PacketFilterColorConverter.Converter}}"/>
                 </Grid>
             </Grid>
         </Border>

--- a/Arbiter.App/Views/TraceView.axaml
+++ b/Arbiter.App/Views/TraceView.axaml
@@ -28,6 +28,22 @@
         <Style Selector="ToggleButton.trace-state:not(.active):checked /template/ Border#SelectionBorder">
             <Setter Property="BorderBrush" Value="{StaticResource Talgonite.ToggleButton.SegmentBorderBrush}" />
         </Style>
+        <Style Selector="TextBox.query-error /template/ Border#Border">
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.TextBox.ErrorBorderBrush}"/>
+        </Style>
+        <Style Selector="Border.query-help:pointerover">
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Color.LightGray}"/>
+        </Style>
+        <Style Selector="ToggleButton.query-case">
+            <Setter Property="Width" Value="40"/>
+            <Setter Property="Height" Value="40"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="FontFamily" Value="{StaticResource Talgonite.Font.Monospace}"/>
+            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </Style>
     </UserControl.Styles>
 
     <UserControl.KeyBindings>
@@ -323,79 +339,227 @@
                 BorderBrush="{StaticResource Talgonite.Window.TitleBorderBrush}"
                 BorderThickness="0,1,0,0"
                 Padding="0,4"
-                Height="50">
-            <WrapPanel ItemSpacing="4" VerticalAlignment="Center">
+                MinHeight="50">
+            <Grid ColumnDefinitions="48,Auto,460,40,24,Auto,*"
+                  RowDefinitions="40,Auto"
+                  ColumnSpacing="4">
                 <!-- Bar Icon -->
-                <Border Padding="12,4"
+                <Border Grid.Row="0" Grid.Column="0"
                         BorderBrush="{StaticResource Talgonite.Border.DividerBrush}"
                         BorderThickness="0,0,1,0">
                     <Path Width="16" Height="16"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
                           Stroke="{StaticResource Talgonite.TextBlock.DimForeground}"
                           Data="{StaticResource Talgonite.Icon.SearchMagnify}"/>
                 </Border>
-                
-                <!-- Command Search -->
-                <Label Content="Command"
-                       ToolTip.Tip="Searches for packets matching the command hex code."
-                       VerticalAlignment="Center" />
-                <ComboBox ItemsSource="{Binding SearchParameters.Commands}"
-                          SelectedItem="{Binding SearchParameters.SelectedCommand}"
-                          IsTextSearchEnabled="True"
-                          FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                          FontSize="16"
-                          MaxDropDownHeight="400"
-                          Width="300"
-                          HorizontalContentAlignment="Stretch">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate>
-                            <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Stretch" Margin="8,2">
-                                <TextBlock Grid.Column="0"
-                                           Text="{Binding DisplayName}"
-                                           Foreground="{Binding Direction, Converter={x:Static converters:PacketDirectionColorConverter.Converter}}"
-                                           FontSize="14"
-                                           VerticalAlignment="Center"/>
-                                <Border Grid.Column="1" IsVisible="{Binding Value, Converter={x:Static ObjectConverters.IsNotNull}}">
-                                    <TextBlock Text="{Binding Value, StringFormat={}0x{0:X2}}"
-                                               Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
-                                               FontSize="14"
-                                               VerticalAlignment="Center"/>
-                                </Border>
-                            </Grid>
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                    <ComboBox.SelectionBoxItemTemplate>
-                        <DataTemplate>
-                            <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Stretch">
-                                <TextBlock Grid.Column="0"
-                                           Text="{Binding DisplayName}"
-                                           TextTrimming="CharacterEllipsis"
-                                           Foreground="{Binding Direction, Converter={x:Static converters:PacketDirectionColorConverter.Converter}}"
-                                           FontSize="16"
-                                           VerticalAlignment="Center"/>
-                                <Border Grid.Column="1" IsVisible="{Binding Value, Converter={x:Static ObjectConverters.IsNotNull}}">
-                                    <TextBlock Text="{Binding Value, StringFormat={}0x{0:X2}}"
-                                               Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
-                                               FontSize="16"
-                                               VerticalAlignment="Center"/>
-                                </Border>
-                            </Grid>
-                        </DataTemplate>
-                    </ComboBox.SelectionBoxItemTemplate>
-                </ComboBox>
-                
-                <StackPanel Orientation="Horizontal" Spacing="4"
+
+                    <Label Grid.Row="0" Grid.Column="1" Content="Query" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="0" Grid.Column="2"
+                             Name="SearchQueryTextBox"
+                             Text="{Binding SearchParameters.QueryText, Mode=TwoWay}"
+                             c:QuerySyntax.IsEnabled="True"
+                             Classes.query-error="{Binding SearchParameters.HasQueryError}"
+                             Watermark="Enter search query..."
+                             FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                             FontSize="15"
+                             Height="40">
+                        <TextBox.KeyBindings>
+                            <KeyBinding Gesture="Enter" Command="{Binding GotoNextSearchResultCommand}"/>
+                            <KeyBinding Gesture="Shift+Enter" Command="{Binding GotoPreviousSearchResultCommand}"/>
+                        </TextBox.KeyBindings>
+                        <TextBox.InnerRightContent>
+                            <Border Width="28" VerticalAlignment="Center">
+                                <Button Command="{Binding SearchParameters.ClearCommand}"
+                                        Classes="clear"
+                                        VerticalAlignment="Center"
+                                        IsVisible="{Binding SearchParameters.HasQueryText}"
+                                        ToolTip.Tip="Clears the search query.">
+                                    <Path Width="8" Height="8"
+                                          Stretch="Uniform"
+                                          Stroke="{Binding $parent[Button].Foreground}"
+                                          Data="{StaticResource Talgonite.Icon.CrossX}"/>
+                                </Button>
+                            </Border>
+                        </TextBox.InnerRightContent>
+                    </TextBox>
+
+                    <ToggleButton Grid.Row="0" Grid.Column="3"
+                                  IsChecked="{Binding SearchParameters.IsTextCaseSensitive, Mode=TwoWay}"
+                                  Classes="outline query-case"
+                                  ToolTip.Tip="Toggles case sensitivity for text and regex searches."
+                                  ToolTip.ShowDelay="250">
+                        <TextBlock Text="aA"
+                                   FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                   FontSize="16"
+                                   FontWeight="Bold"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center">
+                            <TextBlock.RenderTransform>
+                                <TranslateTransform Y="2"/>
+                            </TextBlock.RenderTransform>
+                        </TextBlock>
+                    </ToggleButton>
+
+                    <Border Grid.Row="0" Grid.Column="4"
+                            Classes="query-help"
+                            Width="22" Height="22"
+                            CornerRadius="11"
+                            BorderThickness="1"
+                            Background="Transparent"
+                            BorderBrush="{StaticResource Talgonite.TextBlock.DimForeground}"
+                            Cursor="Help"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            ToolTip.ShowDelay="250"
+                            ToolTip.Placement="Bottom">
+                        <Path Width="4" Height="12"
+                              Fill="{Binding $parent[Border].BorderBrush}"
+                              Stretch="Uniform"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Data="{StaticResource Talgonite.Icon.Information}">
+                            <Path.RenderTransform>
+                                <TranslateTransform X="1"/>
+                            </Path.RenderTransform>
+                        </Path>
+                        <ToolTip.Tip>
+                            <ScrollViewer Width="520"
+                                          MaxHeight="460"
+                                          HorizontalScrollBarVisibility="Disabled"
+                                          VerticalScrollBarVisibility="Auto">
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Text="Packet Query Syntax"
+                                                   Foreground="{StaticResource Talgonite.Color.White}"
+                                                   FontSize="16"
+                                                   FontWeight="SemiBold"/>
+                                        <TextBlock Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                   TextWrapping="Wrap">
+                                            <Run Text="Separate predicates with spaces or commas. Client and server predicates are alternatives by default; other predicates narrow the results. Use "/><Run Text="AND" Foreground="{StaticResource Talgonite.Color.LightBlue}"/><Run Text=", "/><Run Text="OR" Foreground="{StaticResource Talgonite.Color.LightBlue}"/><Run Text=", or "/><Run Text="NOT" Foreground="{StaticResource Talgonite.Color.LightBlue}"/><Run Text=" only to override that logic. AND is evaluated before OR; parentheses set the grouping."/>
+                                        </TextBlock>
+
+                                        <Grid ColumnDefinitions="Auto,*"
+                                              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
+                                              ColumnSpacing="12"
+                                              RowSpacing="4">
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Logic"
+                                                       Foreground="{StaticResource Talgonite.Color.LightGray}"
+                                                       FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Row="0" Grid.Column="1"
+                                                       Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                                       TextWrapping="Wrap">
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightGray}">(</Run>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">server</Run><Run>=13 </Run>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">OR</Run><Run> </Run>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">client</Run><Run>=45-47</Run>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightGray}">)</Run><Run> </Run>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">AND NOT text</Run><Run>=error</Run>
+                                                <LineBreak/>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">server</Run><Run>!=12</Run>
+                                            </TextBlock>
+
+                                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Commands"
+                                                       Foreground="{StaticResource Talgonite.Color.LightGray}"
+                                                       FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="1"
+                                                       Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                       FontFamily="{StaticResource Talgonite.Font.Monospace}">
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">client</Run><Run>=45-47|Heartbeat</Run>
+                                                <LineBreak/>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">server</Run><Run>=05,15|HealthBar</Run>
+                                            </TextBlock>
+
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Payload"
+                                                       Foreground="{StaticResource Talgonite.Color.LightGray}"
+                                                       FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Row="2" Grid.Column="1"
+                                                       Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                       FontFamily="{StaticResource Talgonite.Font.Monospace}">
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">data</Run><Run>=65 01 01</Run>
+                                                <LineBreak/>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">raw</Run><Run>=AA 00 04 13</Run>
+                                            </TextBlock>
+
+                                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Text"
+                                                       Foreground="{StaticResource Talgonite.Color.LightGray}"
+                                                       FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Row="3" Grid.Column="1"
+                                                       Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                       FontFamily="{StaticResource Talgonite.Font.Monospace}">
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">text</Run><Run>=Test</Run>
+                                                <LineBreak/>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">text</Run><Run>=&quot;hello world&quot;</Run>
+                                                <LineBreak/>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">text</Run><Run>=/error|warning/</Run>
+                                            </TextBlock>
+
+                                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Client name"
+                                                       Foreground="{StaticResource Talgonite.Color.LightGray}"
+                                                       FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Row="4" Grid.Column="1"
+                                                       Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                       FontFamily="{StaticResource Talgonite.Font.Monospace}">
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">name</Run><Run>=CharacterName</Run>
+                                                <LineBreak/>
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">name</Run><Run>=/^silo.*$/</Run>
+                                            </TextBlock>
+
+                                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Sequence"
+                                                       Foreground="{StaticResource Talgonite.Color.LightGray}"
+                                                       FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Row="5" Grid.Column="1"
+                                                       Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                       FontFamily="{StaticResource Talgonite.Font.Monospace}">
+                                                <Run Foreground="{StaticResource Talgonite.Color.LightBlue}">sequence</Run><Run>=02|04-08</Run>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <Border Classes="divider-h"/>
+                                        <TextBlock Foreground="{StaticResource Talgonite.Color.DimWhite}"
+                                                   TextWrapping="Wrap">
+                                            <Run>Command and sequence lists can mix individual values and ascending ranges separated by commas or |. For example, 05,12-15,19 is valid, while 17-11 is not.</Run>
+                                        </TextBlock>
+                                        <TextBlock Foreground="{StaticResource Talgonite.Color.LightGray}"
+                                                   TextWrapping="Wrap">
+                                            <Run>Numeric values are hexadecimal. Unquoted text and names cannot contain spaces. Text and text regex searches follow the aA case toggle and use ASCII; case sensitivity is on by default. Character names are always case-insensitive. Regex values use /pattern/ and do not accept flags.</Run>
+                                        </TextBlock>
+                                    </StackPanel>
+                            </ScrollViewer>
+                        </ToolTip.Tip>
+                    </Border>
+
+                    <StackPanel Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="3"
+                                Orientation="Horizontal"
+                                Spacing="6"
+                                Margin="0,3,0,0"
+                                IsVisible="{Binding SearchParameters.HasQueryError}">
+                        <Grid Width="18" Height="16" VerticalAlignment="Center">
+                            <Path Fill="{StaticResource Talgonite.Color.LightRed}"
+                                  Stretch="Uniform"
+                                  Data="{StaticResource Talgonite.Icon.WarningLevel}"/>
+                            <TextBlock Text="!"
+                                       Foreground="{StaticResource Talgonite.TextBox.Background}"
+                                       FontSize="10"
+                                       FontWeight="Bold"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       Margin="0,2,0,0"/>
+                        </Grid>
+                        <TextBlock Text="{Binding SearchParameters.QueryErrorText}"
+                                   Foreground="{StaticResource Talgonite.Color.LightRed}"
+                                   FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                   FontSize="12"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="460"
+                                   VerticalAlignment="Center"
+                                   ToolTip.Tip="{Binding SearchParameters.QueryErrorText}"/>
+                    </StackPanel>
+
+                <StackPanel Grid.Row="0" Grid.Column="5"
+                            Orientation="Horizontal" Spacing="4"
                             IsVisible="{Binding ShowSearchResults}"
                             Height="40">
-                    
-                    <!-- Clear Button -->
-                    <Button Command="{Binding SearchParameters.ClearCommand}"
-                            Classes="toolbar destructive"
-                            ToolTip.Tip="Clears the search criteria.">
-                        <Path Width="16" Height="16"
-                              Stroke="{Binding $parent[Button].Foreground}"
-                              Data="{StaticResource Talgonite.Icon.CrossX}"/>
-                    </Button>
-                    
                     <!-- Result count -->
                     <TextBlock Text="{Binding FormattedSearchResultsText, FallbackValue=no matches}"
                                TextAlignment="Center"
@@ -427,7 +591,8 @@
                         </Button>
                     </StackPanel>
                 </StackPanel>
-            </WrapPanel>
+
+            </Grid>
         </Border>
 
         <!-- Trace List -->

--- a/Arbiter.App/Views/TraceView.axaml.cs
+++ b/Arbiter.App/Views/TraceView.axaml.cs
@@ -1,11 +1,73 @@
-﻿using Avalonia.Controls;
+using System;
+using System.ComponentModel;
+using Arbiter.App.ViewModels.Tracing;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
 
 namespace Arbiter.App.Views;
 
 public partial class TraceView : UserControl
 {
+    private TraceViewModel? _viewModel;
+
     public TraceView()
     {
         InitializeComponent();
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+
+        if (VisualRoot is not null)
+        {
+            AttachViewModel();
+        }
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        AttachViewModel();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        DetachViewModel();
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    private void AttachViewModel()
+    {
+        var viewModel = DataContext as TraceViewModel;
+        if (ReferenceEquals(viewModel, _viewModel))
+        {
+            return;
+        }
+
+        DetachViewModel();
+        _viewModel = viewModel;
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void DetachViewModel()
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _viewModel = null;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TraceViewModel.ShowSearchBar) && _viewModel?.ShowSearchBar == true)
+        {
+            Dispatcher.UIThread.Post(() => SearchQueryTextBox.Focus(), DispatcherPriority.Input);
+        }
     }
 }

--- a/Arbiter.sln
+++ b/Arbiter.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.Json", "Arbiter.Jso
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.Net.Tests", "Arbiter.Net.Tests\Arbiter.Net.Tests.csproj", "{DEB71D62-0C17-40A5-BBC5-5638E1D8F8EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.App.Tests", "Arbiter.App.Tests\Arbiter.App.Tests.csproj", "{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{DEB71D62-0C17-40A5-BBC5-5638E1D8F8EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DEB71D62-0C17-40A5-BBC5-5638E1D8F8EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DEB71D62-0C17-40A5-BBC5-5638E1D8F8EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configure default client and server packet filters that apply on startup and can be restored while tracing
+- Search traces with an inline query language supporting implicit criteria, boolean operators and grouping, command lists and ranges, regular expressions, case control for text searches while character names remain case-insensitive, validation help, and in-packet match highlighting
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- replace the command-only trace search dropdown with an inline packet query language
- support client/server commands, command lists and ranges, sequence values, character names, ASCII text, raw/decrypted byte sequences, regular expressions, `AND`/`OR`/`NOT`, `!=`, and parentheses
- preserve concise implicit searches, including directional alternatives such as `server=05,15 client=12`
- add query validation, syntax highlighting, detailed inline help, case-sensitivity control for text searches, and keyboard navigation
- highlight matching text and byte ranges inside packet rows
- add focused NUnit coverage for parsing, matching, diagnostics, highlighting, boolean precedence, shorthand syntax, and case behavior

## Why

The previous trace search could select only one packet command from a dropdown. Real tracing workflows often need to combine a small set of directional commands with character, payload, sequence, or text criteria. This provides a compact query workflow without requiring explicit boolean syntax for common searches.

## User impact

Trace searches can now express precise packet combinations in one field, show actionable validation without discarding the last valid search, and visually identify matching bytes in packet content. Text matching is case-sensitive by default and can be toggled with the `aA` control; character names remain case-insensitive.

## Validation

- `dotnet build Arbiter.sln`: succeeded with 0 warnings and 0 errors
- `dotnet test Arbiter.App.Tests/Arbiter.App.Tests.csproj`: 33 passed
- `dotnet test Arbiter.Net.Tests/Arbiter.Net.Tests.csproj`: 44 passed
