### PR TITLE
Render item, skill, and spell sprites

### DIFF
--- a/Arbiter.App.Tests/ViewModels/Player/CooldownFormatterTests.cs
+++ b/Arbiter.App.Tests/ViewModels/Player/CooldownFormatterTests.cs
@@ -1,0 +1,18 @@
+using Arbiter.App.ViewModels.Player;
+
+namespace Arbiter.App.Tests.ViewModels.Player;
+
+public sealed class CooldownFormatterTests
+{
+    [TestCase(120, "2m")]
+    [TestCase(119, "2m")]
+    [TestCase(60, "1m")]
+    [TestCase(59, "59s")]
+    [TestCase(1, "1s")]
+    [TestCase(0, "")]
+    [TestCase(-1, "")]
+    public void Should_Format_Wow_Style_Minutes_And_Seconds(int seconds, string expected)
+    {
+        Assert.That(CooldownFormatter.Format(TimeSpan.FromSeconds(seconds)), Is.EqualTo(expected));
+    }
+}

--- a/Arbiter.App.Tests/ViewModels/Player/PlayerInventoryViewModelTests.cs
+++ b/Arbiter.App.Tests/ViewModels/Player/PlayerInventoryViewModelTests.cs
@@ -1,0 +1,98 @@
+using Arbiter.App.Collections;
+using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
+using Arbiter.App.ViewModels.Player;
+using Avalonia.Media;
+
+namespace Arbiter.App.Tests.ViewModels.Player;
+
+public sealed class PlayerInventoryViewModelTests
+{
+    [Test]
+    public void Should_Reserve_Last_Inventory_Slot_For_Gold()
+    {
+        var inventory = new SlottedCollection<InventoryItem>(PlayerState.MaxInventorySlots);
+        var viewModel = new PlayerInventoryViewModel(inventory, new NullSprites());
+
+        var gold = viewModel.InventorySlots[^1];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gold.Slot, Is.EqualTo(60));
+            Assert.That(gold.IsGold, Is.True);
+            Assert.That(gold.IsEmpty, Is.False);
+            Assert.That(gold.Name, Is.EqualTo("Gold"));
+            Assert.That(gold.Sprite, Is.EqualTo(PlayerInventorySlotViewModel.GoldSprite));
+            Assert.That(gold.Quantity, Is.Zero);
+            Assert.That(gold.ShowsQuantity, Is.False);
+        });
+    }
+
+    [Test]
+    public void Should_Show_Compact_And_Exact_Gold_Counts()
+    {
+        var gold = PlayerInventorySlotViewModel.CreateGold(60, 1_234_567, new NullSprites());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gold.DetailText, Is.EqualTo("1.2m"));
+            Assert.That(gold.GoldAmountText, Is.EqualTo($"{1_234_567:N0} gold"));
+            Assert.That(gold.SpriteFallbackText, Is.EqualTo("#136"));
+        });
+    }
+
+    [Test]
+    public void Should_Show_Item_Quantities_At_The_Bottom_Of_The_Slot()
+    {
+        var item = new InventoryItem
+        {
+            Name = "Cherry",
+            Sprite = 1,
+            Quantity = 4,
+            IsStackable = true
+        };
+        var viewModel = new PlayerInventorySlotViewModel(1, item, new NullSprites());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.ShowsQuantity, Is.True);
+            Assert.That(viewModel.QuantityDisplayText, Is.EqualTo("(x4)"));
+            Assert.That(viewModel.DetailText, Is.EqualTo("(x4)"));
+        });
+    }
+
+    [Test]
+    public void Should_Hide_Item_Quantity_When_Only_One_Remains()
+    {
+        var item = new InventoryItem
+        {
+            Name = "Cherry",
+            Sprite = 1,
+            Quantity = 1,
+            IsStackable = true
+        };
+        var viewModel = new PlayerInventorySlotViewModel(1, item, new NullSprites());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.ShowsQuantity, Is.False);
+            Assert.That(viewModel.DetailText, Is.Empty);
+        });
+    }
+
+    private sealed class NullSprites : IGameSpriteService
+    {
+        public event EventHandler? SpritesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public IImage? GetItem(ushort sprite, byte color) => null;
+        public IImage? GetSkill(ushort sprite, bool isOnCooldown) => null;
+        public IImage? GetSpell(ushort sprite, bool isOnCooldown) => null;
+    }
+}

--- a/Arbiter.App.Tests/ViewModels/Player/PlayerSkillSlotViewModelTests.cs
+++ b/Arbiter.App.Tests/ViewModels/Player/PlayerSkillSlotViewModelTests.cs
@@ -1,0 +1,116 @@
+using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
+using Arbiter.App.ViewModels.Player;
+using Avalonia.Media;
+
+namespace Arbiter.App.Tests.ViewModels.Player;
+
+public sealed class PlayerSkillSlotViewModelTests
+{
+    [Test]
+    public void Should_Replace_Cooldown_With_Every_Authoritative_Server_Update()
+    {
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 7, 9, 12, 0, 0, TimeSpan.Zero));
+        var skill = new SkillbookItem { Name = "Assail", Sprite = 7 };
+        var viewModel = new PlayerSkillSlotViewModel(1, skill, new RecordingSpriteService(), timeProvider);
+
+        viewModel.SetCooldown(TimeSpan.FromMinutes(2));
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        viewModel.SetCooldown(TimeSpan.FromSeconds(30));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(skill.CooldownDuration, Is.EqualTo(TimeSpan.FromSeconds(30)));
+            Assert.That(skill.CooldownUntil, Is.EqualTo(timeProvider.GetUtcNow().AddSeconds(30)));
+            Assert.That(viewModel.CooldownText, Is.EqualTo("30s"));
+            Assert.That(viewModel.CooldownDurationText, Is.EqualTo("30s"));
+        });
+
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+        viewModel.SetCooldown(TimeSpan.FromSeconds(90));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(skill.CooldownDuration, Is.EqualTo(TimeSpan.FromSeconds(90)));
+            Assert.That(skill.CooldownUntil, Is.EqualTo(timeProvider.GetUtcNow().AddSeconds(90)));
+            Assert.That(viewModel.CooldownText, Is.EqualTo("2m"));
+            Assert.That(viewModel.CooldownDurationText, Is.EqualTo("2m"));
+        });
+
+        timeProvider.Advance(TimeSpan.FromSeconds(90));
+        viewModel.TickCooldown();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.HasCooldown, Is.False);
+            Assert.That(viewModel.HasCooldownDuration, Is.True);
+            Assert.That(viewModel.CooldownDurationText, Is.EqualTo("2m"));
+        });
+    }
+
+    [Test]
+    public void Should_Tick_Cooldown_To_Expiration_And_Select_Tinted_Sprite_State()
+    {
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 7, 9, 12, 0, 0, TimeSpan.Zero));
+        var sprites = new RecordingSpriteService();
+        var skill = new SkillbookItem { Name = "Assail", Sprite = 7 };
+        var viewModel = new PlayerSkillSlotViewModel(1, skill, sprites, timeProvider);
+
+        viewModel.SetCooldown(TimeSpan.FromMinutes(2));
+        _ = viewModel.SpriteImage;
+        timeProvider.Advance(TimeSpan.FromSeconds(61));
+        viewModel.TickCooldown();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.HasCooldown, Is.True);
+            Assert.That(viewModel.CooldownText, Is.EqualTo("59s"));
+            Assert.That(sprites.LastSkillCooldownState, Is.True);
+        });
+
+        timeProvider.Advance(TimeSpan.FromSeconds(59));
+        viewModel.TickCooldown();
+        _ = viewModel.SpriteImage;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.HasCooldown, Is.False);
+            Assert.That(viewModel.CooldownText, Is.Empty);
+            Assert.That(skill.CooldownUntil, Is.Null);
+            Assert.That(sprites.LastSkillCooldownState, Is.False);
+        });
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow += duration;
+    }
+
+    private sealed class RecordingSpriteService : IGameSpriteService
+    {
+        public bool LastSkillCooldownState { get; private set; }
+
+        public event EventHandler? SpritesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public IImage? GetItem(ushort sprite, byte color) => null;
+
+        public IImage? GetSkill(ushort sprite, bool isOnCooldown)
+        {
+            LastSkillCooldownState = isOnCooldown;
+            return null;
+        }
+
+        public IImage? GetSpell(ushort sprite, bool isOnCooldown) => null;
+    }
+}

--- a/Arbiter.App/App.axaml
+++ b/Arbiter.App/App.axaml
@@ -7,6 +7,9 @@
              
     <Application.Styles>
         <StyleInclude Source="/Themes/TalgoniteStyles.axaml"/>
+        <Style Selector="Border.sprite-slot:pointerover">
+            <Setter Property="BorderBrush" Value="White"/>
+        </Style>
     </Application.Styles>
     
     <Application.Resources>

--- a/Arbiter.App/App.axaml.cs
+++ b/Arbiter.App/App.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
+using System;
 using System.Linq;
 using Arbiter.App.Logging;
 using Arbiter.App.Mappings;
@@ -10,6 +11,7 @@ using Arbiter.App.Services.Entities;
 using Arbiter.App.Services.Input;
 using Arbiter.App.Services.Players;
 using Arbiter.App.Services.Settings;
+using Arbiter.App.Services.Sprites;
 using Arbiter.App.Services.Tracing;
 using Avalonia.Markup.Xaml;
 using Arbiter.App.ViewModels;
@@ -103,6 +105,8 @@ public class App : Application
         services.AddSingleton<InspectorViewModelFactory>();
         services.AddSingleton<ProxyServer>();
         services.AddSingleton<IPlayerService, PlayerService>();
+        services.AddSingleton<IGameSpriteService, GameSpriteService>();
+        services.AddSingleton(TimeProvider.System);
         
         // Transients
         services.AddTransient<IDialogService, DialogService>();

--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -38,6 +38,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Arbiter.Interop\Arbiter.Interop.csproj" />
+      <ProjectReference Include="..\Arbiter.Imaging\Arbiter.Imaging.csproj" />
       <ProjectReference Include="..\Arbiter.Json\Arbiter.Json.csproj" />
       <ProjectReference Include="..\Arbiter.Net\Arbiter.Net.csproj" />
     </ItemGroup>

--- a/Arbiter.App/Controls/SpritePresenter.axaml
+++ b/Arbiter.App/Controls/SpritePresenter.axaml
@@ -1,0 +1,87 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="using:Arbiter.App.Controls"
+             x:Class="Arbiter.App.Controls.SpritePresenter"
+             x:Name="Root"
+             x:DataType="controls:SpritePresenter"
+             x:CompileBindings="False">
+    <UserControl.Styles>
+        <Style Selector="Border.cooldown-frame">
+            <Setter Property="BorderBrush" Value="Transparent"/>
+        </Style>
+        <Style Selector="Border.cooldown-frame.active">
+            <Setter Property="BorderBrush" Value="{StaticResource Talgonite.Color.LightBlue}"/>
+        </Style>
+        <Style Selector="TextBlock.fallback.active">
+            <Setter Property="Foreground" Value="{StaticResource Talgonite.Color.LightBlue}"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Grid>
+        <Border Background="{StaticResource Talgonite.Border.ShadowBrush}"
+                IsVisible="{Binding #Root.IsEmpty}"/>
+
+        <Image Source="{Binding #Root.Source}"
+               IsVisible="{Binding #Root.Source, Converter={x:Static ObjectConverters.IsNotNull}}"
+               Stretch="Uniform"
+               StretchDirection="{Binding #Root.SpriteStretchDirection}"
+               Margin="2"
+               RenderOptions.BitmapInterpolationMode="None"/>
+
+        <TextBlock Text="{Binding #Root.FallbackText}"
+                   Classes="fallback"
+                   Classes.active="{Binding #Root.IsCooldownActive}"
+                   IsVisible="{Binding #Root.Source, Converter={x:Static ObjectConverters.IsNull}}"
+                   FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                   FontSize="14"
+                   Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"/>
+
+        <Border Classes="cooldown-frame"
+                Classes.active="{Binding #Root.IsCooldownActive}"
+                BorderThickness="1"
+                IsHitTestVisible="False"/>
+
+        <Border Background="#B0000000"
+                Padding="3,1"
+                CornerRadius="2"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsVisible="{Binding #Root.IsCooldownActive}">
+            <TextBlock Text="{Binding #Root.CooldownText}"
+                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                       FontSize="15"
+                       FontWeight="SemiBold"
+                       Foreground="{StaticResource Talgonite.Color.LightBlue}"/>
+        </Border>
+
+        <Border Background="#B0000000"
+                Padding="2,0"
+                CornerRadius="2"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Margin="2"
+                IsVisible="{Binding #Root.DetailText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <TextBlock Text="{Binding #Root.DetailText}"
+                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                       FontSize="10"
+                       FontWeight="SemiBold"
+                       Foreground="{StaticResource Talgonite.TextBlock.Foreground}"/>
+        </Border>
+
+        <Border Background="#78000000"
+                Padding="2,0"
+                CornerRadius="1"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Margin="2"
+                IsVisible="{Binding #Root.SlotText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <TextBlock Text="{Binding #Root.SlotText}"
+                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                       FontSize="11"
+                       FontWeight="SemiBold"
+                       Foreground="{StaticResource Talgonite.TextBlock.Foreground}"/>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Arbiter.App/Controls/SpritePresenter.axaml.cs
+++ b/Arbiter.App/Controls/SpritePresenter.axaml.cs
@@ -1,0 +1,89 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Markup.Xaml;
+
+namespace Arbiter.App.Controls;
+
+public partial class SpritePresenter : UserControl
+{
+    public static readonly StyledProperty<IImage?> SourceProperty =
+        AvaloniaProperty.Register<SpritePresenter, IImage?>(nameof(Source));
+
+    public static readonly StyledProperty<string> SlotTextProperty =
+        AvaloniaProperty.Register<SpritePresenter, string>(nameof(SlotText), string.Empty);
+
+    public static readonly StyledProperty<string> FallbackTextProperty =
+        AvaloniaProperty.Register<SpritePresenter, string>(nameof(FallbackText), string.Empty);
+
+    public static readonly StyledProperty<bool> IsEmptyProperty =
+        AvaloniaProperty.Register<SpritePresenter, bool>(nameof(IsEmpty));
+
+    public static readonly StyledProperty<bool> IsCooldownActiveProperty =
+        AvaloniaProperty.Register<SpritePresenter, bool>(nameof(IsCooldownActive));
+
+    public static readonly StyledProperty<string> CooldownTextProperty =
+        AvaloniaProperty.Register<SpritePresenter, string>(nameof(CooldownText), string.Empty);
+
+    public static readonly StyledProperty<string> DetailTextProperty =
+        AvaloniaProperty.Register<SpritePresenter, string>(nameof(DetailText), string.Empty);
+
+    public static readonly StyledProperty<StretchDirection> SpriteStretchDirectionProperty =
+        AvaloniaProperty.Register<SpritePresenter, StretchDirection>(
+            nameof(SpriteStretchDirection),
+            StretchDirection.Both);
+
+    public IImage? Source
+    {
+        get => GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
+    }
+
+    public string SlotText
+    {
+        get => GetValue(SlotTextProperty);
+        set => SetValue(SlotTextProperty, value);
+    }
+
+    public string FallbackText
+    {
+        get => GetValue(FallbackTextProperty);
+        set => SetValue(FallbackTextProperty, value);
+    }
+
+    public bool IsEmpty
+    {
+        get => GetValue(IsEmptyProperty);
+        set => SetValue(IsEmptyProperty, value);
+    }
+
+    public bool IsCooldownActive
+    {
+        get => GetValue(IsCooldownActiveProperty);
+        set => SetValue(IsCooldownActiveProperty, value);
+    }
+
+    public string CooldownText
+    {
+        get => GetValue(CooldownTextProperty);
+        set => SetValue(CooldownTextProperty, value);
+    }
+
+    public string DetailText
+    {
+        get => GetValue(DetailTextProperty);
+        set => SetValue(DetailTextProperty, value);
+    }
+
+    public StretchDirection SpriteStretchDirection
+    {
+        get => GetValue(SpriteStretchDirectionProperty);
+        set => SetValue(SpriteStretchDirectionProperty, value);
+    }
+
+    public SpritePresenter()
+    {
+        InitializeComponent();
+    }
+}

--- a/Arbiter.App/Models/Player/PlayerState.cs
+++ b/Arbiter.App/Models/Player/PlayerState.cs
@@ -29,6 +29,7 @@ public sealed class PlayerState
     public long MaxHealth { get; set; }
     public long CurrentMana { get; set; }
     public long MaxMana { get; set; }
+    public uint Gold { get; set; }
 
     public ISlottedCollection<InventoryItem> Inventory { get; } =
         new ConcurrentSlottedCollection<InventoryItem>(MaxInventorySlots);

--- a/Arbiter.App/Models/Player/SkillbookItem.cs
+++ b/Arbiter.App/Models/Player/SkillbookItem.cs
@@ -8,7 +8,8 @@ public sealed class SkillbookItem
     public required string Name { get; init; }
     public int CurrentLevel { get; init; }
     public int MaxLevel { get; init; }
-    public TimeSpan Cooldown { get; set; }
+    public TimeSpan CooldownDuration { get; set; }
+    public DateTimeOffset? CooldownUntil { get; set; }
     public bool IsVirtual { get; init; }
     public Action? OnUse { get; init; }
 

--- a/Arbiter.App/Models/Player/SpellbookItem.cs
+++ b/Arbiter.App/Models/Player/SpellbookItem.cs
@@ -12,7 +12,8 @@ public sealed class SpellbookItem
     public int MaxLevel { get; init; }
     public int CastLines { get; init; }
     public string? Prompt { get; init; }
-    public TimeSpan Cooldown { get; set; }
+    public TimeSpan CooldownDuration { get; set; }
+    public DateTimeOffset? CooldownUntil { get; set; }
     public bool IsVirtual { get; init; }
     public Action<SpellCastParameters>? OnCast { get; init; }
 

--- a/Arbiter.App/Services/Sprites/AvaloniaSpriteAtlas.cs
+++ b/Arbiter.App/Services/Sprites/AvaloniaSpriteAtlas.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Arbiter.Imaging.Sprites;
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+
+namespace Arbiter.App.Services.Sprites;
+
+internal sealed class AvaloniaSpriteAtlas : IDisposable
+{
+    private readonly SpriteAtlas _atlas;
+    private readonly WriteableBitmap _bitmap;
+    private readonly Dictionary<int, CroppedBitmap> _frames = [];
+
+    public AvaloniaSpriteAtlas(SpriteAtlas atlas)
+    {
+        _atlas = atlas;
+        var rgba = atlas.Pixels.Span;
+        var bgra = new byte[rgba.Length];
+        for (var index = 0; index < rgba.Length; index += 4)
+        {
+            bgra[index] = rgba[index + 2];
+            bgra[index + 1] = rgba[index + 1];
+            bgra[index + 2] = rgba[index];
+            bgra[index + 3] = rgba[index + 3];
+        }
+
+        var handle = GCHandle.Alloc(bgra, GCHandleType.Pinned);
+        try
+        {
+            _bitmap = new WriteableBitmap(
+                PixelFormat.Bgra8888,
+                AlphaFormat.Unpremul,
+                handle.AddrOfPinnedObject(),
+                new PixelSize(atlas.Width, atlas.Height),
+                new Vector(96, 96),
+                checked(atlas.Width * 4));
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
+
+    public IImage? GetIcon(ushort icon)
+    {
+        return _atlas.TryResolveIcon(icon, out var frameIndex, out var region)
+            ? GetFrame(frameIndex, region)
+            : null;
+    }
+
+    public IImage? GetFrame(int frameIndex)
+    {
+        return _atlas.TryGetFrame(frameIndex, out var region)
+            ? GetFrame(frameIndex, region)
+            : null;
+    }
+
+    public void Dispose()
+    {
+        _frames.Clear();
+        _bitmap.Dispose();
+    }
+
+    private IImage GetFrame(int frameIndex, SpriteAtlasRegion region)
+    {
+        if (_frames.TryGetValue(frameIndex, out var frame))
+        {
+            return frame;
+        }
+
+        frame = new CroppedBitmap
+        {
+            Source = _bitmap,
+            SourceRect = new PixelRect(region.X, region.Y, region.Width, region.Height)
+        };
+        _frames.Add(frameIndex, frame);
+        return frame;
+    }
+}

--- a/Arbiter.App/Services/Sprites/GameSpriteService.cs
+++ b/Arbiter.App/Services/Sprites/GameSpriteService.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Arbiter.Imaging.Sprites;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Arbiter.App.Services.Sprites;
+
+public sealed class GameSpriteService : IGameSpriteService, IDisposable
+{
+    private readonly ILogger<GameSpriteService> _logger;
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
+    private readonly Dictionary<(uint FirstItemId, byte Color), AvaloniaSpriteAtlas> _itemAtlases = [];
+    private readonly HashSet<(uint FirstItemId, byte Color)> _failedItemAtlases = [];
+
+    private GameSpriteData? _data;
+    private AvaloniaSpriteAtlas? _skills;
+    private AvaloniaSpriteAtlas? _skillsOnCooldown;
+    private AvaloniaSpriteAtlas? _spells;
+    private AvaloniaSpriteAtlas? _spellsOnCooldown;
+    private string? _loadedDirectory;
+
+    public GameSpriteService(ILogger<GameSpriteService> logger)
+    {
+        _logger = logger;
+    }
+
+    public event EventHandler? SpritesChanged;
+
+    public async Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(clientExecutablePath);
+        await _loadGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (string.Equals(directory, _loadedDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            GameSpriteData? data = null;
+            Exception? loadException = null;
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                loadException = new DirectoryNotFoundException("The configured client path does not have a directory.");
+            }
+            else
+            {
+                try
+                {
+                    data = await Task.Run(() => GameSpriteDataLoader.Load(directory), cancellationToken);
+                }
+                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or
+                                                   InvalidDataException or OverflowException)
+                {
+                    loadException = exception;
+                }
+            }
+
+            await Dispatcher.UIThread.InvokeAsync(() => ApplyLoadedData(directory, data, loadException));
+        }
+        finally
+        {
+            _loadGate.Release();
+        }
+    }
+
+    public IImage? GetItem(ushort sprite, byte color)
+    {
+        var itemAtlas = _data?.Items?.Find(sprite);
+        if (itemAtlas is null)
+        {
+            return null;
+        }
+
+        var key = (itemAtlas.FirstItemId, color);
+        if (_failedItemAtlases.Contains(key))
+        {
+            return null;
+        }
+
+        if (!_itemAtlases.TryGetValue(key, out var atlas))
+        {
+            try
+            {
+                var source = itemAtlas.BuildColorVariant(color);
+                atlas = new AvaloniaSpriteAtlas(source);
+                _itemAtlases.Add(key, atlas);
+            }
+            catch (Exception exception) when (exception is ArgumentException or InvalidDataException or OverflowException)
+            {
+                _failedItemAtlases.Add(key);
+                _logger.LogWarning(
+                    exception,
+                    "Failed to build item sprite atlas starting at {FirstItemId} with color {Color}",
+                    itemAtlas.FirstItemId,
+                    color);
+                return null;
+            }
+        }
+
+        var frameIndex = checked((int)(sprite - itemAtlas.FirstItemId));
+        return atlas.GetFrame(frameIndex);
+    }
+
+    public IImage? GetSkill(ushort sprite, bool isOnCooldown) =>
+        (isOnCooldown ? _skillsOnCooldown : _skills)?.GetIcon(sprite);
+
+    public IImage? GetSpell(ushort sprite, bool isOnCooldown) =>
+        (isOnCooldown ? _spellsOnCooldown : _spells)?.GetIcon(sprite);
+
+    public void Dispose()
+    {
+        DisposeAtlases();
+        _loadGate.Dispose();
+    }
+
+    private void ApplyLoadedData(string? directory, GameSpriteData? data, Exception? loadException)
+    {
+        var oldSkills = _skills;
+        var oldSkillsOnCooldown = _skillsOnCooldown;
+        var oldSpells = _spells;
+        var oldSpellsOnCooldown = _spellsOnCooldown;
+        var oldItems = _itemAtlases.Values.ToArray();
+
+        _data = data;
+        _skills = CreateAtlas(data?.Skills, "skills");
+        _skillsOnCooldown = CreateAtlas(data?.SkillsOnCooldown, "skills cooldown");
+        _spells = CreateAtlas(data?.Spells, "spells");
+        _spellsOnCooldown = CreateAtlas(data?.SpellsOnCooldown, "spells cooldown");
+        _itemAtlases.Clear();
+        _failedItemAtlases.Clear();
+        _loadedDirectory = directory;
+
+        if (loadException is not null)
+        {
+            _logger.LogWarning(loadException, "Failed to load game sprites from {Directory}", directory);
+        }
+
+        if (data is not null)
+        {
+            foreach (var issue in data.Issues)
+            {
+                _logger.LogWarning(issue.Exception, "Failed to load {Category} sprites", issue.Category);
+            }
+        }
+
+        try
+        {
+            SpritesChanged?.Invoke(this, EventArgs.Empty);
+        }
+        finally
+        {
+            oldSkills?.Dispose();
+            oldSkillsOnCooldown?.Dispose();
+            oldSpells?.Dispose();
+            oldSpellsOnCooldown?.Dispose();
+            foreach (var atlas in oldItems)
+            {
+                atlas.Dispose();
+            }
+        }
+    }
+
+    private AvaloniaSpriteAtlas? CreateAtlas(SpriteAtlas? atlas, string category)
+    {
+        if (atlas is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return new AvaloniaSpriteAtlas(atlas);
+        }
+        catch (Exception exception) when (exception is ArgumentException or OverflowException)
+        {
+            _logger.LogWarning(exception, "Failed to create the Avalonia {Category} atlas", category);
+            return null;
+        }
+    }
+
+    private void DisposeAtlases()
+    {
+        _skills?.Dispose();
+        _skillsOnCooldown?.Dispose();
+        _spells?.Dispose();
+        _spellsOnCooldown?.Dispose();
+        foreach (var atlas in _itemAtlases.Values)
+        {
+            atlas.Dispose();
+        }
+
+        _itemAtlases.Clear();
+    }
+}

--- a/Arbiter.App/Services/Sprites/IGameSpriteService.cs
+++ b/Arbiter.App/Services/Sprites/IGameSpriteService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Media;
+
+namespace Arbiter.App.Services.Sprites;
+
+public interface IGameSpriteService
+{
+    event EventHandler? SpritesChanged;
+
+    Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default);
+    IImage? GetItem(ushort sprite, byte color);
+    IImage? GetSkill(ushort sprite, bool isOnCooldown);
+    IImage? GetSpell(ushort sprite, bool isOnCooldown);
+}

--- a/Arbiter.App/Services/Sprites/NullGameSpriteService.cs
+++ b/Arbiter.App/Services/Sprites/NullGameSpriteService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Media;
+
+namespace Arbiter.App.Services.Sprites;
+
+internal sealed class NullGameSpriteService : IGameSpriteService
+{
+    public static NullGameSpriteService Instance { get; } = new();
+
+    private NullGameSpriteService()
+    {
+    }
+
+    public event EventHandler? SpritesChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    public IImage? GetItem(ushort sprite, byte color) => null;
+    public IImage? GetSkill(ushort sprite, bool isOnCooldown) => null;
+    public IImage? GetSpell(ushort sprite, bool isOnCooldown) => null;
+}

--- a/Arbiter.App/ViewModels/Client/ClientManagerViewModel.cs
+++ b/Arbiter.App/ViewModels/Client/ClientManagerViewModel.cs
@@ -9,6 +9,7 @@ using Arbiter.App.Models.Settings;
 using Arbiter.App.Services.Client;
 using Arbiter.App.Services.Entities;
 using Arbiter.App.Services.Players;
+using Arbiter.App.Services.Sprites;
 using Arbiter.Net.Proxy;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -21,6 +22,8 @@ public partial class ClientManagerViewModel : ViewModelBase
     private readonly IGameClientService _gameClientService;
     private readonly IPlayerService _playerService;
     private readonly IEntityStore _entityStore;
+    private readonly IGameSpriteService _spriteService;
+    private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<long, ClientViewModel> _clients = [];
     
     private DebugSettings? _debugSettings;
@@ -40,12 +43,15 @@ public partial class ClientManagerViewModel : ViewModelBase
     public event Action<ClientViewModel>? ClientDisconnected;
 
     public ClientManagerViewModel(ProxyServer proxyServer, IGameClientService gameClientService,
-        IPlayerService playerService, IEntityStore entityStore)
+        IPlayerService playerService, IEntityStore entityStore, IGameSpriteService spriteService,
+        TimeProvider timeProvider)
     {
         _proxyServer = proxyServer;
         _gameClientService = gameClientService;
         _playerService = playerService;
         _entityStore = entityStore;
+        _spriteService = spriteService;
+        _timeProvider = timeProvider;
 
         _proxyServer.ClientAuthenticated += OnClientAuthenticated;
         _proxyServer.ClientLoggedIn += OnClientLoggedIn;
@@ -80,7 +86,7 @@ public partial class ClientManagerViewModel : ViewModelBase
     {
         var connection = e.Connection;
         var state = new PlayerState(connection.Id, connection.Name);
-        var client = new ClientViewModel(connection, state)
+        var client = new ClientViewModel(connection, state, _spriteService, _timeProvider)
             { Id = connection.Id, Name = connection.Name ?? string.Empty };
 
         // Start listening for packets and updating state
@@ -145,8 +151,6 @@ public partial class ClientManagerViewModel : ViewModelBase
     private void OnClientDisconnected(object? sender, ProxyConnectionEventArgs e)
     {
         var client = Clients.FirstOrDefault(c => c.Id == e.Connection.Id);
-        client?.Unsubscribe();
-
         if (client is not null)
         {
             CleanupClient(client);
@@ -158,6 +162,7 @@ public partial class ClientManagerViewModel : ViewModelBase
 
     private void CleanupClient(ClientViewModel client)
     {
+        client.Unsubscribe();
         SetClientWindowTitle(client, "Darkages");
         client.BringToFrontRequested -= OnClientBringToFront;
 

--- a/Arbiter.App/ViewModels/Client/ClientViewModel.cs
+++ b/Arbiter.App/ViewModels/Client/ClientViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
 using Arbiter.App.ViewModels.Player;
 using Arbiter.Net;
 using Arbiter.Net.Client.Messages;
@@ -19,29 +20,51 @@ public partial class ClientViewModel : ViewModelBase
     public required string Name { get; set; }
 
     private readonly ProxyConnection _connection;
+    private bool _isSubscribed;
 
     public ProxyConnection Connection => _connection;
     
     public PlayerViewModel Player { get; }
 
     public ClientViewModel(ProxyConnection connection, PlayerState player)
+        : this(connection, player, NullGameSpriteService.Instance, TimeProvider.System)
+    {
+    }
+
+    public ClientViewModel(
+        ProxyConnection connection,
+        PlayerState player,
+        IGameSpriteService spriteService,
+        TimeProvider timeProvider)
     {
         _connection = connection;
-        Player = new PlayerViewModel(player);
+        Player = new PlayerViewModel(player, spriteService, timeProvider);
     }
 
     public event EventHandler? BringToFrontRequested;
 
     public void Subscribe()
     {
+        if (_isSubscribed)
+        {
+            return;
+        }
+
         RegisterFilters();
         Player.Subscribe(_connection);
+        _isSubscribed = true;
     }
 
     public void Unsubscribe()
     {
+        if (!_isSubscribed)
+        {
+            return;
+        }
+
         Player.Unsubscribe();
         UnregisterFilters();
+        _isSubscribed = false;
     }
 
     public void SendBarMessage(string message, WorldMessageType messageType = WorldMessageType.BarMessage)

--- a/Arbiter.App/ViewModels/MainWindowViewModel.Lifecycle.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.Lifecycle.cs
@@ -10,6 +10,7 @@ public partial class MainWindowViewModel
     internal async Task OnOpened()
     {
         Settings = await _settingsService.LoadFromFileAsync();
+        await _gameSpriteService.LoadAsync(Settings.ClientExecutablePath);
         LaunchClientCommand.NotifyCanExecuteChanged();
 
         ApplySettings(applyTraceDefaults: true);

--- a/Arbiter.App/ViewModels/MainWindowViewModel.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.cs
@@ -6,6 +6,7 @@ using Arbiter.App.Models.Settings;
 using Arbiter.App.Services.Client;
 using Arbiter.App.Services.Dialogs;
 using Arbiter.App.Services.Settings;
+using Arbiter.App.Services.Sprites;
 using Arbiter.App.ViewModels.Client;
 using Arbiter.App.ViewModels.Dialogs;
 using Arbiter.App.ViewModels.Entities;
@@ -32,6 +33,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IDialogService _dialogService;
     private readonly IGameClientService _gameClientService;
     private readonly ISettingsService _settingsService;
+    private readonly IGameSpriteService _gameSpriteService;
     private readonly Window _mainWindow;
 
     [ObservableProperty] private string _title = "Arbiter";
@@ -58,6 +60,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _dialogService = serviceProvider.GetRequiredService<IDialogService>();
         _gameClientService = serviceProvider.GetRequiredService<IGameClientService>();
         _settingsService = serviceProvider.GetRequiredService<ISettingsService>();
+        _gameSpriteService = serviceProvider.GetRequiredService<IGameSpriteService>();
         _mainWindow = mainWindow;
 
         ClientManager = serviceProvider.GetRequiredService<ClientManagerViewModel>();
@@ -164,6 +167,7 @@ public partial class MainWindowViewModel : ViewModelBase
         Settings.SettingsPanelIndex = vm.SelectedTabIndex;
         
         await _settingsService.SaveToFileAsync(Settings);
+        await _gameSpriteService.LoadAsync(Settings.ClientExecutablePath);
         LaunchClientCommand.NotifyCanExecuteChanged();
 
         ApplySettings();

--- a/Arbiter.App/ViewModels/Player/CooldownFormatter.cs
+++ b/Arbiter.App/ViewModels/Player/CooldownFormatter.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Arbiter.App.ViewModels.Player;
+
+public static class CooldownFormatter
+{
+    public static string Format(DateTimeOffset? cooldownUntil, DateTimeOffset now)
+    {
+        return cooldownUntil.HasValue ? Format(cooldownUntil.Value - now) : string.Empty;
+    }
+
+    public static string Format(TimeSpan remaining)
+    {
+        var seconds = (long)Math.Ceiling(remaining.TotalSeconds);
+        if (seconds <= 0)
+        {
+            return string.Empty;
+        }
+
+        return seconds >= 60
+            ? $"{(seconds + 59) / 60}m"
+            : $"{seconds}s";
+    }
+}

--- a/Arbiter.App/ViewModels/Player/DesignPlayerSkillbookViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/DesignPlayerSkillbookViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Arbiter.App.Collections;
+using System;
+using Arbiter.App.Collections;
 using Arbiter.App.Models.Player;
 
 namespace Arbiter.App.ViewModels.Player;
@@ -19,7 +20,9 @@ public sealed class DesignPlayerSkillbookViewModel : PlayerSkillbookViewModel
             Name = "Assail",
             Sprite = 1,
             CurrentLevel = 80,
-            MaxLevel = 100
+            MaxLevel = 100,
+            CooldownDuration = TimeSpan.FromMinutes(2),
+            CooldownUntil = DateTimeOffset.Now.AddMinutes(2)
         };
 
         skills.SetSlot(1, skill);

--- a/Arbiter.App/ViewModels/Player/DesignPlayerSpellbookViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/DesignPlayerSpellbookViewModel.cs
@@ -1,5 +1,7 @@
-﻿using Arbiter.App.Collections;
+using System;
+using Arbiter.App.Collections;
 using Arbiter.App.Models.Player;
+using Arbiter.Net.Types;
 
 namespace Arbiter.App.ViewModels.Player;
 
@@ -14,8 +16,16 @@ public sealed class DesignPlayerSpellbookViewModel : PlayerSpellbookViewModel
     {
         var spellbook = new SlottedCollection<SpellbookItem>(PlayerState.MaxTemuairSpells +
                                                              PlayerState.MaxMedeniaSpells + PlayerState.MaxWorldSpells);
-
-
+        spellbook.SetSlot(1, new SpellbookItem
+        {
+            Name = "Fas Spiorad",
+            Sprite = 1,
+            TargetType = SpellTargetType.Target,
+            CurrentLevel = 50,
+            MaxLevel = 100,
+            CooldownDuration = TimeSpan.FromSeconds(59),
+            CooldownUntil = DateTimeOffset.Now.AddSeconds(59)
+        });
 
         return spellbook;
     }

--- a/Arbiter.App/ViewModels/Player/PlayerInventorySlotViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerInventorySlotViewModel.cs
@@ -1,10 +1,16 @@
-﻿using Arbiter.App.Models.Player;
+using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
+using Avalonia.Media;
 
 namespace Arbiter.App.ViewModels.Player;
 
 public class PlayerInventorySlotViewModel : ViewModelBase
 {
+    public const ushort GoldSprite = 136;
+
     private readonly InventoryItem? _item;
+    private readonly IGameSpriteService _spriteService;
+    private readonly bool _isGold;
 
     public int Slot { get; }
     public bool IsEmpty => _item is null;
@@ -12,18 +18,64 @@ public class PlayerInventorySlotViewModel : ViewModelBase
     public ushort Sprite => _item?.Sprite ?? 0;
     public byte Color => _item?.Color ?? 0;
     public bool IsStackable => _item?.IsStackable ?? false;
+    public bool IsGold => _isGold;
+    public bool ShowsQuantity => !IsGold && Quantity > 1;
     public long Quantity => _item?.Quantity ?? 0;
+    public string QuantityDisplayText => $"(x{Quantity:N0})";
+    public string GoldAmountText => $"{Quantity:N0} gold";
+    public string DetailText => IsGold
+        ? FormatCompactQuantity(Quantity)
+        : ShowsQuantity
+            ? QuantityDisplayText
+            : string.Empty;
     public long Durability => _item?.Durability ?? 0;
     public long MaxDurability => _item?.MaxDurability ?? 0;
     public bool HasDurability => Durability > 0 && MaxDurability > 0;
     public int PercentDurability => HasDurability ? (int)(Durability * 100 / MaxDurability) : 100;
     public bool IsVirtual => _item?.IsVirtual ?? false;
+    public IImage? SpriteImage => _item is null ? null : _spriteService.GetItem(Sprite, Color);
+    public string SpriteFallbackText => IsEmpty ? string.Empty : $"#{Sprite}";
 
     public PlayerInventorySlotViewModel(int slot, InventoryItem? item = null)
+        : this(slot, item, NullGameSpriteService.Instance)
+    {
+    }
+
+    public PlayerInventorySlotViewModel(int slot, InventoryItem? item, IGameSpriteService spriteService)
+        : this(slot, item, spriteService, false)
+    {
+    }
+
+    private PlayerInventorySlotViewModel(
+        int slot,
+        InventoryItem? item,
+        IGameSpriteService spriteService,
+        bool isGold)
     {
         Slot = slot;
         _item = item;
+        _spriteService = spriteService;
+        _isGold = isGold;
     }
+
+    public static PlayerInventorySlotViewModel CreateGold(
+        int slot,
+        uint gold,
+        IGameSpriteService spriteService)
+    {
+        return new PlayerInventorySlotViewModel(
+            slot,
+            new InventoryItem
+            {
+                Name = "Gold",
+                Sprite = GoldSprite,
+                Quantity = gold
+            },
+            spriteService,
+            true);
+    }
+
+    public void RefreshSprite() => OnPropertyChanged(nameof(SpriteImage));
 
     public override string ToString()
     {
@@ -32,6 +84,17 @@ public class PlayerInventorySlotViewModel : ViewModelBase
             return "<empty>";
         }
 
-        return IsStackable ? $"{Name} [{Quantity}]" : Name;
+        return ShowsQuantity ? $"{Name} [{Quantity}]" : Name;
+    }
+
+    private static string FormatCompactQuantity(long quantity)
+    {
+        return quantity switch
+        {
+            < 1_000 => quantity.ToString(),
+            < 1_000_000 => $"{quantity / 1_000.0:0.#}k",
+            < 1_000_000_000 => $"{quantity / 1_000_000.0:0.#}m",
+            _ => $"{quantity / 1_000_000_000.0:0.#}b"
+        };
     }
 }

--- a/Arbiter.App/ViewModels/Player/PlayerInventoryViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerInventoryViewModel.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using Arbiter.App.Collections;
 using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -10,26 +10,49 @@ namespace Arbiter.App.ViewModels.Player;
 
 public partial class PlayerInventoryViewModel : ViewModelBase
 {
+    public const int GoldSlot = PlayerState.MaxInventorySlots;
+
     private readonly ISlottedCollection<InventoryItem> _inventory;
+    private readonly IGameSpriteService _spriteService;
 
     [ObservableProperty] private PlayerInventorySlotViewModel? _selectedItem;
 
     public ObservableCollection<PlayerInventorySlotViewModel> InventorySlots { get; } = [];
 
     public PlayerInventoryViewModel(ISlottedCollection<InventoryItem> inventory)
+        : this(inventory, NullGameSpriteService.Instance)
+    {
+    }
+
+    public PlayerInventoryViewModel(
+        ISlottedCollection<InventoryItem> inventory,
+        IGameSpriteService spriteService)
     {
         _inventory = inventory;
+        _spriteService = spriteService;
 
         for (var i = 0; i < inventory.Capacity; i++)
         {
-            InventorySlots.Add(new PlayerInventorySlotViewModel(i + 1));
+            var slot = i + 1;
+            InventorySlots.Add(slot == GoldSlot ? CreateGoldSlot(0) : CreateSlot(slot));
         }
 
         _inventory.ItemAdded += OnItemAdded;
         _inventory.ItemRemoved += OnItemRemoved;
     }
     
-    public int? GetFirstEmptySlot() => _inventory.GetFirstEmptySlot();
+    public int? GetFirstEmptySlot()
+    {
+        foreach (var slot in _inventory.GetEmptySlots())
+        {
+            if (slot < GoldSlot)
+            {
+                return slot;
+            }
+        }
+
+        return null;
+    }
 
     public bool HasItem(string name) => GetItem(name, out _);
 
@@ -64,9 +87,28 @@ public partial class PlayerInventoryViewModel : ViewModelBase
     public void ClearSlot(int slot)
         => _inventory.ClearSlot(slot);
 
+    public void SetGold(uint gold)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => SetGold(gold));
+            return;
+        }
+
+        InventorySlots[GoldSlot - 1] = CreateGoldSlot(gold);
+    }
+
+    public void RefreshSprites()
+    {
+        foreach (var slot in InventorySlots)
+        {
+            slot.RefreshSprite();
+        }
+    }
+
     private void OnItemAdded(Slotted<InventoryItem> item)
     {
-        if (item.Slot < 1 || item.Slot > _inventory.Capacity)
+        if (item.Slot < 1 || item.Slot >= GoldSlot)
         {
             return;
         }
@@ -77,12 +119,12 @@ public partial class PlayerInventoryViewModel : ViewModelBase
             return;
         }
 
-        InventorySlots[item.Slot - 1] = new PlayerInventorySlotViewModel(item.Slot, item.Value);
+        InventorySlots[item.Slot - 1] = CreateSlot(item.Slot, item.Value);
     }
 
     private void OnItemRemoved(Slotted<InventoryItem> item)
     {
-        if (item.Slot < 1 || item.Slot > _inventory.Capacity)
+        if (item.Slot < 1 || item.Slot >= GoldSlot)
         {
             return;
         }
@@ -93,6 +135,12 @@ public partial class PlayerInventoryViewModel : ViewModelBase
             return;
         }
 
-        InventorySlots[item.Slot - 1] = new PlayerInventorySlotViewModel(item.Slot);
+        InventorySlots[item.Slot - 1] = CreateSlot(item.Slot);
     }
+
+    private PlayerInventorySlotViewModel CreateSlot(int slot, InventoryItem? item = null) =>
+        new(slot, item, _spriteService);
+
+    private PlayerInventorySlotViewModel CreateGoldSlot(uint gold) =>
+        PlayerInventorySlotViewModel.CreateGold(GoldSlot, gold, _spriteService);
 }

--- a/Arbiter.App/ViewModels/Player/PlayerSkillSlotViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerSkillSlotViewModel.cs
@@ -1,12 +1,17 @@
-﻿using System;
+using System;
 using Arbiter.App.Models.Player;
-using Avalonia.Markup.Xaml.MarkupExtensions;
+using Arbiter.App.Services.Sprites;
+using Avalonia.Media;
 
 namespace Arbiter.App.ViewModels.Player;
 
 public sealed class PlayerSkillSlotViewModel : ViewModelBase
 {
     private readonly SkillbookItem? _skill;
+    private readonly IGameSpriteService _spriteService;
+    private readonly TimeProvider _timeProvider;
+    private string _cooldownText = string.Empty;
+    private bool _hasCooldown;
 
     public int Slot { get; }
 
@@ -22,33 +27,90 @@ public sealed class PlayerSkillSlotViewModel : ViewModelBase
             };
         }
     }
+
     public bool IsEmpty => _skill is null;
     public string Name => _skill?.Name ?? string.Empty;
     public ushort Sprite => _skill?.Sprite ?? 0;
     public int CurrentLevel => _skill?.CurrentLevel ?? 0;
     public int MaxLevel => _skill?.MaxLevel ?? 0;
-    public TimeSpan Cooldown => _skill?.Cooldown ?? TimeSpan.Zero;
+    public TimeSpan Cooldown => _skill?.CooldownUntil is { } until
+        ? TimeSpan.FromTicks(Math.Max(0, (until - _timeProvider.GetUtcNow()).Ticks))
+        : TimeSpan.Zero;
     public bool HasLevel => _skill?.MaxLevel > 0;
-    public bool HasCooldown => Cooldown > TimeSpan.Zero;
+    public bool HasCooldown => _hasCooldown;
+    public bool HasCooldownDuration => _skill?.CooldownDuration > TimeSpan.Zero;
+    public string CooldownText => _cooldownText;
+    public string CooldownDurationText => CooldownFormatter.Format(_skill?.CooldownDuration ?? TimeSpan.Zero);
     public bool IsVirtual => _skill?.IsVirtual ?? false;
+    public IImage? SpriteImage => _skill is null ? null : _spriteService.GetSkill(Sprite, HasCooldown);
+    public string SpriteFallbackText => IsEmpty ? string.Empty : $"#{Sprite}";
 
     public PlayerSkillSlotViewModel(int slot, SkillbookItem? skill = null)
+        : this(slot, skill, NullGameSpriteService.Instance, TimeProvider.System)
+    {
+    }
+
+    public PlayerSkillSlotViewModel(
+        int slot,
+        SkillbookItem? skill,
+        IGameSpriteService spriteService,
+        TimeProvider timeProvider)
     {
         Slot = slot;
         _skill = skill;
+        _spriteService = spriteService;
+        _timeProvider = timeProvider;
+        UpdateCooldown(_timeProvider.GetUtcNow());
     }
 
-    public void SetCooldown(TimeSpan duration)
+    public bool SetCooldown(TimeSpan duration)
     {
         if (_skill is null)
         {
-            return;
+            return false;
         }
 
-        _skill.Cooldown = duration;
-        OnPropertyChanged(nameof(Cooldown));
-        OnPropertyChanged(nameof(HasCooldown));
+        var now = _timeProvider.GetUtcNow();
+        var previousDuration = _skill.CooldownDuration;
+        _skill.CooldownDuration = duration;
+        _skill.CooldownUntil = duration > TimeSpan.Zero ? now + duration : null;
+        if (previousDuration != duration)
+        {
+            OnPropertyChanged(nameof(HasCooldownDuration));
+            OnPropertyChanged(nameof(CooldownDurationText));
+        }
+
+        return UpdateCooldown(now);
     }
 
+    public bool TickCooldown() => UpdateCooldown(_timeProvider.GetUtcNow());
+    public void RefreshSprite() => OnPropertyChanged(nameof(SpriteImage));
+
     public override string ToString() => IsEmpty ? "<empty>" : Name;
+
+    private bool UpdateCooldown(DateTimeOffset now)
+    {
+        var cooldownText = CooldownFormatter.Format(_skill?.CooldownUntil, now);
+        var hasCooldown = !string.IsNullOrEmpty(cooldownText);
+        if (!hasCooldown && _skill is not null)
+        {
+            _skill.CooldownUntil = null;
+        }
+
+        if (!string.Equals(_cooldownText, cooldownText, StringComparison.Ordinal))
+        {
+            _cooldownText = cooldownText;
+            OnPropertyChanged(nameof(CooldownText));
+            OnPropertyChanged(nameof(Cooldown));
+        }
+
+        if (_hasCooldown != hasCooldown)
+        {
+            _hasCooldown = hasCooldown;
+            OnPropertyChanged(nameof(HasCooldown));
+            OnPropertyChanged(nameof(SpriteImage));
+        }
+
+        return hasCooldown;
+    }
 }

--- a/Arbiter.App/ViewModels/Player/PlayerSkillbookViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerSkillbookViewModel.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Arbiter.App.Collections;
 using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -11,6 +13,8 @@ namespace Arbiter.App.ViewModels.Player;
 public partial class PlayerSkillbookViewModel : ViewModelBase
 {
     private readonly ISlottedCollection<SkillbookItem> _skills;
+    private readonly IGameSpriteService _spriteService;
+    private readonly TimeProvider _timeProvider;
 
     [ObservableProperty] private PlayerSkillSlotViewModel? _selectedSkill;
 
@@ -19,22 +23,32 @@ public partial class PlayerSkillbookViewModel : ViewModelBase
     public ObservableCollection<PlayerSkillSlotViewModel> WorldSkills { get; } = [];
 
     public PlayerSkillbookViewModel(ISlottedCollection<SkillbookItem> skills)
+        : this(skills, NullGameSpriteService.Instance, TimeProvider.System)
+    {
+    }
+
+    public PlayerSkillbookViewModel(
+        ISlottedCollection<SkillbookItem> skills,
+        IGameSpriteService spriteService,
+        TimeProvider timeProvider)
     {
         _skills = skills;
+        _spriteService = spriteService;
+        _timeProvider = timeProvider;
 
         for (var i = 0; i < _skills.Capacity; i++)
         {
             if (i < 36)
             {
-                TemuairSkills.Add(new PlayerSkillSlotViewModel(i + 1));
+                TemuairSkills.Add(CreateSlot(i + 1));
             }
             else if (i < 72)
             {
-                MedeniaSkills.Add(new PlayerSkillSlotViewModel(i + 1));
+                MedeniaSkills.Add(CreateSlot(i + 1));
             }
             else
             {
-                WorldSkills.Add(new PlayerSkillSlotViewModel(i + 1));
+                WorldSkills.Add(CreateSlot(i + 1));
             }
         }
 
@@ -87,11 +101,11 @@ public partial class PlayerSkillbookViewModel : ViewModelBase
         return true;
     }
 
-    public void UpdateCooldown(int slot, TimeSpan duration)
+    public bool UpdateCooldown(int slot, TimeSpan duration)
     {
         if (slot < 1 || slot > _skills.Capacity)
         {
-            return;
+            return false;
         }
 
         var index = slot - 1;
@@ -102,7 +116,26 @@ public partial class PlayerSkillbookViewModel : ViewModelBase
             _ => WorldSkills[index - 72]
         };
         
-        vm.SetCooldown(duration);
+        return vm.SetCooldown(duration);
+    }
+
+    public bool TickCooldowns()
+    {
+        var hasCooldowns = false;
+        foreach (var skill in TemuairSkills.Concat(MedeniaSkills).Concat(WorldSkills))
+        {
+            hasCooldowns |= skill.TickCooldown();
+        }
+
+        return hasCooldowns;
+    }
+
+    public void RefreshSprites()
+    {
+        foreach (var skill in TemuairSkills.Concat(MedeniaSkills).Concat(WorldSkills))
+        {
+            skill.RefreshSprite();
+        }
     }
 
     private void OnSkillAdded(Slotted<SkillbookItem> skill)
@@ -149,14 +182,17 @@ public partial class PlayerSkillbookViewModel : ViewModelBase
         switch (slot - 1)
         {
             case < 36:
-                TemuairSkills[index] = new PlayerSkillSlotViewModel(slot, skill);
+                TemuairSkills[index] = CreateSlot(slot, skill);
                 break;
             case < 72:
-                MedeniaSkills[index] = new PlayerSkillSlotViewModel(slot, skill);
+                MedeniaSkills[index] = CreateSlot(slot, skill);
                 break;
             default:
-                WorldSkills[index] = new PlayerSkillSlotViewModel(slot, skill);
+                WorldSkills[index] = CreateSlot(slot, skill);
                 break;
         }
     }
+
+    private PlayerSkillSlotViewModel CreateSlot(int slot, SkillbookItem? skill = null) =>
+        new(slot, skill, _spriteService, _timeProvider);
 }

--- a/Arbiter.App/ViewModels/Player/PlayerSpellSlotViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerSpellSlotViewModel.cs
@@ -1,12 +1,18 @@
-﻿using System;
+using System;
 using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
 using Arbiter.Net.Types;
+using Avalonia.Media;
 
 namespace Arbiter.App.ViewModels.Player;
 
 public sealed class PlayerSpellSlotViewModel : ViewModelBase
 {
     private readonly SpellbookItem? _spell;
+    private readonly IGameSpriteService _spriteService;
+    private readonly TimeProvider _timeProvider;
+    private string _cooldownText = string.Empty;
+    private bool _hasCooldown;
 
     public int Slot { get; }
 
@@ -29,9 +35,14 @@ public sealed class PlayerSpellSlotViewModel : ViewModelBase
     public ushort Sprite => _spell?.Sprite ?? 0;
     public int CurrentLevel => _spell?.CurrentLevel ?? 0;
     public int MaxLevel => _spell?.MaxLevel ?? 0;
-    public TimeSpan Cooldown => _spell?.Cooldown ?? TimeSpan.Zero;
+    public TimeSpan Cooldown => _spell?.CooldownUntil is { } until
+        ? TimeSpan.FromTicks(Math.Max(0, (until - _timeProvider.GetUtcNow()).Ticks))
+        : TimeSpan.Zero;
     public bool HasLevel => _spell?.MaxLevel > 0;
-    public bool HasCooldown => Cooldown > TimeSpan.Zero;
+    public bool HasCooldown => _hasCooldown;
+    public bool HasCooldownDuration => _spell?.CooldownDuration > TimeSpan.Zero;
+    public string CooldownText => _cooldownText;
+    public string CooldownDurationText => CooldownFormatter.Format(_spell?.CooldownDuration ?? TimeSpan.Zero);
     public int CastLines => _spell?.CastLines ?? 0;
     public string CastLinesText => CastLines switch
     {
@@ -40,6 +51,8 @@ public sealed class PlayerSpellSlotViewModel : ViewModelBase
         _ => $"{CastLines} lines"
     };
     public bool IsVirtual => _spell?.IsVirtual ?? false;
+    public IImage? SpriteImage => _spell is null ? null : _spriteService.GetSpell(Sprite, HasCooldown);
+    public string SpriteFallbackText => IsEmpty ? string.Empty : $"#{Sprite}";
 
     public string TargetTypeText => TargetType switch
     {
@@ -53,22 +66,71 @@ public sealed class PlayerSpellSlotViewModel : ViewModelBase
     };
 
     public PlayerSpellSlotViewModel(int slot, SpellbookItem? spell = null)
+        : this(slot, spell, NullGameSpriteService.Instance, TimeProvider.System)
+    {
+    }
+
+    public PlayerSpellSlotViewModel(
+        int slot,
+        SpellbookItem? spell,
+        IGameSpriteService spriteService,
+        TimeProvider timeProvider)
     {
         Slot = slot;
         _spell = spell;
+        _spriteService = spriteService;
+        _timeProvider = timeProvider;
+        UpdateCooldown(_timeProvider.GetUtcNow());
     }
-    
-    public void SetCooldown(TimeSpan duration)
+
+    public bool SetCooldown(TimeSpan duration)
     {
         if (_spell is null)
         {
-            return;
+            return false;
         }
 
-        _spell.Cooldown = duration;
-        OnPropertyChanged(nameof(Cooldown));
-        OnPropertyChanged(nameof(HasCooldown));
+        var now = _timeProvider.GetUtcNow();
+        var previousDuration = _spell.CooldownDuration;
+        _spell.CooldownDuration = duration;
+        _spell.CooldownUntil = duration > TimeSpan.Zero ? now + duration : null;
+        if (previousDuration != duration)
+        {
+            OnPropertyChanged(nameof(HasCooldownDuration));
+            OnPropertyChanged(nameof(CooldownDurationText));
+        }
+
+        return UpdateCooldown(now);
     }
-    
+
+    public bool TickCooldown() => UpdateCooldown(_timeProvider.GetUtcNow());
+    public void RefreshSprite() => OnPropertyChanged(nameof(SpriteImage));
+
     public override string ToString() => IsEmpty ? "<empty>" : Name;
+
+    private bool UpdateCooldown(DateTimeOffset now)
+    {
+        var cooldownText = CooldownFormatter.Format(_spell?.CooldownUntil, now);
+        var hasCooldown = !string.IsNullOrEmpty(cooldownText);
+        if (!hasCooldown && _spell is not null)
+        {
+            _spell.CooldownUntil = null;
+        }
+
+        if (!string.Equals(_cooldownText, cooldownText, StringComparison.Ordinal))
+        {
+            _cooldownText = cooldownText;
+            OnPropertyChanged(nameof(CooldownText));
+            OnPropertyChanged(nameof(Cooldown));
+        }
+
+        if (_hasCooldown != hasCooldown)
+        {
+            _hasCooldown = hasCooldown;
+            OnPropertyChanged(nameof(HasCooldown));
+            OnPropertyChanged(nameof(SpriteImage));
+        }
+
+        return hasCooldown;
+    }
 }

--- a/Arbiter.App/ViewModels/Player/PlayerSpellbookViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerSpellbookViewModel.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Arbiter.App.Collections;
 using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -10,6 +12,8 @@ namespace Arbiter.App.ViewModels.Player;
 public partial class PlayerSpellbookViewModel : ViewModelBase
 {
     private readonly ISlottedCollection<SpellbookItem> _spells;
+    private readonly IGameSpriteService _spriteService;
+    private readonly TimeProvider _timeProvider;
 
     [ObservableProperty] private PlayerSpellSlotViewModel? _selectedSpell;
 
@@ -18,22 +22,32 @@ public partial class PlayerSpellbookViewModel : ViewModelBase
     public ObservableCollection<PlayerSpellSlotViewModel> WorldSpells { get; } = [];
 
     public PlayerSpellbookViewModel(ISlottedCollection<SpellbookItem> spells)
+        : this(spells, NullGameSpriteService.Instance, TimeProvider.System)
+    {
+    }
+
+    public PlayerSpellbookViewModel(
+        ISlottedCollection<SpellbookItem> spells,
+        IGameSpriteService spriteService,
+        TimeProvider timeProvider)
     {
         _spells = spells;
+        _spriteService = spriteService;
+        _timeProvider = timeProvider;
 
         for (var i = 0; i < _spells.Capacity; i++)
         {
             if (i < 36)
             {
-                TemuairSpells.Add(new PlayerSpellSlotViewModel(i + 1));
+                TemuairSpells.Add(CreateSlot(i + 1));
             }
             else if (i < 72)
             {
-                MedeniaSpells.Add(new PlayerSpellSlotViewModel(i + 1));
+                MedeniaSpells.Add(CreateSlot(i + 1));
             }
             else
             {
-                WorldSpells.Add(new PlayerSpellSlotViewModel(i + 1));
+                WorldSpells.Add(CreateSlot(i + 1));
             }
         }
 
@@ -89,11 +103,11 @@ public partial class PlayerSpellbookViewModel : ViewModelBase
         return true;
     }
 
-    public void UpdateCooldown(int slot, TimeSpan duration)
+    public bool UpdateCooldown(int slot, TimeSpan duration)
     {
         if (slot < 1 || slot > _spells.Capacity)
         {
-            return;
+            return false;
         }
 
         var index = slot - 1;
@@ -104,7 +118,26 @@ public partial class PlayerSpellbookViewModel : ViewModelBase
             _ => WorldSpells[index - 72]
         };
         
-        vm.SetCooldown(duration);
+        return vm.SetCooldown(duration);
+    }
+
+    public bool TickCooldowns()
+    {
+        var hasCooldowns = false;
+        foreach (var spell in TemuairSpells.Concat(MedeniaSpells).Concat(WorldSpells))
+        {
+            hasCooldowns |= spell.TickCooldown();
+        }
+
+        return hasCooldowns;
+    }
+
+    public void RefreshSprites()
+    {
+        foreach (var spell in TemuairSpells.Concat(MedeniaSpells).Concat(WorldSpells))
+        {
+            spell.RefreshSprite();
+        }
     }
 
     private void OnSpellAdded(Slotted<SpellbookItem> spell)
@@ -151,14 +184,17 @@ public partial class PlayerSpellbookViewModel : ViewModelBase
         switch (slot - 1)
         {
             case < 36:
-                TemuairSpells[index] = new PlayerSpellSlotViewModel(slot, spell);
+                TemuairSpells[index] = CreateSlot(slot, spell);
                 break;
             case < 72:
-                MedeniaSpells[index] = new PlayerSpellSlotViewModel(slot, spell);
+                MedeniaSpells[index] = CreateSlot(slot, spell);
                 break;
             default:
-                WorldSpells[index] = new PlayerSpellSlotViewModel(slot, spell);
+                WorldSpells[index] = CreateSlot(slot, spell);
                 break;
         }
     }
+
+    private PlayerSpellSlotViewModel CreateSlot(int slot, SpellbookItem? spell = null) =>
+        new(slot, spell, _spriteService, _timeProvider);
 }

--- a/Arbiter.App/ViewModels/Player/PlayerViewModel.Observers.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerViewModel.Observers.cs
@@ -145,6 +145,7 @@ public partial class PlayerViewModel
         MaxHealth = message.MaxHealth ?? MaxHealth;
         CurrentMana = message.Mana ?? CurrentMana;
         MaxMana = message.MaxMana ?? MaxMana;
+        Gold = message.Gold ?? Gold;
     }
 
     #endregion
@@ -292,13 +293,6 @@ public partial class PlayerViewModel
     {
         var duration = TimeSpan.FromSeconds(message.Seconds);
 
-        if (message.AbilityType == AbilityType.Skill)
-        {
-            Skills.UpdateCooldown(message.Slot, duration);
-        }
-        else if (message.AbilityType == AbilityType.Spell)
-        {
-            Spells.UpdateCooldown(message.Slot, duration);
-        }
+        SetCooldown(message.AbilityType, message.Slot, duration);
     }
 }

--- a/Arbiter.App/ViewModels/Player/PlayerViewModel.cs
+++ b/Arbiter.App/ViewModels/Player/PlayerViewModel.cs
@@ -1,6 +1,9 @@
-﻿using System;
+using System;
 using Arbiter.App.Models.Player;
+using Arbiter.App.Services.Sprites;
 using Arbiter.Net.Proxy;
+using Arbiter.Net.Types;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Arbiter.App.ViewModels.Player;
@@ -8,6 +11,9 @@ namespace Arbiter.App.ViewModels.Player;
 public partial class PlayerViewModel : ViewModelBase
 {
     private readonly PlayerState _player;
+    private readonly IGameSpriteService _spriteService;
+    private readonly DispatcherTimer _cooldownTimer;
+    private bool _isSpriteServiceSubscribed;
 
     [ObservableProperty] [NotifyPropertyChangedFor(nameof(IsLoggedIn))]
     private long? _entityId;
@@ -54,6 +60,8 @@ public partial class PlayerViewModel : ViewModelBase
     [NotifyPropertyChangedFor(nameof(FormatedManaText))]
     private long _maxMana;
 
+    [ObservableProperty] private uint _gold;
+
     public bool IsLoggedIn => EntityId is not null;
 
     public string MapPosition => MapX.HasValue && MapY.HasValue ? $"{MapX}, {MapY}" : "?, ?";
@@ -96,24 +104,95 @@ public partial class PlayerViewModel : ViewModelBase
     public PlayerSpellbookViewModel Spells { get; }
 
     public PlayerViewModel(PlayerState player)
+        : this(player, NullGameSpriteService.Instance, TimeProvider.System)
+    {
+    }
+
+    public PlayerViewModel(
+        PlayerState player,
+        IGameSpriteService spriteService,
+        TimeProvider timeProvider)
     {
         _player = player;
+        _spriteService = spriteService;
+        _cooldownTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(250)
+        };
+        _cooldownTimer.Tick += OnCooldownTimerTick;
         
-        Inventory = new PlayerInventoryViewModel(player.Inventory);
-        Skills = new PlayerSkillbookViewModel(player.Skills);
-        Spells = new PlayerSpellbookViewModel(player.Spells);
+        Inventory = new PlayerInventoryViewModel(player.Inventory, spriteService);
+        Skills = new PlayerSkillbookViewModel(player.Skills, spriteService, timeProvider);
+        Spells = new PlayerSpellbookViewModel(player.Spells, spriteService, timeProvider);
     }
 
     public void Subscribe(ProxyConnection connection)
     {
         AddObservers(connection);
         AddVirtualFilters(connection);
+
+        if (!_isSpriteServiceSubscribed)
+        {
+            _spriteService.SpritesChanged += OnSpritesChanged;
+            _isSpriteServiceSubscribed = true;
+        }
     }
 
     public void Unsubscribe()
     {
+        _cooldownTimer.Stop();
+        if (_isSpriteServiceSubscribed)
+        {
+            _spriteService.SpritesChanged -= OnSpritesChanged;
+            _isSpriteServiceSubscribed = false;
+        }
+
         RemoveObservers();
         RemoveVirtualFilters();
+    }
+
+    private void SetCooldown(AbilityType abilityType, int slot, TimeSpan duration)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => SetCooldown(abilityType, slot, duration));
+            return;
+        }
+
+        var isActive = abilityType switch
+        {
+            AbilityType.Skill => Skills.UpdateCooldown(slot, duration),
+            AbilityType.Spell => Spells.UpdateCooldown(slot, duration),
+            _ => false
+        };
+
+        if (isActive && !_cooldownTimer.IsEnabled)
+        {
+            _cooldownTimer.Start();
+        }
+    }
+
+    private void OnCooldownTimerTick(object? sender, EventArgs e)
+    {
+        var hasSkillCooldowns = Skills.TickCooldowns();
+        var hasSpellCooldowns = Spells.TickCooldowns();
+        if (!hasSkillCooldowns && !hasSpellCooldowns)
+        {
+            _cooldownTimer.Stop();
+        }
+    }
+
+    private void OnSpritesChanged(object? sender, EventArgs e)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => OnSpritesChanged(sender, e));
+            return;
+        }
+
+        Inventory.RefreshSprites();
+        Skills.RefreshSprites();
+        Spells.RefreshSprites();
     }
 
     // Forward all property changes to the player model
@@ -129,6 +208,11 @@ public partial class PlayerViewModel : ViewModelBase
     partial void OnMaxHealthChanged(long value) => _player.MaxHealth = value;
     partial void OnCurrentManaChanged(long value) => _player.CurrentMana = value;
     partial void OnMaxManaChanged(long value) => _player.MaxMana = value;
+    partial void OnGoldChanged(uint value)
+    {
+        _player.Gold = value;
+        Inventory.SetGold(value);
+    }
 
     private static string FormatHealthManaValue(long value)
     {

--- a/Arbiter.App/Views/PlayerInventoryView.axaml
+++ b/Arbiter.App/Views/PlayerInventoryView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:Arbiter.App.ViewModels.Player"
+             xmlns:controls="using:Arbiter.App.Controls"
              mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="320"
              x:Class="Arbiter.App.Views.PlayerInventoryView"
              x:DataType="vm:PlayerInventoryViewModel">
@@ -33,40 +34,32 @@
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <Border Width="48" Height="48"
+                            Classes="sprite-slot"
                             Background="Transparent"
                             BorderBrush="{StaticResource Talgonite.Border.HighlightBrush}"
                             BorderThickness="1"
                             ToolTip.Placement="Pointer"
                             IsEnabled="{Binding !IsEmpty}">
-                        <Grid>
-                            <Border Background="{StaticResource Talgonite.Border.ShadowBrush}"
-                                    IsVisible="{Binding IsEmpty}"/>
-                            <!-- Slot Number -->
-                            <TextBlock Text="{Binding Slot}"
-                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                       FontSize="12"
-                                       Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
-                                       HorizontalAlignment="Left"
-                                       VerticalAlignment="Top"
-                                       Margin="4,2"/>
-                   
-                            <!-- Sprite Number -->
-                            <TextBlock Text="{Binding Sprite}"
-                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       IsVisible="{Binding !IsEmpty}"/>
-
-                        </Grid>
+                        <controls:SpritePresenter Source="{Binding SpriteImage}"
+                                                  SlotText="{Binding Slot}"
+                                                  FallbackText="{Binding SpriteFallbackText}"
+                                                  IsEmpty="{Binding IsEmpty}"
+                                                  DetailText="{Binding DetailText}"
+                                                  SpriteStretchDirection="DownOnly"/>
                         <!-- Tooltip -->
                         <ToolTip.Tip>
                             <Border Padding="4">
-                                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto"
+                                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto"
                                           RowSpacing="4" ColumnSpacing="8"
                                           MinWidth="200">
                                         <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                                            <!-- Icon -->
+                                            <controls:SpritePresenter Width="36" Height="36"
+                                                                      Source="{Binding SpriteImage}"
+                                                                      FallbackText="{Binding SpriteFallbackText}"
+                                                                      IsEmpty="{Binding IsEmpty}"
+                                                                      SpriteStretchDirection="DownOnly"/>
+
                                             <!-- Name -->
                                             <TextBlock Text="{Binding Name}"
                                                        Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
@@ -76,12 +69,12 @@
                                                        VerticalAlignment="Center"/>
                                             
                                             <!-- Quantity -->
-                                            <TextBlock Text="{Binding Quantity, StringFormat={}[{0}]}"
+                                            <TextBlock Text="{Binding QuantityDisplayText}"
                                                        Foreground="{StaticResource Talgonite.Color.LightGray}"
                                                        FontSize="16"
                                                        FontFamily="{StaticResource Talgonite.Font.Monospace}"
                                                        VerticalAlignment="Center"
-                                                       IsVisible="{Binding IsStackable}"/>
+                                                       IsVisible="{Binding ShowsQuantity}"/>
                                         </StackPanel>
 
                                         
@@ -107,7 +100,7 @@
                                                    VerticalAlignment="Center"/>
                                         
                                         <!-- Durability -->
-                                        <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
+                                        <TextBlock Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                                                    Foreground="{StaticResource Talgonite.Color.LightBlue}"
                                                    FontSize="14"
                                                    FontFamily="{StaticResource Talgonite.Font.Monospace}"
@@ -122,13 +115,22 @@
                                         </TextBlock>
                                         
                                         <!-- Virtual Item -->
-                                        <TextBlock Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                                        <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                                                    Text="Virtual Item"
                                                    Foreground="{StaticResource Talgonite.Color.LightYellow}"
                                                    FontSize="14"
                                                    FontFamily="{StaticResource Talgonite.Font.Monospace}"
                                                    VerticalAlignment="Center"
                                                    IsVisible="{Binding IsVirtual}"/>
+
+                                        <!-- Gold -->
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
+                                                   Text="{Binding GoldAmountText}"
+                                                   Foreground="{StaticResource Talgonite.Color.LightYellow}"
+                                                   FontSize="14"
+                                                   FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                                   VerticalAlignment="Center"
+                                                   IsVisible="{Binding IsGold}"/>
                                     </Grid>
                                 </Border>
                         </ToolTip.Tip>

--- a/Arbiter.App/Views/PlayerSkillbookView.axaml
+++ b/Arbiter.App/Views/PlayerSkillbookView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:Arbiter.App.ViewModels.Player"
+             xmlns:controls="using:Arbiter.App.Controls"
              mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="640"
              x:Class="Arbiter.App.Views.PlayerSkillbookView"
              x:DataType="vm:PlayerSkillbookViewModel">
@@ -14,33 +15,18 @@
     <UserControl.DataTemplates>
         <DataTemplate DataType="vm:PlayerSkillSlotViewModel">
             <Border Width="48" Height="48"
+                            Classes="sprite-slot"
                             Background="Transparent"
                             BorderBrush="{StaticResource Talgonite.Border.HighlightBrush}"
                             BorderThickness="1"
                             ToolTip.Placement="Pointer"
                             IsEnabled="{Binding !IsEmpty}">
-                        <Grid>
-                            <Border Background="{StaticResource Talgonite.Border.ShadowBrush}"
-                                    IsVisible="{Binding IsEmpty}"/>
-                            <!-- Slot Number -->
-                            <TextBlock Text="{Binding RelativeSlot}"
-                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                       FontSize="12"
-                                       Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
-                                       HorizontalAlignment="Left"
-                                       VerticalAlignment="Top"
-                                       Margin="4,2"/>
-                   
-                            <!-- Sprite Number -->
-                            <TextBlock Text="{Binding Sprite}"
-                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       IsVisible="{Binding !IsEmpty}"/>
-
-                        </Grid>
+                        <controls:SpritePresenter Source="{Binding SpriteImage}"
+                                                  SlotText="{Binding RelativeSlot}"
+                                                  FallbackText="{Binding SpriteFallbackText}"
+                                                  IsEmpty="{Binding IsEmpty}"
+                                                  IsCooldownActive="{Binding HasCooldown}"
+                                                  CooldownText="{Binding CooldownText}"/>
                         <!-- Tooltip -->
                         <ToolTip.Tip>
                             <Border Padding="4">
@@ -48,6 +34,12 @@
                                           RowSpacing="4" ColumnSpacing="8"
                                           MinWidth="200">
                                         <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                                            <!-- Icon -->
+                                            <controls:SpritePresenter Width="36" Height="36"
+                                                                      Source="{Binding SpriteImage}"
+                                                                      FallbackText="{Binding SpriteFallbackText}"
+                                                                      IsEmpty="{Binding IsEmpty}"/>
+
                                             <!-- Name -->
                                             <TextBlock Text="{Binding Name}"
                                                        Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
@@ -98,11 +90,10 @@
                                                    FontSize="14"
                                                    FontFamily="{StaticResource Talgonite.Font.Monospace}"
                                                    VerticalAlignment="Center"
-                                                   IsVisible="{Binding HasCooldown}">
+                                                   IsVisible="{Binding HasCooldownDuration}">
                                             <Span>
                                                 <Run Text="Cooldown:" FontWeight="SemiBold"/>
-                                                <Run Text="{Binding Cooldown.TotalSeconds, StringFormat={}{0}}"/>
-                                                <Run Text="seconds"/>
+                                                <Run Text="{Binding CooldownDurationText}"/>
                                             </Span>
                                         </TextBlock>
                                         

--- a/Arbiter.App/Views/PlayerSpellbookView.axaml
+++ b/Arbiter.App/Views/PlayerSpellbookView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:Arbiter.App.ViewModels.Player"
+             xmlns:controls="using:Arbiter.App.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="700"
              x:Class="Arbiter.App.Views.PlayerSpellbookView"
              x:DataType="vm:PlayerSpellbookViewModel">
@@ -13,33 +14,18 @@
     <UserControl.DataTemplates>
         <DataTemplate DataType="vm:PlayerSpellSlotViewModel">
             <Border Width="48" Height="48"
+                            Classes="sprite-slot"
                             Background="Transparent"
                             BorderBrush="{StaticResource Talgonite.Border.HighlightBrush}"
                             BorderThickness="1"
                             ToolTip.Placement="Pointer"
                             IsEnabled="{Binding !IsEmpty}">
-                        <Grid>
-                            <Border Background="{StaticResource Talgonite.Border.ShadowBrush}"
-                                    IsVisible="{Binding IsEmpty}"/>
-                            <!-- Slot Number -->
-                            <TextBlock Text="{Binding RelativeSlot}"
-                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                       FontSize="12"
-                                       Foreground="{StaticResource Talgonite.TextBlock.DimForeground}"
-                                       HorizontalAlignment="Left"
-                                       VerticalAlignment="Top"
-                                       Margin="4,2"/>
-                   
-                            <!-- Sprite Number -->
-                            <TextBlock Text="{Binding Sprite}"
-                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       IsVisible="{Binding !IsEmpty}"/>
-
-                        </Grid>
+                        <controls:SpritePresenter Source="{Binding SpriteImage}"
+                                                  SlotText="{Binding RelativeSlot}"
+                                                  FallbackText="{Binding SpriteFallbackText}"
+                                                  IsEmpty="{Binding IsEmpty}"
+                                                  IsCooldownActive="{Binding HasCooldown}"
+                                                  CooldownText="{Binding CooldownText}"/>
                         <!-- Tooltip -->
                         <ToolTip.Tip>
                             <Border Padding="4">
@@ -47,6 +33,12 @@
                                           RowSpacing="4" ColumnSpacing="8"
                                           MinWidth="200">
                                         <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                                            <!-- Icon -->
+                                            <controls:SpritePresenter Width="36" Height="36"
+                                                                      Source="{Binding SpriteImage}"
+                                                                      FallbackText="{Binding SpriteFallbackText}"
+                                                                      IsEmpty="{Binding IsEmpty}"/>
+
                                             <!-- Name -->
                                             <TextBlock Text="{Binding Name}"
                                                        Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
@@ -117,11 +109,10 @@
                                                    FontSize="14"
                                                    FontFamily="{StaticResource Talgonite.Font.Monospace}"
                                                    VerticalAlignment="Center"
-                                                   IsVisible="{Binding HasCooldown}">
+                                                   IsVisible="{Binding HasCooldownDuration}">
                                             <Span>
                                                 <Run Text="Cooldown:" FontWeight="SemiBold"/>
-                                                <Run Text="{Binding Cooldown.TotalSeconds, StringFormat={}{0}}"/>
-                                                <Run Text="seconds"/>
+                                                <Run Text="{Binding CooldownDurationText}"/>
                                             </Span>
                                         </TextBlock>
                                         

--- a/Arbiter.IO.Tests/Arbiter.IO.Tests.csproj
+++ b/Arbiter.IO.Tests/Arbiter.IO.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Arbiter.IO\Arbiter.IO.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Arbiter.IO.Tests/Archives/DatArchiveTests.cs
+++ b/Arbiter.IO.Tests/Archives/DatArchiveTests.cs
@@ -1,0 +1,69 @@
+using Arbiter.IO.Archives;
+
+namespace Arbiter.IO.Tests.Archives;
+
+public sealed class DatArchiveTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Arbiter.IO.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(_directory, true);
+    }
+
+    [Test]
+    public void Should_Read_Entries_Through_Bounded_Streams()
+    {
+        var path = MockDatArchive.Write(
+            _directory,
+            "mock.dat",
+            ("first.bin", [1, 2, 3]),
+            ("second.bin", [4, 5, 6, 7]));
+
+        var archive = DatArchive.Open(path);
+        using var stream = archive.OpenRead(archive.Entries[0]);
+        var bytes = new byte[10];
+        var bytesRead = stream.Read(bytes);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(archive.Entries.Select(entry => entry.Name), Is.EqualTo(new[] { "first.bin", "second.bin" }));
+            Assert.That(stream.Length, Is.EqualTo(3));
+            Assert.That(bytesRead, Is.EqualTo(3));
+            Assert.That(bytes[..bytesRead], Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(stream.ReadByte(), Is.EqualTo(-1));
+        });
+    }
+
+    [Test]
+    public void Should_Seek_Only_Inside_An_Entry()
+    {
+        var path = MockDatArchive.Write(_directory, "mock.dat", ("value.bin", [10, 20, 30]));
+        var archive = DatArchive.Open(path);
+        using var stream = archive.OpenRead(archive.Entries[0]);
+
+        stream.Seek(-1, SeekOrigin.End);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stream.ReadByte(), Is.EqualTo(30));
+            Assert.That(() => stream.Seek(1, SeekOrigin.End), Throws.TypeOf<IOException>());
+        });
+    }
+
+    [Test]
+    public void Should_Reject_Archive_Entries_Outside_File_Bounds()
+    {
+        var path = MockDatArchive.WriteInvalidRange(_directory, "invalid.dat");
+
+        Assert.That(() => DatArchive.Open(path), Throws.TypeOf<InvalidDataException>());
+    }
+}

--- a/Arbiter.IO.Tests/Archives/MockDatArchive.cs
+++ b/Arbiter.IO.Tests/Archives/MockDatArchive.cs
@@ -1,0 +1,50 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Arbiter.IO.Tests.Archives;
+
+internal static class MockDatArchive
+{
+    private const int HeaderSize = sizeof(uint);
+    private const int TableEntrySize = sizeof(uint) + 13;
+
+    public static string Write(string directory, string fileName, params (string Name, byte[] Data)[] entries)
+    {
+        var path = Path.Combine(directory, fileName);
+        var tableEntryCount = entries.Length + 1;
+        var dataOffset = HeaderSize + tableEntryCount * TableEntrySize;
+        var bytes = new byte[dataOffset + entries.Sum(entry => entry.Data.Length)];
+
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, (uint)tableEntryCount);
+        var currentOffset = dataOffset;
+        for (var index = 0; index < entries.Length; index++)
+        {
+            WriteTableEntry(bytes, index, currentOffset, entries[index].Name);
+            entries[index].Data.CopyTo(bytes, currentOffset);
+            currentOffset += entries[index].Data.Length;
+        }
+
+        WriteTableEntry(bytes, entries.Length, currentOffset, string.Empty);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    public static string WriteInvalidRange(string directory, string fileName)
+    {
+        var path = Path.Combine(directory, fileName);
+        var bytes = new byte[HeaderSize + 2 * TableEntrySize];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, 2);
+        WriteTableEntry(bytes, 0, bytes.Length + 1, "bad.bin");
+        WriteTableEntry(bytes, 1, bytes.Length, string.Empty);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static void WriteTableEntry(byte[] destination, int index, int offset, string name)
+    {
+        var baseOffset = HeaderSize + index * TableEntrySize;
+        BinaryPrimitives.WriteUInt32LittleEndian(destination.AsSpan(baseOffset), (uint)offset);
+        var nameBytes = Encoding.ASCII.GetBytes(name);
+        nameBytes.AsSpan(0, Math.Min(nameBytes.Length, 13)).CopyTo(destination.AsSpan(baseOffset + 4, 13));
+    }
+}

--- a/Arbiter.IO.Tests/Assets/DatAssetCatalogTests.cs
+++ b/Arbiter.IO.Tests/Assets/DatAssetCatalogTests.cs
@@ -1,0 +1,57 @@
+using Arbiter.IO.Assets;
+using Arbiter.IO.Tests.Archives;
+
+namespace Arbiter.IO.Tests.Assets;
+
+public sealed class DatAssetCatalogTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Arbiter.IO.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(_directory, true);
+    }
+
+    [Test]
+    public void Should_Prefer_Assets_From_Later_Archives()
+    {
+        MockDatArchive.Write(_directory, "a.dat", ("sprite.epf", [1]));
+        MockDatArchive.Write(_directory, "b.dat", ("sprite.epf", [2]));
+
+        var catalog = DatAssetCatalog.Load(_directory);
+        var found = catalog.TryGet("SPRITE.EPF", out var asset);
+        using var stream = asset!.OpenRead();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.True);
+            Assert.That(asset.ArchiveName, Is.EqualTo("b.dat"));
+            Assert.That(stream.ReadByte(), Is.EqualTo(2));
+            Assert.That(catalog.GetAll("sprite.epf").Select(value => value.ArchiveName),
+                Is.EqualTo(new[] { "a.dat", "b.dat" }));
+        });
+    }
+
+    [Test]
+    public void Should_Ignore_Non_Dat_Files()
+    {
+        MockDatArchive.Write(_directory, "assets.dat", ("value.bin", [1]));
+        File.WriteAllBytes(Path.Combine(_directory, "ignored.bin"), [2]);
+
+        var catalog = DatAssetCatalog.Load(_directory);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(catalog.Archives, Has.Count.EqualTo(1));
+            Assert.That(catalog.Names, Is.EquivalentTo(new[] { "value.bin" }));
+        });
+    }
+}

--- a/Arbiter.IO/Arbiter.IO.csproj
+++ b/Arbiter.IO/Arbiter.IO.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <Company>Erik 'SiLo' Rogers</Company>
+        <Product>Arbiter IO Library</Product>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <FileVersion>1.0.0</FileVersion>
+    </PropertyGroup>
+
+</Project>

--- a/Arbiter.IO/Archives/ArchiveEntryStream.cs
+++ b/Arbiter.IO/Archives/ArchiveEntryStream.cs
@@ -1,0 +1,99 @@
+namespace Arbiter.IO.Archives;
+
+internal sealed class ArchiveEntryStream : Stream
+{
+    private readonly FileStream _stream;
+    private readonly long _start;
+    private readonly long _length;
+    private long _position;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => _length;
+
+    public override long Position
+    {
+        get => _position;
+        set => Seek(value, SeekOrigin.Begin);
+    }
+
+    public ArchiveEntryStream(string filePath, long offset, long length)
+    {
+        _stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        _start = offset;
+        _length = length;
+        _stream.Position = _start;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        if (offset > buffer.Length - count)
+        {
+            throw new ArgumentException("The buffer range is invalid.");
+        }
+
+        var bytesToRead = (int)Math.Min(count, _length - _position);
+        if (bytesToRead <= 0)
+        {
+            return 0;
+        }
+
+        var bytesRead = _stream.Read(buffer, offset, bytesToRead);
+        _position += bytesRead;
+        return bytesRead;
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        var bytesToRead = (int)Math.Min(buffer.Length, _length - _position);
+        if (bytesToRead <= 0)
+        {
+            return 0;
+        }
+
+        var bytesRead = _stream.Read(buffer[..bytesToRead]);
+        _position += bytesRead;
+        return bytesRead;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        var target = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => checked(_position + offset),
+            SeekOrigin.End => checked(_length + offset),
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+
+        if (target < 0 || target > _length)
+        {
+            throw new IOException("Cannot seek outside the archive entry bounds.");
+        }
+
+        _stream.Position = checked(_start + target);
+        _position = target;
+        return _position;
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _stream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/Arbiter.IO/Archives/DatArchive.cs
+++ b/Arbiter.IO/Archives/DatArchive.cs
@@ -1,0 +1,99 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Arbiter.IO.Archives;
+
+public sealed class DatArchive
+{
+    private const int HeaderSize = sizeof(uint);
+    private const int TableEntrySize = sizeof(uint) + NameLength;
+    private const int NameLength = 13;
+
+    private readonly IReadOnlyList<DatArchiveEntry> _entries;
+
+    public string FilePath { get; }
+    public string Name => Path.GetFileName(FilePath);
+    public IReadOnlyList<DatArchiveEntry> Entries => _entries;
+
+    private DatArchive(string filePath, IReadOnlyList<DatArchiveEntry> entries)
+    {
+        FilePath = filePath;
+        _entries = entries;
+    }
+
+    public static DatArchive Open(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        if (stream.Length < HeaderSize)
+        {
+            throw new InvalidDataException($"Archive '{filePath}' is too small for a header.");
+        }
+
+        Span<byte> header = stackalloc byte[HeaderSize];
+        stream.ReadExactly(header);
+        var tableEntryCount = BinaryPrimitives.ReadUInt32LittleEndian(header);
+        if (tableEntryCount == 0)
+        {
+            throw new InvalidDataException($"Archive '{filePath}' does not contain an end marker.");
+        }
+
+        var tableLength = checked((long)tableEntryCount * TableEntrySize);
+        var tableEnd = checked(HeaderSize + tableLength);
+        if (tableEnd > stream.Length)
+        {
+            throw new InvalidDataException($"Archive '{filePath}' table exceeds the file bounds.");
+        }
+
+        var tableBytes = new byte[checked((int)tableLength)];
+        stream.ReadExactly(tableBytes);
+
+        var entries = new List<DatArchiveEntry>(checked((int)tableEntryCount - 1));
+        for (var index = 0; index < tableEntryCount - 1; index++)
+        {
+            var currentOffset = ReadOffset(tableBytes, index);
+            var nextOffset = ReadOffset(tableBytes, index + 1);
+            if (currentOffset < tableEnd || nextOffset < currentOffset || nextOffset > stream.Length)
+            {
+                throw new InvalidDataException(
+                    $"Archive '{filePath}' entry {index} has an invalid range {currentOffset}..{nextOffset}.");
+            }
+
+            var nameOffset = checked((int)index * TableEntrySize + sizeof(uint));
+            var nameBytes = tableBytes.AsSpan(nameOffset, NameLength);
+            var terminator = nameBytes.IndexOf((byte)0);
+            if (terminator >= 0)
+            {
+                nameBytes = nameBytes[..terminator];
+            }
+
+            var name = Encoding.ASCII.GetString(nameBytes);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new InvalidDataException($"Archive '{filePath}' entry {index} has an empty name.");
+            }
+
+            entries.Add(new DatArchiveEntry(name, currentOffset, nextOffset - currentOffset));
+        }
+
+        return new DatArchive(Path.GetFullPath(filePath), entries);
+    }
+
+    public Stream OpenRead(DatArchiveEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        if (!_entries.Contains(entry))
+        {
+            throw new ArgumentException("The entry does not belong to this archive.", nameof(entry));
+        }
+
+        return new ArchiveEntryStream(FilePath, entry.Offset, entry.Length);
+    }
+
+    private static long ReadOffset(ReadOnlySpan<byte> table, int index)
+    {
+        var offset = checked((int)index * TableEntrySize);
+        return BinaryPrimitives.ReadUInt32LittleEndian(table.Slice(offset, sizeof(uint)));
+    }
+}

--- a/Arbiter.IO/Archives/DatArchiveEntry.cs
+++ b/Arbiter.IO/Archives/DatArchiveEntry.cs
@@ -1,0 +1,3 @@
+namespace Arbiter.IO.Archives;
+
+public sealed record DatArchiveEntry(string Name, long Offset, long Length);

--- a/Arbiter.IO/Assets/DatAsset.cs
+++ b/Arbiter.IO/Assets/DatAsset.cs
@@ -1,0 +1,21 @@
+using Arbiter.IO.Archives;
+
+namespace Arbiter.IO.Assets;
+
+public sealed class DatAsset
+{
+    private readonly DatArchive _archive;
+    private readonly DatArchiveEntry _entry;
+
+    public string Name => _entry.Name;
+    public string ArchiveName => _archive.Name;
+    public long Length => _entry.Length;
+
+    internal DatAsset(DatArchive archive, DatArchiveEntry entry)
+    {
+        _archive = archive;
+        _entry = entry;
+    }
+
+    public Stream OpenRead() => _archive.OpenRead(_entry);
+}

--- a/Arbiter.IO/Assets/DatAssetCatalog.cs
+++ b/Arbiter.IO/Assets/DatAssetCatalog.cs
@@ -1,0 +1,77 @@
+using Arbiter.IO.Archives;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Arbiter.IO.Assets;
+
+public sealed class DatAssetCatalog
+{
+    private readonly Dictionary<string, DatAsset> _assets;
+    private readonly Dictionary<string, IReadOnlyList<DatAsset>> _variants;
+
+    public string DirectoryPath { get; }
+    public IReadOnlyCollection<string> Names => _assets.Keys;
+    public IReadOnlyList<DatArchive> Archives { get; }
+
+    private DatAssetCatalog(
+        string directoryPath,
+        IReadOnlyList<DatArchive> archives,
+        Dictionary<string, DatAsset> assets,
+        Dictionary<string, IReadOnlyList<DatAsset>> variants)
+    {
+        DirectoryPath = directoryPath;
+        Archives = archives;
+        _assets = assets;
+        _variants = variants;
+    }
+
+    public static DatAssetCatalog Load(string directoryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPath);
+
+        var fullPath = Path.GetFullPath(directoryPath);
+        var archivePaths = Directory.EnumerateFiles(fullPath)
+            .Where(path => string.Equals(Path.GetExtension(path), ".dat", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var archives = archivePaths.Select(DatArchive.Open).ToArray();
+        var assets = new Dictionary<string, DatAsset>(StringComparer.OrdinalIgnoreCase);
+        var variantLists = new Dictionary<string, List<DatAsset>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var archive in archives)
+        {
+            foreach (var entry in archive.Entries)
+            {
+                var asset = new DatAsset(archive, entry);
+                assets[entry.Name] = asset;
+
+                if (!variantLists.TryGetValue(entry.Name, out var variants))
+                {
+                    variants = [];
+                    variantLists.Add(entry.Name, variants);
+                }
+
+                variants.Add(asset);
+            }
+        }
+
+        var readOnlyVariants = variantLists.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyList<DatAsset>)pair.Value,
+            StringComparer.OrdinalIgnoreCase);
+
+        return new DatAssetCatalog(fullPath, archives, assets, readOnlyVariants);
+    }
+
+    public bool TryGet(string name, [NotNullWhen(true)] out DatAsset? asset)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _assets.TryGetValue(name, out asset);
+    }
+
+    public IReadOnlyList<DatAsset> GetAll(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _variants.GetValueOrDefault(name) ?? [];
+    }
+}

--- a/Arbiter.Imaging.Tests/Arbiter.Imaging.Tests.csproj
+++ b/Arbiter.Imaging.Tests/Arbiter.Imaging.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Arbiter.Imaging\Arbiter.Imaging.csproj" />
+        <ProjectReference Include="..\Arbiter.IO\Arbiter.IO.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Arbiter.Imaging.Tests/Formats/EpfFileTests.cs
+++ b/Arbiter.Imaging.Tests/Formats/EpfFileTests.cs
@@ -1,0 +1,31 @@
+using System.Buffers.Binary;
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Tests.Formats;
+
+public sealed class EpfFileTests
+{
+    [Test]
+    public void Should_Parse_Frames_And_Empty_Frame_Entries()
+    {
+        var epf = EpfFile.Parse(TestImageData.Epf(2, 1, [1, 2], null));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(epf.PixelWidth, Is.EqualTo(2));
+            Assert.That(epf.PixelHeight, Is.EqualTo(1));
+            Assert.That(epf.Frames, Has.Count.EqualTo(2));
+            Assert.That(epf.Frames[0]!.Pixels.ToArray(), Is.EqualTo(new byte[] { 1, 2 }));
+            Assert.That(epf.Frames[1], Is.Null);
+        });
+    }
+
+    [Test]
+    public void Should_Reject_Frame_Data_Outside_The_File()
+    {
+        var bytes = TestImageData.Epf(1, 1, [1]);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(bytes.Length - 8), uint.MaxValue);
+
+        Assert.That(() => EpfFile.Parse(bytes), Throws.TypeOf<OverflowException>().Or.TypeOf<InvalidDataException>());
+    }
+}

--- a/Arbiter.Imaging.Tests/Formats/PaletteTests.cs
+++ b/Arbiter.Imaging.Tests/Formats/PaletteTests.cs
@@ -1,0 +1,23 @@
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Tests.Formats;
+
+public sealed class PaletteTests
+{
+    [Test]
+    public void Should_Treat_Palette_Index_Zero_As_Transparent()
+    {
+        var palette = Palette.Parse(TestImageData.Palette((0, 255, 255, 255)));
+        Span<byte> rgba = stackalloc byte[4];
+
+        palette.GetColor(0, false, rgba);
+
+        Assert.That(rgba.ToArray(), Is.EqualTo(new byte[] { 0, 0, 0, 0 }));
+    }
+
+    [Test]
+    public void Should_Reject_Palettes_With_The_Wrong_Size()
+    {
+        Assert.That(() => Palette.Parse(new byte[10]), Throws.TypeOf<InvalidDataException>());
+    }
+}

--- a/Arbiter.Imaging.Tests/Sprites/GameSpriteDataLoaderTests.cs
+++ b/Arbiter.Imaging.Tests/Sprites/GameSpriteDataLoaderTests.cs
@@ -1,0 +1,42 @@
+using Arbiter.Imaging.Sprites;
+
+namespace Arbiter.Imaging.Tests.Sprites;
+
+public sealed class GameSpriteDataLoaderTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Arbiter.Imaging.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(_directory, true);
+    }
+
+    [Test]
+    public void Should_Load_Available_Families_And_Report_Missing_Ones()
+    {
+        TestImageData.WriteDat(
+            _directory,
+            "mock.dat",
+            ("skill001.epf", TestImageData.Epf(1, 1, [1])),
+            ("gui06.pal", TestImageData.Palette((1, 100, 150, 200))));
+
+        var data = GameSpriteDataLoader.Load(_directory);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(data.Skills, Is.Not.Null);
+            Assert.That(data.SkillsOnCooldown, Is.Not.Null);
+            Assert.That(data.Spells, Is.Null);
+            Assert.That(data.Items, Is.Null);
+            Assert.That(data.Issues.Select(issue => issue.Category), Is.EquivalentTo(new[] { "spells", "items" }));
+        });
+    }
+}

--- a/Arbiter.Imaging.Tests/Sprites/ItemSpriteAtlasLoaderTests.cs
+++ b/Arbiter.Imaging.Tests/Sprites/ItemSpriteAtlasLoaderTests.cs
@@ -1,0 +1,96 @@
+using Arbiter.IO.Assets;
+using Arbiter.Imaging.Sprites;
+
+namespace Arbiter.Imaging.Tests.Sprites;
+
+public sealed class ItemSpriteAtlasLoaderTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Arbiter.Imaging.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(_directory, true);
+    }
+
+    [Test]
+    public void Should_Map_Item_Ranges_And_Prefer_Legend_Archive_Variants()
+    {
+        var palette = TestImageData.Palette((1, 200, 10, 20), (2, 10, 200, 20));
+        TestImageData.WriteDat(
+            _directory,
+            "Legend.dat",
+            ("item001.epf", TestImageData.Epf(1, 1, [1])),
+            ("item000.pal", palette),
+            ("itempal.tbl", TestImageData.Text("1 1 0\n")));
+        TestImageData.WriteDat(
+            _directory,
+            "setoa.dat",
+            ("item001.epf", TestImageData.Epf(1, 1, [2])));
+
+        var items = ItemSpriteAtlasLoader.Load(DatAssetCatalog.Load(_directory));
+        var atlas = items.Atlases.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(atlas.FirstItemId, Is.EqualTo(1));
+            Assert.That(atlas.LastItemId, Is.EqualTo(1));
+            Assert.That(atlas.BaseAtlas.SourceImageName, Does.Contain("Legend.dat"));
+            Assert.That(atlas.BaseAtlas.Pixels.ToArray(), Is.EqualTo(new byte[] { 200, 10, 20, 255 }));
+            Assert.That(items.Find(1), Is.SameAs(atlas));
+            Assert.That(items.Find(267), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Should_Build_Dyed_Item_Variants_From_Mock_Tables()
+    {
+        var palette = TestImageData.Palette(
+            (98, 10, 10, 10),
+            (99, 20, 20, 20),
+            (100, 30, 30, 30),
+            (101, 40, 40, 40),
+            (102, 50, 50, 50),
+            (103, 60, 60, 60));
+        const string dyeTable = """
+                                6
+                                0
+                                10,10,10
+                                20,20,20
+                                30,30,30
+                                40,40,40
+                                50,50,50
+                                60,60,60
+                                1
+                                200,100,50
+                                201,101,51
+                                202,102,52
+                                203,103,53
+                                204,104,54
+                                205,105,55
+                                """;
+        TestImageData.WriteDat(
+            _directory,
+            "mock.dat",
+            ("item001.epf", TestImageData.Epf(1, 1, [98])),
+            ("item000.pal", palette),
+            ("itempal.tbl", TestImageData.Text("1 1 0\n")),
+            ("color0.tbl", TestImageData.Text(dyeTable)));
+
+        var atlas = ItemSpriteAtlasLoader.Load(DatAssetCatalog.Load(_directory)).Atlases.Single();
+        var variant = atlas.BuildColorVariant(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(atlas.BaseAtlas.Pixels.ToArray(), Is.EqualTo(new byte[] { 10, 10, 10, 255 }));
+            Assert.That(variant.Pixels.ToArray(), Is.EqualTo(new byte[] { 200, 100, 50, 255 }));
+        });
+    }
+}

--- a/Arbiter.Imaging.Tests/Sprites/SpriteAtlasTests.cs
+++ b/Arbiter.Imaging.Tests/Sprites/SpriteAtlasTests.cs
@@ -1,0 +1,68 @@
+using Arbiter.IO.Assets;
+using Arbiter.Imaging.Sprites;
+
+namespace Arbiter.Imaging.Tests.Sprites;
+
+public sealed class SpriteAtlasTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Arbiter.Imaging.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(_directory, true);
+    }
+
+    [Test]
+    public void Should_Resolve_One_Based_Icons_When_The_Direct_Frame_Is_Empty()
+    {
+        TestImageData.WriteDat(
+            _directory,
+            "mock.dat",
+            ("skill001.epf", TestImageData.Epf(1, 1, [1], null)),
+            ("gui06.pal", TestImageData.Palette((1, 100, 150, 200))));
+        var atlas = SpriteAtlasLoader.LoadNamed(
+            DatAssetCatalog.Load(_directory),
+            SpriteAtlasLoader.DefaultSkillImageName,
+            SpriteAtlasLoader.DefaultGuiPaletteName);
+
+        var found = atlas.TryResolveIcon(1, out var frameIndex, out var region);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.True);
+            Assert.That(frameIndex, Is.Zero);
+            Assert.That(region, Is.EqualTo(new SpriteAtlasRegion(0, 0, 1, 1)));
+        });
+    }
+
+    [Test]
+    public void Should_Apply_Grayscale_And_Blue_Tint_Without_Changing_Alpha()
+    {
+        TestImageData.WriteDat(
+            _directory,
+            "mock.dat",
+            ("skill001.epf", TestImageData.Epf(1, 1, [1])),
+            ("gui06.pal", TestImageData.Palette((1, 100, 150, 200))));
+        var atlas = SpriteAtlasLoader.LoadNamed(
+            DatAssetCatalog.Load(_directory),
+            SpriteAtlasLoader.DefaultSkillImageName,
+            SpriteAtlasLoader.DefaultGuiPaletteName);
+
+        var grayscale = SpriteAtlasTransforms.Grayscale(atlas);
+        var tinted = SpriteAtlasTransforms.Tint(grayscale, 147, 189, 255);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(grayscale.Pixels.ToArray(), Is.EqualTo(new byte[] { 141, 141, 141, 255 }));
+            Assert.That(tinted.Pixels.ToArray(), Is.EqualTo(new byte[] { 81, 105, 141, 255 }));
+        });
+    }
+}

--- a/Arbiter.Imaging.Tests/TestImageData.cs
+++ b/Arbiter.Imaging.Tests/TestImageData.cs
@@ -1,0 +1,89 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Arbiter.Imaging.Tests;
+
+internal static class TestImageData
+{
+    private const int DatHeaderSize = sizeof(uint);
+    private const int DatTableEntrySize = sizeof(uint) + 13;
+
+    public static string WriteDat(string directory, string name, params (string Name, byte[] Data)[] assets)
+    {
+        var path = Path.Combine(directory, name);
+        var tableEntryCount = assets.Length + 1;
+        var dataOffset = DatHeaderSize + tableEntryCount * DatTableEntrySize;
+        var bytes = new byte[dataOffset + assets.Sum(asset => asset.Data.Length)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, (uint)tableEntryCount);
+
+        var currentOffset = dataOffset;
+        for (var index = 0; index < assets.Length; index++)
+        {
+            WriteDatTableEntry(bytes, index, currentOffset, assets[index].Name);
+            assets[index].Data.CopyTo(bytes, currentOffset);
+            currentOffset += assets[index].Data.Length;
+        }
+
+        WriteDatTableEntry(bytes, assets.Length, currentOffset, string.Empty);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    public static byte[] Epf(int width, int height, params byte[]?[] frames)
+    {
+        var pixelLength = frames.Sum(frame => frame?.Length ?? 0);
+        var tableOffset = pixelLength;
+        var bytes = new byte[12 + pixelLength + frames.Length * 16];
+        BinaryPrimitives.WriteInt16LittleEndian(bytes, (short)frames.Length);
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(2), (short)width);
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(4), (short)height);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(8), (uint)tableOffset);
+
+        var pixelOffset = 0;
+        for (var index = 0; index < frames.Length; index++)
+        {
+            var frame = frames[index];
+            var entryOffset = 12 + tableOffset + index * 16;
+            if (frame is not null)
+            {
+                if (frame.Length != width * height)
+                {
+                    throw new ArgumentException("Test EPF frames must fill the declared canvas.");
+                }
+
+                BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(entryOffset + 4), (short)height);
+                BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(entryOffset + 6), (short)width);
+                BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset + 8), (uint)pixelOffset);
+                BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset + 12), (uint)(pixelOffset + frame.Length));
+                frame.CopyTo(bytes, 12 + pixelOffset);
+                pixelOffset += frame.Length;
+            }
+        }
+
+        return bytes;
+    }
+
+    public static byte[] Palette(params (byte Index, byte Red, byte Green, byte Blue)[] colors)
+    {
+        var bytes = new byte[256 * 3];
+        foreach (var color in colors)
+        {
+            var offset = color.Index * 3;
+            bytes[offset] = color.Red;
+            bytes[offset + 1] = color.Green;
+            bytes[offset + 2] = color.Blue;
+        }
+
+        return bytes;
+    }
+
+    public static byte[] Text(string value) => Encoding.ASCII.GetBytes(value);
+
+    private static void WriteDatTableEntry(byte[] bytes, int index, int offset, string name)
+    {
+        var entryOffset = DatHeaderSize + index * DatTableEntrySize;
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset), (uint)offset);
+        var nameBytes = Encoding.ASCII.GetBytes(name);
+        nameBytes.AsSpan(0, Math.Min(nameBytes.Length, 13)).CopyTo(bytes.AsSpan(entryOffset + 4, 13));
+    }
+}

--- a/Arbiter.Imaging/Arbiter.Imaging.csproj
+++ b/Arbiter.Imaging/Arbiter.Imaging.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <Company>Erik 'SiLo' Rogers</Company>
+        <Product>Arbiter Imaging Library</Product>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <FileVersion>1.0.0</FileVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Arbiter.IO\Arbiter.IO.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Arbiter.Imaging/Formats/DyeTable.cs
+++ b/Arbiter.Imaging/Formats/DyeTable.cs
@@ -1,0 +1,78 @@
+namespace Arbiter.Imaging.Formats;
+
+internal sealed class DyeTable
+{
+    private readonly Dictionary<byte, IReadOnlyList<RgbColor>> _entries;
+
+    private DyeTable(Dictionary<byte, IReadOnlyList<RgbColor>> entries)
+    {
+        _entries = entries;
+    }
+
+    public static DyeTable Empty { get; } = new([]);
+
+    public static DyeTable Parse(Stream stream)
+    {
+        using var reader = new StreamReader(stream, leaveOpen: true);
+        var entries = new Dictionary<byte, IReadOnlyList<RgbColor>>();
+        if (!int.TryParse(reader.ReadLine()?.Trim(), out var colorsPerEntry) || colorsPerEntry <= 0)
+        {
+            return new DyeTable(entries);
+        }
+
+        while (reader.ReadLine() is { } indexLine)
+        {
+            if (!byte.TryParse(indexLine.Trim(), out var colorIndex))
+            {
+                continue;
+            }
+
+            var colors = new List<RgbColor>(PaletteDye.ColorCount);
+            var valid = true;
+            for (var index = 0; index < colorsPerEntry; index++)
+            {
+                var line = reader.ReadLine();
+                if (line is null || !TryParseColor(line, out var color))
+                {
+                    valid = false;
+                    break;
+                }
+
+                if (index < PaletteDye.ColorCount)
+                {
+                    colors.Add(color);
+                }
+            }
+
+            if (!valid)
+            {
+                break;
+            }
+
+            if (colors.Count == PaletteDye.ColorCount)
+            {
+                entries[colorIndex] = colors;
+            }
+        }
+
+        return new DyeTable(entries);
+    }
+
+    public IReadOnlyList<RgbColor>? GetColors(byte colorIndex) => _entries.GetValueOrDefault(colorIndex);
+
+    private static bool TryParseColor(string text, out RgbColor color)
+    {
+        color = default;
+        var channels = text.Split(',', StringSplitOptions.TrimEntries);
+        if (channels.Length != 3 ||
+            !byte.TryParse(channels[0], out var red) ||
+            !byte.TryParse(channels[1], out var green) ||
+            !byte.TryParse(channels[2], out var blue))
+        {
+            return false;
+        }
+
+        color = new RgbColor(red, green, blue);
+        return true;
+    }
+}

--- a/Arbiter.Imaging/Formats/EpfFile.cs
+++ b/Arbiter.Imaging/Formats/EpfFile.cs
@@ -1,0 +1,112 @@
+using System.Buffers.Binary;
+
+namespace Arbiter.Imaging.Formats;
+
+public sealed class EpfFile
+{
+    private const int HeaderSize = 12;
+    private const int TableEntrySize = 16;
+
+    public int PixelWidth { get; }
+    public int PixelHeight { get; }
+    public IReadOnlyList<EpfFrame?> Frames { get; }
+
+    private EpfFile(int pixelWidth, int pixelHeight, IReadOnlyList<EpfFrame?> frames)
+    {
+        PixelWidth = pixelWidth;
+        PixelHeight = pixelHeight;
+        Frames = frames;
+    }
+
+    public static EpfFile Load(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return Parse(buffer.ToArray());
+    }
+
+    public static EpfFile Parse(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < HeaderSize)
+        {
+            throw new InvalidDataException("The EPF is too small for a header.");
+        }
+
+        var frameCount = ReadNonNegativeInt16(bytes, 0, "frame count");
+        var pixelWidth = ReadNonNegativeInt16(bytes, 2, "pixel width");
+        var pixelHeight = ReadNonNegativeInt16(bytes, 4, "pixel height");
+        var tableOffset = checked((int)ReadUInt32(bytes, 8));
+        var data = bytes[HeaderSize..];
+        var tableLength = checked(frameCount * TableEntrySize);
+        if (tableOffset > data.Length - tableLength)
+        {
+            throw new InvalidDataException("The EPF frame table exceeds the file bounds.");
+        }
+
+        var frames = new List<EpfFrame?>(frameCount);
+        for (var index = 0; index < frameCount; index++)
+        {
+            var entryOffset = checked(tableOffset + index * TableEntrySize);
+            var top = ReadInt16(data, entryOffset);
+            var left = ReadInt16(data, entryOffset + 2);
+            var bottom = ReadInt16(data, entryOffset + 4);
+            var right = ReadInt16(data, entryOffset + 6);
+            var start = checked((int)ReadUInt32(data, entryOffset + 8));
+            var end = checked((int)ReadUInt32(data, entryOffset + 12));
+
+            var width = right - left;
+            var height = bottom - top;
+            if (width == 0 || height == 0)
+            {
+                frames.Add(null);
+                continue;
+            }
+
+            if (left < 0 || top < 0 || width < 0 || height < 0)
+            {
+                throw new InvalidDataException($"EPF frame {index} has invalid dimensions.");
+            }
+
+            var expectedLength = checked(width * height);
+            var declaredLength = end >= start ? end - start : 0;
+            var dataLength = declaredLength == expectedLength ? declaredLength : tableOffset - start;
+            if (start < 0 || dataLength < expectedLength || start > data.Length - dataLength)
+            {
+                throw new InvalidDataException($"EPF frame {index} data exceeds the file bounds.");
+            }
+
+            frames.Add(new EpfFrame(left, top, width, height, data.Slice(start, dataLength).ToArray()));
+        }
+
+        return new EpfFile(pixelWidth, pixelHeight, frames);
+    }
+
+    private static int ReadNonNegativeInt16(ReadOnlySpan<byte> bytes, int offset, string fieldName)
+    {
+        var value = ReadInt16(bytes, offset);
+        return value < 0
+            ? throw new InvalidDataException($"The EPF {fieldName} cannot be negative.")
+            : value;
+    }
+
+    private static short ReadInt16(ReadOnlySpan<byte> bytes, int offset)
+    {
+        if (offset < 0 || offset > bytes.Length - sizeof(short))
+        {
+            throw new InvalidDataException($"The EPF is missing an Int16 at offset {offset}.");
+        }
+
+        return BinaryPrimitives.ReadInt16LittleEndian(bytes[offset..]);
+    }
+
+    private static uint ReadUInt32(ReadOnlySpan<byte> bytes, int offset)
+    {
+        if (offset < 0 || offset > bytes.Length - sizeof(uint))
+        {
+            throw new InvalidDataException($"The EPF is missing a UInt32 at offset {offset}.");
+        }
+
+        return BinaryPrimitives.ReadUInt32LittleEndian(bytes[offset..]);
+    }
+}

--- a/Arbiter.Imaging/Formats/EpfFrame.cs
+++ b/Arbiter.Imaging/Formats/EpfFrame.cs
@@ -1,0 +1,21 @@
+namespace Arbiter.Imaging.Formats;
+
+public sealed class EpfFrame
+{
+    private readonly byte[] _pixels;
+
+    public int Left { get; }
+    public int Top { get; }
+    public int Width { get; }
+    public int Height { get; }
+    public ReadOnlyMemory<byte> Pixels => _pixels;
+
+    internal EpfFrame(int left, int top, int width, int height, byte[] pixels)
+    {
+        Left = left;
+        Top = top;
+        Width = width;
+        Height = height;
+        _pixels = pixels;
+    }
+}

--- a/Arbiter.Imaging/Formats/Palette.cs
+++ b/Arbiter.Imaging/Formats/Palette.cs
@@ -1,0 +1,104 @@
+namespace Arbiter.Imaging.Formats;
+
+public sealed class Palette
+{
+    public const int ColorCount = 256;
+    public const int ByteLength = ColorCount * 3;
+
+    private readonly byte[] _colors;
+
+    private Palette(byte[] colors)
+    {
+        _colors = colors;
+    }
+
+    public static Palette Load(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return Parse(buffer.ToArray());
+    }
+
+    public static Palette Parse(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length != ByteLength)
+        {
+            throw new InvalidDataException($"A palette must contain exactly {ByteLength} bytes.");
+        }
+
+        return new Palette(bytes.ToArray());
+    }
+
+    public void GetColor(byte index, bool useLuminanceAlpha, Span<byte> rgba)
+    {
+        if (rgba.Length < 4)
+        {
+            throw new ArgumentException("The destination must contain at least four bytes.", nameof(rgba));
+        }
+
+        if (index == 0)
+        {
+            rgba[..4].Clear();
+            return;
+        }
+
+        var offset = index * 3;
+        var red = _colors[offset];
+        var green = _colors[offset + 1];
+        var blue = _colors[offset + 2];
+        rgba[0] = red;
+        rgba[1] = green;
+        rgba[2] = blue;
+        rgba[3] = useLuminanceAlpha ? GetLuminanceAlpha(red, green, blue) : byte.MaxValue;
+    }
+
+    internal bool DyeRangeMatches(IReadOnlyList<RgbColor> colors)
+    {
+        for (var index = 0; index < colors.Count; index++)
+        {
+            var offset = (PaletteDye.StartIndex + index) * 3;
+            if (_colors[offset] != colors[index].Red ||
+                _colors[offset + 1] != colors[index].Green ||
+                _colors[offset + 2] != colors[index].Blue)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal Palette WithDye(IReadOnlyList<RgbColor> colors)
+    {
+        var dyed = (byte[])_colors.Clone();
+        for (var index = 0; index < colors.Count; index++)
+        {
+            var offset = (PaletteDye.StartIndex + index) * 3;
+            dyed[offset] = colors[index].Red;
+            dyed[offset + 1] = colors[index].Green;
+            dyed[offset + 2] = colors[index].Blue;
+        }
+
+        return new Palette(dyed);
+    }
+
+    private static byte GetLuminanceAlpha(byte red, byte green, byte blue)
+    {
+        const double gamma = 2.0;
+        var linearRed = Math.Pow(red / 255.0, gamma);
+        var linearGreen = Math.Pow(green / 255.0, gamma);
+        var linearBlue = Math.Pow(blue / 255.0, gamma);
+        var linearLuminance = 0.299 * linearRed + 0.587 * linearGreen + 0.114 * linearBlue;
+        var luminance = Math.Pow(linearLuminance, 1.0 / gamma) * 255.0;
+        return (byte)Math.Clamp(Math.Round(luminance), byte.MinValue, byte.MaxValue);
+    }
+}
+
+internal readonly record struct RgbColor(byte Red, byte Green, byte Blue);
+
+internal static class PaletteDye
+{
+    public const int StartIndex = 98;
+    public const int ColorCount = 6;
+}

--- a/Arbiter.Imaging/Formats/PaletteTable.cs
+++ b/Arbiter.Imaging/Formats/PaletteTable.cs
@@ -1,0 +1,44 @@
+namespace Arbiter.Imaging.Formats;
+
+internal sealed class PaletteTable
+{
+    private readonly Dictionary<uint, uint> _ranges = [];
+    private readonly Dictionary<uint, uint> _overrides = [];
+
+    public void Merge(Stream stream)
+    {
+        using var reader = new StreamReader(stream, leaveOpen: true);
+        while (reader.ReadLine() is { } line)
+        {
+            var values = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (values.Length == 2 &&
+                uint.TryParse(values[0], out var itemId) &&
+                uint.TryParse(values[1], out var paletteId))
+            {
+                _overrides[itemId] = paletteId;
+                continue;
+            }
+
+            if (values.Length != 3 ||
+                !uint.TryParse(values[0], out var minimum) ||
+                !uint.TryParse(values[1], out var maximum) ||
+                !int.TryParse(values[2], out var rangePaletteId) ||
+                rangePaletteId < 0)
+            {
+                continue;
+            }
+
+            for (var id = minimum; id <= maximum; id++)
+            {
+                _ranges[id] = (uint)rangePaletteId;
+                if (id == uint.MaxValue)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    public uint GetPaletteId(uint itemId) =>
+        _overrides.GetValueOrDefault(itemId, _ranges.GetValueOrDefault(itemId));
+}

--- a/Arbiter.Imaging/Sprites/GameSpriteData.cs
+++ b/Arbiter.Imaging/Sprites/GameSpriteData.cs
@@ -1,0 +1,27 @@
+namespace Arbiter.Imaging.Sprites;
+
+public sealed class GameSpriteData
+{
+    public SpriteAtlas? Skills { get; }
+    public SpriteAtlas? SkillsOnCooldown { get; }
+    public SpriteAtlas? Spells { get; }
+    public SpriteAtlas? SpellsOnCooldown { get; }
+    public ItemSpriteAtlasCollection? Items { get; }
+    public IReadOnlyList<GameSpriteLoadIssue> Issues { get; }
+
+    internal GameSpriteData(
+        SpriteAtlas? skills,
+        SpriteAtlas? skillsOnCooldown,
+        SpriteAtlas? spells,
+        SpriteAtlas? spellsOnCooldown,
+        ItemSpriteAtlasCollection? items,
+        IReadOnlyList<GameSpriteLoadIssue> issues)
+    {
+        Skills = skills;
+        SkillsOnCooldown = skillsOnCooldown;
+        Spells = spells;
+        SpellsOnCooldown = spellsOnCooldown;
+        Items = items;
+        Issues = issues;
+    }
+}

--- a/Arbiter.Imaging/Sprites/GameSpriteDataLoader.cs
+++ b/Arbiter.Imaging/Sprites/GameSpriteDataLoader.cs
@@ -1,0 +1,66 @@
+using Arbiter.IO.Assets;
+
+namespace Arbiter.Imaging.Sprites;
+
+public static class GameSpriteDataLoader
+{
+    public const byte CooldownTintRed = 147;
+    public const byte CooldownTintGreen = 189;
+    public const byte CooldownTintBlue = 255;
+
+    public static GameSpriteData Load(string assetDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assetDirectory);
+        var catalog = DatAssetCatalog.Load(assetDirectory);
+        var issues = new List<GameSpriteLoadIssue>();
+
+        var (skills, skillsOnCooldown) = LoadAbility(
+            catalog,
+            "skills",
+            SpriteAtlasLoader.DefaultSkillImageName,
+            issues);
+        var (spells, spellsOnCooldown) = LoadAbility(
+            catalog,
+            "spells",
+            SpriteAtlasLoader.DefaultSpellImageName,
+            issues);
+
+        ItemSpriteAtlasCollection? items = null;
+        try
+        {
+            items = ItemSpriteAtlasLoader.Load(catalog);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or
+                                           InvalidDataException or OverflowException)
+        {
+            issues.Add(new GameSpriteLoadIssue("items", exception));
+        }
+
+        return new GameSpriteData(skills, skillsOnCooldown, spells, spellsOnCooldown, items, issues);
+    }
+
+    private static (SpriteAtlas? Normal, SpriteAtlas? Cooldown) LoadAbility(
+        DatAssetCatalog catalog,
+        string category,
+        string imageName,
+        ICollection<GameSpriteLoadIssue> issues)
+    {
+        try
+        {
+            var source = SpriteAtlasLoader.LoadNamed(catalog, imageName, SpriteAtlasLoader.DefaultGuiPaletteName);
+            var grayscale = SpriteAtlasTransforms.Grayscale(source);
+            var cooldown = SpriteAtlasTransforms.Tint(
+                grayscale,
+                CooldownTintRed,
+                CooldownTintGreen,
+                CooldownTintBlue);
+            return (grayscale, cooldown);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or
+                                           InvalidDataException or OverflowException)
+        {
+            issues.Add(new GameSpriteLoadIssue(category, exception));
+            return (null, null);
+        }
+    }
+}

--- a/Arbiter.Imaging/Sprites/GameSpriteLoadIssue.cs
+++ b/Arbiter.Imaging/Sprites/GameSpriteLoadIssue.cs
@@ -1,0 +1,3 @@
+namespace Arbiter.Imaging.Sprites;
+
+public sealed record GameSpriteLoadIssue(string Category, Exception Exception);

--- a/Arbiter.Imaging/Sprites/ItemPaletteLookup.cs
+++ b/Arbiter.Imaging/Sprites/ItemPaletteLookup.cs
@@ -1,0 +1,50 @@
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Sprites;
+
+internal sealed class ItemPaletteLookup
+{
+    private readonly IReadOnlyDictionary<uint, Palette> _palettes;
+    private readonly PaletteTable _table;
+    private readonly DyeTable _dyeTable;
+    private readonly IReadOnlyList<RgbColor>? _defaultDyeColors;
+
+    public string SourceName { get; }
+
+    public ItemPaletteLookup(
+        IReadOnlyDictionary<uint, Palette> palettes,
+        PaletteTable table,
+        DyeTable dyeTable,
+        IReadOnlyList<RgbColor>? defaultDyeColors,
+        string sourceName)
+    {
+        _palettes = palettes;
+        _table = table;
+        _dyeTable = dyeTable;
+        _defaultDyeColors = defaultDyeColors;
+        SourceName = sourceName;
+    }
+
+    public PaletteBinding GetPalette(uint itemId, byte color)
+    {
+        var paletteId = _table.GetPaletteId(itemId);
+        var useLuminanceAlpha = paletteId >= 1000;
+        if (useLuminanceAlpha)
+        {
+            paletteId -= 1000;
+        }
+
+        if (!_palettes.TryGetValue(paletteId, out var palette))
+        {
+            throw new InvalidDataException($"Palette {paletteId} for item {itemId} was not found.");
+        }
+
+        if (color == 0 || _defaultDyeColors is null || _dyeTable.GetColors(color) is not { } dyeColors ||
+            !palette.DyeRangeMatches(_defaultDyeColors))
+        {
+            return new PaletteBinding(palette, useLuminanceAlpha);
+        }
+
+        return new PaletteBinding(palette.WithDye(dyeColors), useLuminanceAlpha);
+    }
+}

--- a/Arbiter.Imaging/Sprites/ItemSpriteAtlas.cs
+++ b/Arbiter.Imaging/Sprites/ItemSpriteAtlas.cs
@@ -1,0 +1,40 @@
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Sprites;
+
+public sealed class ItemSpriteAtlas
+{
+    private readonly EpfFile _epf;
+    private readonly ItemPaletteLookup _paletteLookup;
+    private readonly uint _imageIdentifier;
+    private readonly string _sourceImageName;
+
+    public const uint FramesPerImage = 266;
+
+    public uint FirstItemId { get; }
+    public uint LastItemId { get; }
+    public SpriteAtlas BaseAtlas { get; }
+
+    internal ItemSpriteAtlas(
+        uint firstItemId,
+        uint lastItemId,
+        SpriteAtlas baseAtlas,
+        EpfFile epf,
+        ItemPaletteLookup paletteLookup,
+        uint imageIdentifier,
+        string sourceImageName)
+    {
+        FirstItemId = firstItemId;
+        LastItemId = lastItemId;
+        BaseAtlas = baseAtlas;
+        _epf = epf;
+        _paletteLookup = paletteLookup;
+        _imageIdentifier = imageIdentifier;
+        _sourceImageName = sourceImageName;
+    }
+
+    public SpriteAtlas BuildColorVariant(byte color) =>
+        color == 0
+            ? BaseAtlas
+            : ItemSpriteAtlasLoader.BuildAtlas(_epf, _paletteLookup, _imageIdentifier, _sourceImageName, color);
+}

--- a/Arbiter.Imaging/Sprites/ItemSpriteAtlasCollection.cs
+++ b/Arbiter.Imaging/Sprites/ItemSpriteAtlasCollection.cs
@@ -1,0 +1,14 @@
+namespace Arbiter.Imaging.Sprites;
+
+public sealed class ItemSpriteAtlasCollection
+{
+    public IReadOnlyList<ItemSpriteAtlas> Atlases { get; }
+
+    internal ItemSpriteAtlasCollection(IReadOnlyList<ItemSpriteAtlas> atlases)
+    {
+        Atlases = atlases;
+    }
+
+    public ItemSpriteAtlas? Find(ushort itemId) =>
+        Atlases.FirstOrDefault(atlas => itemId >= atlas.FirstItemId && itemId <= atlas.LastItemId);
+}

--- a/Arbiter.Imaging/Sprites/ItemSpriteAtlasLoader.cs
+++ b/Arbiter.Imaging/Sprites/ItemSpriteAtlasLoader.cs
@@ -1,0 +1,168 @@
+using Arbiter.IO.Assets;
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Sprites;
+
+public static class ItemSpriteAtlasLoader
+{
+    public const string DefaultPaletteTableName = "itempal.tbl";
+    public const string DefaultDyeTableName = "color0.tbl";
+
+    public static ItemSpriteAtlasCollection Load(DatAssetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        var imageNames = GetNumberedNames(catalog, "item", ".epf");
+        if (imageNames.Count == 0)
+        {
+            throw new FileNotFoundException("No item EPF assets were found.", "item*.epf");
+        }
+
+        var paletteLookup = LoadPaletteLookup(catalog);
+        var atlases = new List<ItemSpriteAtlas>(imageNames.Count);
+        foreach (var imageName in imageNames)
+        {
+            var imageIdentifier = GetNumericIdentifier(imageName, "item", ".epf")!.Value;
+            if (imageIdentifier == 0)
+            {
+                continue;
+            }
+
+            var firstItemId = checked((imageIdentifier - 1) * ItemSpriteAtlas.FramesPerImage + 1);
+            var (epf, sourceImageName) = LoadBestItemImage(catalog, imageName);
+            var atlas = BuildAtlas(epf, paletteLookup, imageIdentifier, sourceImageName, 0);
+            var lastItemId = checked(firstItemId + (uint)atlas.FrameCount - 1);
+            atlases.Add(new ItemSpriteAtlas(
+                firstItemId,
+                lastItemId,
+                atlas,
+                epf,
+                paletteLookup,
+                imageIdentifier,
+                sourceImageName));
+        }
+
+        return new ItemSpriteAtlasCollection(atlases);
+    }
+
+    internal static SpriteAtlas BuildAtlas(
+        EpfFile epf,
+        ItemPaletteLookup paletteLookup,
+        uint imageIdentifier,
+        string sourceImageName,
+        byte color)
+    {
+        var baseIdentifier = checked(imageIdentifier - 1);
+        return SpriteAtlasBuilder.Build(
+            epf,
+            frameIndex =>
+            {
+                var itemId = checked(baseIdentifier * ItemSpriteAtlas.FramesPerImage + (uint)frameIndex + 1);
+                return paletteLookup.GetPalette(itemId, color);
+            },
+            sourceImageName,
+            color == 0 ? paletteLookup.SourceName : $"{paletteLookup.SourceName} + {DefaultDyeTableName}[{color}]");
+    }
+
+    private static ItemPaletteLookup LoadPaletteLookup(DatAssetCatalog catalog)
+    {
+        var tableNames = catalog.Names
+            .Where(name => name.StartsWith("itempal", StringComparison.OrdinalIgnoreCase) &&
+                           name.EndsWith(".tbl", StringComparison.OrdinalIgnoreCase))
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (tableNames.Length == 0)
+        {
+            throw new FileNotFoundException("No item palette table was found.", "itempal*.tbl");
+        }
+
+        var paletteNames = GetNumberedNames(catalog, "item", ".pal");
+        if (paletteNames.Count == 0)
+        {
+            throw new FileNotFoundException("No item palettes were found.", "item*.pal");
+        }
+
+        var table = new PaletteTable();
+        foreach (var tableName in tableNames)
+        {
+            catalog.TryGet(tableName, out var asset);
+            using var stream = asset!.OpenRead();
+            table.Merge(stream);
+        }
+
+        var palettes = new Dictionary<uint, Palette>();
+        foreach (var paletteName in paletteNames)
+        {
+            catalog.TryGet(paletteName, out var asset);
+            using var stream = asset!.OpenRead();
+            palettes[GetNumericIdentifier(paletteName, "item", ".pal")!.Value] = Palette.Load(stream);
+        }
+
+        var dyeTable = DyeTable.Empty;
+        IReadOnlyList<RgbColor>? defaultDyeColors = null;
+        if (catalog.TryGet(DefaultDyeTableName, out var dyeAsset))
+        {
+            using var stream = dyeAsset.OpenRead();
+            dyeTable = DyeTable.Parse(stream);
+            defaultDyeColors = dyeTable.GetColors(0);
+        }
+
+        return new ItemPaletteLookup(
+            palettes,
+            table,
+            dyeTable,
+            defaultDyeColors,
+            string.Join(" + ", tableNames.Append("item*.pal")));
+    }
+
+    private static (EpfFile Epf, string SourceName) LoadBestItemImage(DatAssetCatalog catalog, string imageName)
+    {
+        var parsed = new List<(DatAsset Asset, EpfFile Epf)>();
+        Exception? firstError = null;
+        foreach (var asset in catalog.GetAll(imageName))
+        {
+            try
+            {
+                using var stream = asset.OpenRead();
+                parsed.Add((asset, EpfFile.Load(stream)));
+            }
+            catch (Exception exception) when (exception is InvalidDataException or OverflowException)
+            {
+                firstError ??= exception;
+            }
+        }
+
+        var best = parsed
+            .OrderByDescending(candidate =>
+                string.Equals(candidate.Asset.ArchiveName, "Legend.dat", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(candidate => candidate.Epf.Frames.Count)
+            .ThenByDescending(candidate => candidate.Asset.Length)
+            .FirstOrDefault();
+        if (best.Asset is null)
+        {
+            throw firstError ?? new FileNotFoundException($"Asset '{imageName}' was not found.", imageName);
+        }
+
+        return (best.Epf, $"{best.Asset.Name} ({best.Asset.ArchiveName})");
+    }
+
+    private static List<string> GetNumberedNames(DatAssetCatalog catalog, string prefix, string suffix) =>
+        catalog.Names
+            .Select(name => (Name: name, Identifier: GetNumericIdentifier(name, prefix, suffix)))
+            .Where(value => value.Identifier.HasValue)
+            .OrderBy(value => value.Identifier)
+            .ThenBy(value => value.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(value => value.Name)
+            .ToList();
+
+    private static uint? GetNumericIdentifier(string name, string prefix, string suffix)
+    {
+        if (!name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+            !name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var identifier = name[prefix.Length..^suffix.Length];
+        return uint.TryParse(identifier, out var value) ? value : null;
+    }
+}

--- a/Arbiter.Imaging/Sprites/SpriteAtlas.cs
+++ b/Arbiter.Imaging/Sprites/SpriteAtlas.cs
@@ -1,0 +1,90 @@
+namespace Arbiter.Imaging.Sprites;
+
+public sealed class SpriteAtlas
+{
+    private readonly byte[] _pixels;
+    private readonly SpriteAtlasRegion[] _cells;
+    private readonly SpriteAtlasRegion?[] _content;
+
+    public string SourceImageName { get; }
+    public string SourcePaletteName { get; }
+    public int Width { get; }
+    public int Height { get; }
+    public int FrameWidth { get; }
+    public int FrameHeight { get; }
+    public int FrameCount => _cells.Length;
+    public ReadOnlyMemory<byte> Pixels => _pixels;
+
+    internal SpriteAtlas(
+        string sourceImageName,
+        string sourcePaletteName,
+        int width,
+        int height,
+        int frameWidth,
+        int frameHeight,
+        byte[] pixels,
+        SpriteAtlasRegion[] cells,
+        SpriteAtlasRegion?[] content)
+    {
+        SourceImageName = sourceImageName;
+        SourcePaletteName = sourcePaletteName;
+        Width = width;
+        Height = height;
+        FrameWidth = frameWidth;
+        FrameHeight = frameHeight;
+        _pixels = pixels;
+        _cells = cells;
+        _content = content;
+    }
+
+    public bool TryGetFrame(int frameIndex, out SpriteAtlasRegion region)
+    {
+        region = default;
+        if (frameIndex < 0 || frameIndex >= _content.Length || _content[frameIndex] is not { } content)
+        {
+            return false;
+        }
+
+        region = content;
+        return true;
+    }
+
+    public bool TryResolveIcon(ushort icon, out int frameIndex, out SpriteAtlasRegion region)
+    {
+        var directIndex = (int)icon;
+        if (TryGetFrame(directIndex, out region))
+        {
+            frameIndex = directIndex;
+            return true;
+        }
+
+        var oneBasedIndex = directIndex - 1;
+        if (TryGetFrame(oneBasedIndex, out region))
+        {
+            frameIndex = oneBasedIndex;
+            return true;
+        }
+
+        frameIndex = -1;
+        return false;
+    }
+
+    internal SpriteAtlas WithPixels(byte[] pixels)
+    {
+        if (pixels.Length != _pixels.Length)
+        {
+            throw new ArgumentException("Replacement atlas pixels must have the same length.", nameof(pixels));
+        }
+
+        return new SpriteAtlas(
+            SourceImageName,
+            SourcePaletteName,
+            Width,
+            Height,
+            FrameWidth,
+            FrameHeight,
+            pixels,
+            _cells,
+            _content);
+    }
+}

--- a/Arbiter.Imaging/Sprites/SpriteAtlasBuilder.cs
+++ b/Arbiter.Imaging/Sprites/SpriteAtlasBuilder.cs
@@ -1,0 +1,85 @@
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Sprites;
+
+internal readonly record struct PaletteBinding(Palette Palette, bool UseLuminanceAlpha);
+
+internal static class SpriteAtlasBuilder
+{
+    public const int DefaultColumns = 16;
+
+    public static SpriteAtlas Build(
+        EpfFile epf,
+        Func<int, PaletteBinding> paletteForFrame,
+        string sourceImageName,
+        string sourcePaletteName,
+        int columns = DefaultColumns)
+    {
+        ArgumentNullException.ThrowIfNull(epf);
+        ArgumentNullException.ThrowIfNull(paletteForFrame);
+        if (epf.Frames.Count == 0)
+        {
+            throw new InvalidDataException("The EPF does not contain any frames.");
+        }
+
+        var frameWidth = epf.Frames.OfType<EpfFrame>()
+            .Aggregate(epf.PixelWidth, (maximum, frame) => Math.Max(maximum, frame.Left + frame.Width));
+        var frameHeight = epf.Frames.OfType<EpfFrame>()
+            .Aggregate(epf.PixelHeight, (maximum, frame) => Math.Max(maximum, frame.Top + frame.Height));
+        if (frameWidth <= 0 || frameHeight <= 0)
+        {
+            throw new InvalidDataException("The EPF declares a zero-sized frame canvas.");
+        }
+
+        columns = Math.Clamp(columns, 1, epf.Frames.Count);
+        var rows = (epf.Frames.Count + columns - 1) / columns;
+        var atlasWidth = checked(frameWidth * columns);
+        var atlasHeight = checked(frameHeight * rows);
+        var pixels = new byte[checked(atlasWidth * atlasHeight * 4)];
+        var cells = new SpriteAtlasRegion[epf.Frames.Count];
+        var content = new SpriteAtlasRegion?[epf.Frames.Count];
+
+        Span<byte> rgba = stackalloc byte[4];
+        for (var frameIndex = 0; frameIndex < epf.Frames.Count; frameIndex++)
+        {
+            var cellX = frameIndex % columns * frameWidth;
+            var cellY = frameIndex / columns * frameHeight;
+            cells[frameIndex] = new SpriteAtlasRegion(cellX, cellY, frameWidth, frameHeight);
+            if (epf.Frames[frameIndex] is not { } frame)
+            {
+                continue;
+            }
+
+            content[frameIndex] = new SpriteAtlasRegion(
+                cellX + frame.Left,
+                cellY + frame.Top,
+                frame.Width,
+                frame.Height);
+            var palette = paletteForFrame(frameIndex);
+            var framePixels = frame.Pixels.Span;
+            for (var y = 0; y < frame.Height; y++)
+            {
+                for (var x = 0; x < frame.Width; x++)
+                {
+                    var sourceIndex = y * frame.Width + x;
+                    palette.Palette.GetColor(framePixels[sourceIndex], palette.UseLuminanceAlpha, rgba);
+                    var targetX = cellX + frame.Left + x;
+                    var targetY = cellY + frame.Top + y;
+                    var targetIndex = (targetY * atlasWidth + targetX) * 4;
+                    rgba.CopyTo(pixels.AsSpan(targetIndex, 4));
+                }
+            }
+        }
+
+        return new SpriteAtlas(
+            sourceImageName,
+            sourcePaletteName,
+            atlasWidth,
+            atlasHeight,
+            frameWidth,
+            frameHeight,
+            pixels,
+            cells,
+            content);
+    }
+}

--- a/Arbiter.Imaging/Sprites/SpriteAtlasLoader.cs
+++ b/Arbiter.Imaging/Sprites/SpriteAtlasLoader.cs
@@ -1,0 +1,35 @@
+using Arbiter.IO.Assets;
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Sprites;
+
+public static class SpriteAtlasLoader
+{
+    public const string DefaultSkillImageName = "skill001.epf";
+    public const string DefaultSpellImageName = "spell001.epf";
+    public const string DefaultGuiPaletteName = "gui06.pal";
+
+    public static SpriteAtlas LoadNamed(DatAssetCatalog catalog, string imageName, string paletteName)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        if (!catalog.TryGet(imageName, out var imageAsset))
+        {
+            throw new FileNotFoundException($"Asset '{imageName}' was not found.", imageName);
+        }
+
+        if (!catalog.TryGet(paletteName, out var paletteAsset))
+        {
+            throw new FileNotFoundException($"Asset '{paletteName}' was not found.", paletteName);
+        }
+
+        using var imageStream = imageAsset.OpenRead();
+        using var paletteStream = paletteAsset.OpenRead();
+        var epf = EpfFile.Load(imageStream);
+        var palette = Palette.Load(paletteStream);
+        return SpriteAtlasBuilder.Build(
+            epf,
+            _ => new PaletteBinding(palette, false),
+            imageAsset.Name,
+            paletteAsset.Name);
+    }
+}

--- a/Arbiter.Imaging/Sprites/SpriteAtlasRegion.cs
+++ b/Arbiter.Imaging/Sprites/SpriteAtlasRegion.cs
@@ -1,0 +1,3 @@
+namespace Arbiter.Imaging.Sprites;
+
+public readonly record struct SpriteAtlasRegion(int X, int Y, int Width, int Height);

--- a/Arbiter.Imaging/Sprites/SpriteAtlasTransforms.cs
+++ b/Arbiter.Imaging/Sprites/SpriteAtlasTransforms.cs
@@ -1,0 +1,35 @@
+namespace Arbiter.Imaging.Sprites;
+
+public static class SpriteAtlasTransforms
+{
+    public static SpriteAtlas Grayscale(SpriteAtlas atlas)
+    {
+        ArgumentNullException.ThrowIfNull(atlas);
+        var pixels = atlas.Pixels.ToArray();
+        for (var index = 0; index < pixels.Length; index += 4)
+        {
+            var luminance = (pixels[index] * 77 + pixels[index + 1] * 150 + pixels[index + 2] * 29 + 128) / 256;
+            pixels[index] = (byte)luminance;
+            pixels[index + 1] = (byte)luminance;
+            pixels[index + 2] = (byte)luminance;
+        }
+
+        return atlas.WithPixels(pixels);
+    }
+
+    public static SpriteAtlas Tint(SpriteAtlas atlas, byte red, byte green, byte blue)
+    {
+        ArgumentNullException.ThrowIfNull(atlas);
+        var pixels = atlas.Pixels.ToArray();
+        for (var index = 0; index < pixels.Length; index += 4)
+        {
+            pixels[index] = Multiply(pixels[index], red);
+            pixels[index + 1] = Multiply(pixels[index + 1], green);
+            pixels[index + 2] = Multiply(pixels[index + 2], blue);
+        }
+
+        return atlas.WithPixels(pixels);
+    }
+
+    private static byte Multiply(byte left, byte right) => (byte)((left * right + 127) / 255);
+}

--- a/Arbiter.sln
+++ b/Arbiter.sln
@@ -12,6 +12,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.Net.Tests", "Arbite
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.App.Tests", "Arbiter.App.Tests\Arbiter.App.Tests.csproj", "{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.IO", "Arbiter.IO\Arbiter.IO.csproj", "{9C34BC00-F82E-41FC-B5DE-66A5B882606A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.IO.Tests", "Arbiter.IO.Tests\Arbiter.IO.Tests.csproj", "{7E64804D-50EF-4389-A196-C01367DD0B50}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.Imaging", "Arbiter.Imaging\Arbiter.Imaging.csproj", "{50E15A04-CBA3-477B-9AA0-3814ACFC75A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbiter.Imaging.Tests", "Arbiter.Imaging.Tests\Arbiter.Imaging.Tests.csproj", "{E41806B7-9312-45BE-B3AF-82F2D50BF1D7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +50,21 @@ Global
 		{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4B493D3-6F3E-4B3B-8A45-A59F32E4E0F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C34BC00-F82E-41FC-B5DE-66A5B882606A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C34BC00-F82E-41FC-B5DE-66A5B882606A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C34BC00-F82E-41FC-B5DE-66A5B882606A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C34BC00-F82E-41FC-B5DE-66A5B882606A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E64804D-50EF-4389-A196-C01367DD0B50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E64804D-50EF-4389-A196-C01367DD0B50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E64804D-50EF-4389-A196-C01367DD0B50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E64804D-50EF-4389-A196-C01367DD0B50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50E15A04-CBA3-477B-9AA0-3814ACFC75A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50E15A04-CBA3-477B-9AA0-3814ACFC75A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50E15A04-CBA3-477B-9AA0-3814ACFC75A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50E15A04-CBA3-477B-9AA0-3814ACFC75A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E41806B7-9312-45BE-B3AF-82F2D50BF1D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E41806B7-9312-45BE-B3AF-82F2D50BF1D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E41806B7-9312-45BE-B3AF-82F2D50BF1D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E41806B7-9312-45BE-B3AF-82F2D50BF1D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add reusable IO and imaging libraries for reading game data archives, decoding EPF and palette data, resolving item dyes, and building sprite atlases
+- Render full-color inventory sprites and grayscale skill and spell sprites from the configured game client's data archives, with numeric fallbacks when sprites cannot be resolved
+- Reserve inventory slot 60 for the player's gold bag and show the current gold count in its tooltip
+- Show blue-tinted skill and spell sprites with centered, compact countdowns while cooldowns are active
 - Configure default client and server packet filters that apply on startup and can be restored while tracing
 - Search traces with an inline query language supporting implicit criteria, boolean operators and grouping, command lists and ranges, regular expressions, case control for text searches while character names remain case-insensitive, validation help, and in-packet match highlighting
 
 ### Changed
 
 - Hide the trace client filter when only one client is present
+- Keep inventory sprites centered at their natural size instead of scaling them up to fill their slots
+- Show item, skill, and spell icons to the left of their names in tooltips
+- Show item quantities greater than one as bottom-aligned `(xN)` labels and format gold as a comma-separated yellow tooltip line
+- Improve slot readability with translucent slot-number backgrounds and white borders on mouseover
+- Treat every cooldown packet as authoritative, replacing the active deadline and latest reported duration while keeping the tooltip duration separate from the ticking countdown
 
 ## [1.8.2] - 2026-07-09
 


### PR DESCRIPTION
## Summary

- Add reusable `Arbiter.IO` and `Arbiter.Imaging` libraries for reading the game's local DAT archives and decoding EPF/palette sprite data.
- Render full-color item sprites and grayscale skill/spell sprites in Avalonia, with numeric fallbacks when an asset cannot be loaded.
- Add blue-tinted, centered WoW-style cooldown countdowns, tooltip icons, clearer slot labels/hover states, item quantities, and the gold bag/count in slot 60.
- Treat each incoming cooldown packet as authoritative so login-time remaining cooldowns and later skill-use cooldowns replace older state correctly.
- Document every user-facing change in the Unreleased changelog.

## New reusable .NET projects

### Arbiter.IO

`Arbiter.IO` owns data access only. It parses DAT archive metadata, validates entry bounds, exposes bounded entry streams, and builds a case-insensitive catalog with later-archive precedence and access to duplicate variants.

### Arbiter.Imaging

`Arbiter.Imaging` owns image formats and transforms only. It decodes EPF frames and palettes, applies item palette/dye mappings, builds item/skill/spell atlases, and provides grayscale and tint transforms. It depends on `Arbiter.IO` for archive access without mixing those concerns into one game-assets project.

Both libraries target .NET 10, enable nullable reference types and implicit usings, and follow the existing Arbiter assembly metadata convention:

- Company: `Erik 'SiLo' Rogers`
- Product: `Arbiter IO Library` / `Arbiter Imaging Library`
- Initial assembly and file version: `1.0.0`

Their NUnit test projects follow the repository's existing non-packable test-project convention. Tests generate mock DAT/EPF/palette/table data at runtime and do not depend on or commit real game assets.

## UI behavior

- Load asset files from the directory containing the configured game executable.
- Keep item sprites in full color, centered at natural size, and only scale them down when oversized.
- Render skill and spell sprites in grayscale.
- Show `#ID` when a requested sprite is unavailable.
- Display the icon to the left of item, skill, and spell names in tooltips.
- Give slot numbers a subtle backing and turn the slot border white on mouseover.
- Show item quantities as bottom-aligned `(xN)` only when the quantity is greater than one.
- Reserve inventory slot 60 for the gold bag sprite and show the player's gold count. Its tooltip uses a new yellow line with comma-separated text such as `123,456,678 gold`.
- Blue-tint active skill/spell cooldowns and center a live countdown such as `2m`, `1m`, or `59s`.

## Cooldown correctness

Cooldown time is game elapsed time rather than wall time while logged out. A login packet can therefore contain a shorter remaining cooldown than the skill's normal duration. Every newly received cooldown packet now replaces the prior deadline and the latest reported tooltip duration, so a later login or skill-use update is always authoritative.

## Asset policy

No game assets are included in this branch. Missing, malformed, or unavailable local data falls back to the existing numeric sprite identifier without preventing the application from starting.

## Validation

- `dotnet build Arbiter.sln -c Release --no-restore`: succeeded with 0 warnings and 0 errors
- `dotnet test Arbiter.sln -c Release --no-build --no-restore`: 104 passed, 0 failed
  - Arbiter.App.Tests: 46
  - Arbiter.Net.Tests: 44
  - Arbiter.IO.Tests: 5
  - Arbiter.Imaging.Tests: 9
- Read-only smoke load against the configured game directory: 114 skill frames, 266 spell frames, 53 item atlases, and 13,882 item frames loaded with no issues
- Verified that no DAT, EPF, PAL, or TBL asset files are included
