### PR TITLE
Render creature previews and stabilize entity updates

### DIFF
--- a/Arbiter.App.Tests/Collections/FilteredObservableCollectionTests.cs
+++ b/Arbiter.App.Tests/Collections/FilteredObservableCollectionTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using Arbiter.App.Collections;
+
+namespace Arbiter.App.Tests.Collections;
+
+public sealed class FilteredObservableCollectionTests
+{
+    [Test]
+    public void Should_Reconcile_Filter_Changes_Without_Resetting_Stable_Items()
+    {
+        var first = new TestItem(1);
+        var second = new TestItem(2);
+        var third = new TestItem(3);
+        var source = new ObservableCollection<TestItem> { first, second, third };
+        var visible = new HashSet<int> { 1, 2 };
+        using var filtered = new FilteredObservableCollection<TestItem>(
+            source,
+            item => visible.Contains(item.Id));
+        var actions = new List<NotifyCollectionChangedAction>();
+        filtered.CollectionChanged += (_, args) => actions.Add(args.Action);
+
+        visible.Remove(2);
+        visible.Add(3);
+        filtered.Reconcile();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(filtered, Is.EqualTo(new[] { first, third }));
+            Assert.That(filtered[0], Is.SameAs(first));
+            Assert.That(actions, Does.Contain(NotifyCollectionChangedAction.Remove));
+            Assert.That(actions, Does.Contain(NotifyCollectionChangedAction.Add));
+            Assert.That(actions, Does.Not.Contain(NotifyCollectionChangedAction.Reset));
+        });
+    }
+
+    [Test]
+    public void Should_Insert_Reconciled_Item_In_Source_Order()
+    {
+        var first = new TestItem(1);
+        var second = new TestItem(2);
+        var third = new TestItem(3);
+        var source = new ObservableCollection<TestItem> { first, second, third };
+        var visible = new HashSet<int> { 1, 3 };
+        using var filtered = new FilteredObservableCollection<TestItem>(
+            source,
+            item => visible.Contains(item.Id));
+        var actions = new List<NotifyCollectionChangedAction>();
+        filtered.CollectionChanged += (_, args) => actions.Add(args.Action);
+
+        visible.Add(2);
+        filtered.ReconcileItem(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(filtered, Is.EqualTo(new[] { first, second, third }));
+            Assert.That(actions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Add }));
+        });
+    }
+
+    private sealed record TestItem(int Id);
+}

--- a/Arbiter.App.Tests/ViewModels/Dialogs/DialogViewModelTests.cs
+++ b/Arbiter.App.Tests/ViewModels/Dialogs/DialogViewModelTests.cs
@@ -1,0 +1,97 @@
+using Arbiter.App.Services.Sprites;
+using Arbiter.App.ViewModels.Dialogs;
+using Arbiter.Net.Types;
+using Avalonia.Media;
+
+namespace Arbiter.App.Tests.ViewModels.Dialogs;
+
+public sealed class DialogViewModelTests
+{
+    [Test]
+    public void Should_Resolve_Creature_Dialog_Portraits()
+    {
+        var sprites = new RecordingSpriteService();
+        var viewModel = new DialogViewModel(sprites)
+        {
+            Sprite = 42,
+            SpriteType = SpriteType.Monster
+        };
+
+        _ = viewModel.SpriteImage;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.HasSprite, Is.True);
+            Assert.That(viewModel.SpriteFallbackText, Is.EqualTo("#42"));
+            Assert.That(sprites.LastCreatureSprite, Is.EqualTo(42));
+            Assert.That(sprites.LastItemSprite, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Should_Resolve_Full_Color_Item_Dialog_Portraits()
+    {
+        var sprites = new RecordingSpriteService();
+        var viewModel = new DialogViewModel(sprites)
+        {
+            Sprite = 123,
+            SpriteType = SpriteType.Item,
+            Color = 7
+        };
+
+        _ = viewModel.SpriteImage;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.SpriteFallbackText, Is.EqualTo("#123"));
+            Assert.That(sprites.LastItemSprite, Is.EqualTo(123));
+            Assert.That(sprites.LastItemColor, Is.EqualTo(7));
+            Assert.That(sprites.LastCreatureSprite, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Should_Show_None_When_Dialog_Has_No_Sprite()
+    {
+        var viewModel = new DialogViewModel();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.HasSprite, Is.False);
+            Assert.That(viewModel.SpriteFallbackText, Is.EqualTo("None"));
+            Assert.That(viewModel.SpriteImage, Is.Null);
+        });
+    }
+
+    private sealed class RecordingSpriteService : IGameSpriteService
+    {
+        public ushort? LastCreatureSprite { get; private set; }
+        public ushort? LastItemSprite { get; private set; }
+        public byte? LastItemColor { get; private set; }
+
+        public event EventHandler? SpritesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public IImage? GetCreature(ushort sprite)
+        {
+            LastCreatureSprite = sprite;
+            return null;
+        }
+
+        public IImage? GetItem(ushort sprite, byte color)
+        {
+            LastItemSprite = sprite;
+            LastItemColor = color;
+            return null;
+        }
+
+        public IImage? GetSkill(ushort sprite, bool isOnCooldown) => null;
+        public IImage? GetSpell(ushort sprite, bool isOnCooldown) => null;
+    }
+}

--- a/Arbiter.App.Tests/ViewModels/Entities/EntityViewModelTests.cs
+++ b/Arbiter.App.Tests/ViewModels/Entities/EntityViewModelTests.cs
@@ -1,0 +1,81 @@
+using Arbiter.App.Models.Entities;
+using Arbiter.App.Services.Sprites;
+using Arbiter.App.ViewModels.Entities;
+using Avalonia.Media;
+
+namespace Arbiter.App.Tests.ViewModels.Entities;
+
+public sealed class EntityViewModelTests
+{
+    [TestCase(EntityFlags.Monster)]
+    [TestCase(EntityFlags.Mundane)]
+    public void Should_Resolve_Creature_Sprites_For_Monster_And_Npc_Tooltips(EntityFlags flags)
+    {
+        var sprites = new RecordingSpriteService();
+        var viewModel = new EntityViewModel(
+            new GameEntity { Id = 1, Flags = flags, Sprite = 42 },
+            sprites);
+
+        _ = viewModel.SpriteImage;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.ShowsSpritePreview, Is.True);
+            Assert.That(viewModel.SpriteFallbackText, Is.EqualTo("#42"));
+            Assert.That(sprites.LastCreatureSprite, Is.EqualTo(42));
+            Assert.That(sprites.LastItemSprite, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Should_Resolve_Full_Color_Item_Sprites_For_Ground_Item_Tooltips()
+    {
+        var sprites = new RecordingSpriteService();
+        var viewModel = new EntityViewModel(
+            new GameEntity { Id = 2, Flags = EntityFlags.Item, Sprite = 123, Color = 7 },
+            sprites);
+
+        _ = viewModel.SpriteImage;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.ShowsSpritePreview, Is.True);
+            Assert.That(viewModel.SpriteFallbackText, Is.EqualTo("#123"));
+            Assert.That(sprites.LastItemSprite, Is.EqualTo(123));
+            Assert.That(sprites.LastItemColor, Is.EqualTo(7));
+            Assert.That(sprites.LastCreatureSprite, Is.Null);
+        });
+    }
+
+    private sealed class RecordingSpriteService : IGameSpriteService
+    {
+        public ushort? LastCreatureSprite { get; private set; }
+        public ushort? LastItemSprite { get; private set; }
+        public byte? LastItemColor { get; private set; }
+
+        public event EventHandler? SpritesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public IImage? GetCreature(ushort sprite)
+        {
+            LastCreatureSprite = sprite;
+            return null;
+        }
+
+        public IImage? GetItem(ushort sprite, byte color)
+        {
+            LastItemSprite = sprite;
+            LastItemColor = color;
+            return null;
+        }
+
+        public IImage? GetSkill(ushort sprite, bool isOnCooldown) => null;
+        public IImage? GetSpell(ushort sprite, bool isOnCooldown) => null;
+    }
+}

--- a/Arbiter.App.Tests/ViewModels/Player/PlayerInventoryViewModelTests.cs
+++ b/Arbiter.App.Tests/ViewModels/Player/PlayerInventoryViewModelTests.cs
@@ -91,6 +91,7 @@ public sealed class PlayerInventoryViewModelTests
         public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
 
+        public IImage? GetCreature(ushort sprite) => null;
         public IImage? GetItem(ushort sprite, byte color) => null;
         public IImage? GetSkill(ushort sprite, bool isOnCooldown) => null;
         public IImage? GetSpell(ushort sprite, bool isOnCooldown) => null;

--- a/Arbiter.App.Tests/ViewModels/Player/PlayerSkillSlotViewModelTests.cs
+++ b/Arbiter.App.Tests/ViewModels/Player/PlayerSkillSlotViewModelTests.cs
@@ -103,6 +103,7 @@ public sealed class PlayerSkillSlotViewModelTests
         public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
 
+        public IImage? GetCreature(ushort sprite) => null;
         public IImage? GetItem(ushort sprite, byte color) => null;
 
         public IImage? GetSkill(ushort sprite, bool isOnCooldown)

--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -17,6 +17,9 @@
     <ItemGroup>
         <AvaloniaResource Include="Assets\**"/>
         <AvaloniaResource Include="Themes\**"/>
+        <None Include="..\THIRD-PARTY-NOTICES.md"
+              Link="THIRD-PARTY-NOTICES.md"
+              CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Arbiter.App/Collections/FilteredObservableCollection.cs
+++ b/Arbiter.App/Collections/FilteredObservableCollection.cs
@@ -53,6 +53,66 @@ public class FilteredObservableCollection<T> : ObservableCollection<T>, IDisposa
         OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
     }
 
+    public void Reconcile()
+    {
+        Dispatcher.UIThread.VerifyAccess();
+
+        for (var index = Count - 1; index >= 0; index--)
+        {
+            var item = this[index];
+            if (!_sourceCollection.Contains(item) || !Predicate(item))
+            {
+                RemoveAt(index);
+            }
+        }
+
+        var targetIndex = 0;
+        foreach (var item in _sourceCollection)
+        {
+            if (!Predicate(item))
+            {
+                continue;
+            }
+
+            var currentIndex = IndexOf(item);
+            if (currentIndex < 0)
+            {
+                Insert(targetIndex, item);
+            }
+            else if (currentIndex != targetIndex)
+            {
+                Move(currentIndex, targetIndex);
+            }
+
+            targetIndex++;
+        }
+    }
+
+    public void ReconcileItem(T item)
+    {
+        Dispatcher.UIThread.VerifyAccess();
+
+        var sourceIndex = _sourceCollection.IndexOf(item);
+        var currentIndex = IndexOf(item);
+        if (sourceIndex < 0 || !Predicate(item))
+        {
+            if (currentIndex >= 0)
+            {
+                RemoveAt(currentIndex);
+            }
+
+            return;
+        }
+
+        if (currentIndex >= 0)
+        {
+            return;
+        }
+
+        var targetIndex = Math.Min(GetFilteredIndexForSourceIndex(sourceIndex), Count);
+        Insert(targetIndex, item);
+    }
+
     public IDisposable DeferRefresh()
     {
         Dispatcher.UIThread.VerifyAccess();

--- a/Arbiter.App/Models/Entities/GameEntity.cs
+++ b/Arbiter.App/Models/Entities/GameEntity.cs
@@ -5,6 +5,7 @@ public readonly record struct GameEntity
     public long Id { get; init; }
     public EntityFlags Flags { get; init; }
     public ushort? Sprite { get; init; }
+    public byte? Color { get; init; }
     public string? Name { get; init; }
 
     // Location where the entity was last seen

--- a/Arbiter.App/Services/Entities/EntityStore.cs
+++ b/Arbiter.App/Services/Entities/EntityStore.cs
@@ -135,6 +135,7 @@ public sealed class EntityStore : IEntityStore
         {
             Name = !string.IsNullOrWhiteSpace(entity.Name) ? entity.Name : existingEntity.Name,
             Sprite = entity.Sprite ?? existingEntity.Sprite,
+            Color = entity.Color ?? existingEntity.Color,
             MapId = entity.MapId ?? existingEntity.MapId,
             MapName = entity.MapName ?? existingEntity.MapName,
             X = entity.X,

--- a/Arbiter.App/Services/Sprites/GameSpriteService.cs
+++ b/Arbiter.App/Services/Sprites/GameSpriteService.cs
@@ -15,6 +15,8 @@ public sealed class GameSpriteService : IGameSpriteService, IDisposable
 {
     private readonly ILogger<GameSpriteService> _logger;
     private readonly SemaphoreSlim _loadGate = new(1, 1);
+    private readonly Dictionary<ushort, AvaloniaSpriteAtlas> _creatureAtlases = [];
+    private readonly HashSet<ushort> _failedCreatureSprites = [];
     private readonly Dictionary<(uint FirstItemId, byte Color), AvaloniaSpriteAtlas> _itemAtlases = [];
     private readonly HashSet<(uint FirstItemId, byte Color)> _failedItemAtlases = [];
 
@@ -23,6 +25,7 @@ public sealed class GameSpriteService : IGameSpriteService, IDisposable
     private AvaloniaSpriteAtlas? _skillsOnCooldown;
     private AvaloniaSpriteAtlas? _spells;
     private AvaloniaSpriteAtlas? _spellsOnCooldown;
+    private CreatureSpriteLoader? _creatures;
     private string? _loadedDirectory;
 
     public GameSpriteService(ILogger<GameSpriteService> logger)
@@ -108,6 +111,39 @@ public sealed class GameSpriteService : IGameSpriteService, IDisposable
         return atlas.GetFrame(frameIndex);
     }
 
+    public IImage? GetCreature(ushort sprite)
+    {
+        if (_creatures is null || sprite == 0 || _failedCreatureSprites.Contains(sprite))
+        {
+            return null;
+        }
+
+        if (!_creatureAtlases.TryGetValue(sprite, out var atlas))
+        {
+            try
+            {
+                var source = _creatures.LoadPreview(sprite);
+                if (source is null)
+                {
+                    _failedCreatureSprites.Add(sprite);
+                    return null;
+                }
+
+                atlas = new AvaloniaSpriteAtlas(source);
+                _creatureAtlases.Add(sprite, atlas);
+            }
+            catch (Exception exception) when (exception is ArgumentException or IOException or
+                                               UnauthorizedAccessException or InvalidDataException or OverflowException)
+            {
+                _failedCreatureSprites.Add(sprite);
+                _logger.LogWarning(exception, "Failed to build creature sprite {Sprite}", sprite);
+                return null;
+            }
+        }
+
+        return atlas.GetFrame(0);
+    }
+
     public IImage? GetSkill(ushort sprite, bool isOnCooldown) =>
         (isOnCooldown ? _skillsOnCooldown : _skills)?.GetIcon(sprite);
 
@@ -126,6 +162,7 @@ public sealed class GameSpriteService : IGameSpriteService, IDisposable
         var oldSkillsOnCooldown = _skillsOnCooldown;
         var oldSpells = _spells;
         var oldSpellsOnCooldown = _spellsOnCooldown;
+        var oldCreatures = _creatureAtlases.Values.ToArray();
         var oldItems = _itemAtlases.Values.ToArray();
 
         _data = data;
@@ -133,6 +170,9 @@ public sealed class GameSpriteService : IGameSpriteService, IDisposable
         _skillsOnCooldown = CreateAtlas(data?.SkillsOnCooldown, "skills cooldown");
         _spells = CreateAtlas(data?.Spells, "spells");
         _spellsOnCooldown = CreateAtlas(data?.SpellsOnCooldown, "spells cooldown");
+        _creatures = data?.Creatures;
+        _creatureAtlases.Clear();
+        _failedCreatureSprites.Clear();
         _itemAtlases.Clear();
         _failedItemAtlases.Clear();
         _loadedDirectory = directory;
@@ -160,6 +200,11 @@ public sealed class GameSpriteService : IGameSpriteService, IDisposable
             oldSkillsOnCooldown?.Dispose();
             oldSpells?.Dispose();
             oldSpellsOnCooldown?.Dispose();
+            foreach (var atlas in oldCreatures)
+            {
+                atlas.Dispose();
+            }
+
             foreach (var atlas in oldItems)
             {
                 atlas.Dispose();
@@ -191,11 +236,17 @@ public sealed class GameSpriteService : IGameSpriteService, IDisposable
         _skillsOnCooldown?.Dispose();
         _spells?.Dispose();
         _spellsOnCooldown?.Dispose();
+        foreach (var atlas in _creatureAtlases.Values)
+        {
+            atlas.Dispose();
+        }
+
         foreach (var atlas in _itemAtlases.Values)
         {
             atlas.Dispose();
         }
 
+        _creatureAtlases.Clear();
         _itemAtlases.Clear();
     }
 }

--- a/Arbiter.App/Services/Sprites/IGameSpriteService.cs
+++ b/Arbiter.App/Services/Sprites/IGameSpriteService.cs
@@ -10,6 +10,7 @@ public interface IGameSpriteService
     event EventHandler? SpritesChanged;
 
     Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default);
+    IImage? GetCreature(ushort sprite);
     IImage? GetItem(ushort sprite, byte color);
     IImage? GetSkill(ushort sprite, bool isOnCooldown);
     IImage? GetSpell(ushort sprite, bool isOnCooldown);

--- a/Arbiter.App/Services/Sprites/NullGameSpriteService.cs
+++ b/Arbiter.App/Services/Sprites/NullGameSpriteService.cs
@@ -22,6 +22,7 @@ internal sealed class NullGameSpriteService : IGameSpriteService
     public Task LoadAsync(string clientExecutablePath, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
+    public IImage? GetCreature(ushort sprite) => null;
     public IImage? GetItem(ushort sprite, byte color) => null;
     public IImage? GetSkill(ushort sprite, bool isOnCooldown) => null;
     public IImage? GetSpell(ushort sprite, bool isOnCooldown) => null;

--- a/Arbiter.App/ViewModels/Dialogs/DialogManagerViewModel.Observers.cs
+++ b/Arbiter.App/ViewModels/Dialogs/DialogManagerViewModel.Observers.cs
@@ -47,7 +47,7 @@ public partial class DialogManagerViewModel
     private void SetActiveDialogForClient(long clientId, DialogViewModel? dialog)
         => _activeDialogs.AddOrUpdate(clientId, dialog, (_, _) => dialog);
 
-    private static DialogViewModel? BuildDialogView(ServerShowDialogMessage message)
+    private DialogViewModel? BuildDialogView(ServerShowDialogMessage message)
     {
         if (message.DialogType == DialogType.CloseDialog)
         {
@@ -55,12 +55,14 @@ public partial class DialogManagerViewModel
         }
         
         var name = !string.IsNullOrWhiteSpace(message.Name) ? message.Name : message.EntityType.ToString();
-        var dialog = new DialogViewModel
+        var dialog = new DialogViewModel(_spriteService)
         {
             Name = name,
             EntityId = message.EntityId,
             EntityType = message.EntityType,
             Sprite = message.Sprite,
+            SpriteType = message.SpriteType,
+            Color = message.Color,
             PursuitId = message.PursuitId,
             StepId = message.StepId,
             Content = message.Content,
@@ -91,15 +93,17 @@ public partial class DialogManagerViewModel
         return dialog;
     }
 
-    private static DialogViewModel BuildDialogView(ServerShowDialogMenuMessage message)
+    private DialogViewModel BuildDialogView(ServerShowDialogMenuMessage message)
     {
         var name = !string.IsNullOrWhiteSpace(message.Name) ? message.Name : message.EntityType.ToString();
-        var dialog = new DialogViewModel
+        var dialog = new DialogViewModel(_spriteService)
         {
             Name = name,
             EntityId = message.EntityId,
             EntityType = message.EntityType,
             Sprite = message.Sprite,
+            SpriteType = message.SpriteType,
+            Color = message.Color,
             PursuitId = message.PursuitId,
             Content = message.Content,
             CanNavigateTop = true

--- a/Arbiter.App/ViewModels/Dialogs/DialogManagerViewModel.cs
+++ b/Arbiter.App/ViewModels/Dialogs/DialogManagerViewModel.cs
@@ -2,11 +2,14 @@
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Threading.Tasks;
 using Arbiter.App.Extensions;
+using Arbiter.App.Services.Sprites;
 using Arbiter.App.ViewModels.Client;
 using Arbiter.Net.Proxy;
 using Avalonia;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +22,7 @@ public partial class DialogManagerViewModel : ViewModelBase
     private readonly ILogger<DialogManagerViewModel> _logger;
     private readonly ProxyServer _proxyServer;
     private readonly ClientManagerViewModel _clientManager;
+    private readonly IGameSpriteService _spriteService;
 
     private readonly ConcurrentDictionary<long, DialogViewModel?> _activeDialogs = [];
 
@@ -34,10 +38,12 @@ public partial class DialogManagerViewModel : ViewModelBase
     {
         _logger = logger;
         _clientManager = serviceProvider.GetRequiredService<ClientManagerViewModel>();
+        _spriteService = serviceProvider.GetRequiredService<IGameSpriteService>();
 
         _clientManager.Clients.CollectionChanged += OnClientsCollectionChanged;
         _clientManager.ClientSelected += OnClientSelected;
         _clientManager.ClientDisconnected += OnClientDisconnected;
+        _spriteService.SpritesChanged += OnSpritesChanged;
 
         _proxyServer = serviceProvider.GetRequiredService<ProxyServer>();
         AddObservers();
@@ -76,6 +82,26 @@ public partial class DialogManagerViewModel : ViewModelBase
         if (ShouldSync)
         {
             ActiveDialog = null;
+        }
+    }
+
+    private void OnSpritesChanged(object? sender, EventArgs e)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => OnSpritesChanged(sender, e));
+            return;
+        }
+
+        var dialogs = _activeDialogs.Values.OfType<DialogViewModel>().ToHashSet();
+        if (ActiveDialog is not null)
+        {
+            dialogs.Add(ActiveDialog);
+        }
+
+        foreach (var dialog in dialogs)
+        {
+            dialog.RefreshSprite();
         }
     }
 

--- a/Arbiter.App/ViewModels/Dialogs/DialogViewModel.cs
+++ b/Arbiter.App/ViewModels/Dialogs/DialogViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using Arbiter.App.Services.Sprites;
 using Arbiter.Net.Types;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -8,9 +10,23 @@ namespace Arbiter.App.ViewModels.Dialogs;
 
 public partial class DialogViewModel : ViewModelBase
 {
+    private readonly IGameSpriteService _spriteService;
+
     [ObservableProperty] private string? _name;
     [ObservableProperty] private string? _content;
-    [ObservableProperty] private int? _sprite;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SpriteImage), nameof(SpriteFallbackText), nameof(HasSprite))]
+    private int? _sprite;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SpriteImage))]
+    private SpriteType _spriteType;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SpriteImage))]
+    private byte? _color;
+
     [ObservableProperty] private long? _entityId;
     [ObservableProperty] private EntityTypeFlags _entityType;
     [ObservableProperty] private int? _pursuitId;
@@ -36,6 +52,26 @@ public partial class DialogViewModel : ViewModelBase
     public ObservableCollection<DialogMenuChoiceViewModel> MenuChoices { get; } = [];
 
     public bool HasMenuChoices => MenuChoices.Count > 0;
+    public bool HasSprite => Sprite.HasValue;
+    public string SpriteFallbackText => Sprite.HasValue ? $"#{Sprite.Value}" : "None";
+    public IImage? SpriteImage
+    {
+        get
+        {
+            if (!Sprite.HasValue || Sprite.Value < ushort.MinValue || Sprite.Value > ushort.MaxValue)
+            {
+                return null;
+            }
+
+            var sprite = (ushort)Sprite.Value;
+            return SpriteType switch
+            {
+                SpriteType.Monster => _spriteService.GetCreature(sprite),
+                SpriteType.Item => _spriteService.GetItem(sprite, Color ?? 0),
+                _ => null
+            };
+        }
+    }
 
     public event EventHandler<DialogEventArgs>? RequestPrevious;
     public event EventHandler<DialogEventArgs>? RequestNext;
@@ -45,9 +81,17 @@ public partial class DialogViewModel : ViewModelBase
     public event EventHandler<DialogEventArgs>? TextInputConfirmed;
 
     public DialogViewModel()
+        : this(NullGameSpriteService.Instance)
     {
+    }
+
+    public DialogViewModel(IGameSpriteService spriteService)
+    {
+        _spriteService = spriteService;
         MenuChoices.CollectionChanged += (_, _) => { OnPropertyChanged(nameof(HasMenuChoices)); };
     }
+
+    public void RefreshSprite() => OnPropertyChanged(nameof(SpriteImage));
 
     [RelayCommand]
     private void SelectMenuChoice(DialogMenuChoiceViewModel viewModel)

--- a/Arbiter.App/ViewModels/Entities/EntityManagerViewModel.Filtering.cs
+++ b/Arbiter.App/ViewModels/Entities/EntityManagerViewModel.Filtering.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Arbiter.App.Collections;
 using Arbiter.App.Models.Entities;
 using Arbiter.App.Threading;
@@ -27,22 +26,22 @@ public partial class EntityManagerViewModel
     public FilteredObservableCollection<EntityViewModel> FilteredEntities { get; }
 
     partial void OnFilterModeChanged(EntityFilterMode oldValue, EntityFilterMode newValue) =>
-        _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+        _filterDebouncer.Execute(ReconcileFilter);
 
     partial void OnIncludePlayersChanged(bool oldValue, bool newValue) =>
-        _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+        _filterDebouncer.Execute(ReconcileFilter);
 
     partial void OnIncludeNpcsChanged(bool oldValue, bool newValue) =>
-        _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+        _filterDebouncer.Execute(ReconcileFilter);
 
     partial void OnIncludeMonstersChanged(bool oldValue, bool newValue) =>
-        _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+        _filterDebouncer.Execute(ReconcileFilter);
 
     partial void OnIncludeItemsChanged(bool oldValue, bool newValue) =>
-        _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+        _filterDebouncer.Execute(ReconcileFilter);
 
     partial void OnIncludeReactorsChanged(bool oldValue, bool newValue) =>
-        _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+        _filterDebouncer.Execute(ReconcileFilter);
 
     private bool MatchesFilter(EntityViewModel entity)
     {
@@ -84,22 +83,5 @@ public partial class EntityManagerViewModel
         return isWithinRange && typeAllowed;
     }
 
-    private void RefreshFilterPreservingSelection()
-    {
-        // Remember selection by IDs
-        var selectedIds = SelectedEntities.Select(e => e.Id).ToHashSet();
-        FilteredEntities.Refresh();
-        if (selectedIds.Count == 0)
-        {
-            return;
-        }
-
-        // Restore selection for items still present
-        var toSelect = FilteredEntities.Where(vm => selectedIds.Contains(vm.Id)).ToList();
-        SelectedEntities.Clear();
-        foreach (var vm in toSelect)
-        {
-            SelectedEntities.Add(vm);
-        }
-    }
+    private void ReconcileFilter() => FilteredEntities.Reconcile();
 }

--- a/Arbiter.App/ViewModels/Entities/EntityManagerViewModel.Observers.cs
+++ b/Arbiter.App/ViewModels/Entities/EntityManagerViewModel.Observers.cs
@@ -79,6 +79,7 @@ public partial class EntityManagerViewModel
                 Id = entity.Id,
                 Name = name,
                 Sprite = entity.Sprite,
+                Color = entity is ServerItemEntity item ? (byte)item.Color : null,
                 MapId = player?.MapId,
                 MapName = player?.MapName,
                 X = entity.X,
@@ -290,11 +291,6 @@ public partial class EntityManagerViewModel
         };
 
         _entityStore.TrySetEntityLocation(message.EntityId, newX, newY);
-
-        if (SelectedClient is not null && FilterMode is not EntityFilterMode.All)
-        {
-            _filterDebouncer.Execute(RefreshFilterPreservingSelection);
-        }
     }
 
     private void OnSelfWalkMessage(ProxyConnection connection, ServerWalkResponseMessage message, object? parameter)
@@ -332,7 +328,7 @@ public partial class EntityManagerViewModel
 
         if (SelectedClient is not null)
         {
-            _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+            _filterDebouncer.Execute(ReconcileFilter);
         }
     }
 
@@ -340,7 +336,7 @@ public partial class EntityManagerViewModel
     {
         if (SelectedClient is not null && FilterMode is not EntityFilterMode.All)
         {
-            _filterDebouncer.Execute(RefreshFilterPreservingSelection);
+            _filterDebouncer.Execute(ReconcileFilter);
         }
     }
 

--- a/Arbiter.App/ViewModels/Entities/EntityManagerViewModel.cs
+++ b/Arbiter.App/ViewModels/Entities/EntityManagerViewModel.cs
@@ -5,6 +5,7 @@ using Arbiter.App.Collections;
 using Arbiter.App.Models.Entities;
 using Arbiter.App.Services.Entities;
 using Arbiter.App.Services.Players;
+using Arbiter.App.Services.Sprites;
 using Arbiter.App.ViewModels.Client;
 using Arbiter.Net.Proxy;
 using Avalonia.Threading;
@@ -17,6 +18,7 @@ public partial class EntityManagerViewModel : ViewModelBase
 {
     private readonly IEntityStore _entityStore;
     private readonly IPlayerService _playerService;
+    private readonly IGameSpriteService _spriteService;
     private readonly ObservableCollection<EntityViewModel> _allEntities = [];
 
     private long _indexCounter = 1;
@@ -33,10 +35,12 @@ public partial class EntityManagerViewModel : ViewModelBase
     {
         _entityStore = serviceProvider.GetRequiredService<IEntityStore>();
         _playerService = serviceProvider.GetRequiredService<IPlayerService>();
+        _spriteService = serviceProvider.GetRequiredService<IGameSpriteService>();
 
         _entityStore.EntityAdded += OnEntityAdded;
         _entityStore.EntityUpdated += OnEntityUpdated;
         _entityStore.EntityRemoved += OnEntityRemoved;
+        _spriteService.SpritesChanged += OnSpritesChanged;
 
         FilteredEntities = new FilteredObservableCollection<EntityViewModel>(_allEntities, MatchesFilter);
 
@@ -64,7 +68,7 @@ public partial class EntityManagerViewModel : ViewModelBase
             return;
         }
 
-        RefreshFilterPreservingSelection();
+        ReconcileFilter();
     }
 
     private void OnClientSelected(ClientViewModel? client)
@@ -81,7 +85,7 @@ public partial class EntityManagerViewModel : ViewModelBase
         }
 
         var sortIndex = ++_indexCounter;
-        var vm = new EntityViewModel(entity)
+        var vm = new EntityViewModel(entity, _spriteService)
         {
             SortIndex = sortIndex
         };
@@ -144,15 +148,19 @@ public partial class EntityManagerViewModel : ViewModelBase
         _allEntities.Remove(vm);
     }
 
-    private void UpdateFiltered(EntityViewModel vm)
+    private void OnSpritesChanged(object? sender, EventArgs e)
     {
-        if (!MatchesFilter(vm))
+        if (!Dispatcher.UIThread.CheckAccess())
         {
-            FilteredEntities.Remove(vm);
+            Dispatcher.UIThread.Post(() => OnSpritesChanged(sender, e));
+            return;
         }
-        else if (!FilteredEntities.Contains(vm))
+
+        foreach (var entity in _allEntities)
         {
-            FilteredEntities.Add(vm);
+            entity.RefreshSprite();
         }
     }
+
+    private void UpdateFiltered(EntityViewModel vm) => FilteredEntities.ReconcileItem(vm);
 }

--- a/Arbiter.App/ViewModels/Entities/EntityViewModel.cs
+++ b/Arbiter.App/ViewModels/Entities/EntityViewModel.cs
@@ -1,17 +1,21 @@
-﻿using Arbiter.App.Models.Entities;
+using Arbiter.App.Models.Entities;
+using Arbiter.App.Services.Sprites;
 using Arbiter.Net.Types;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Arbiter.App.ViewModels.Entities;
 
 public partial class EntityViewModel : ViewModelBase
 {
+    private readonly IGameSpriteService _spriteService;
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(Flags), nameof(Id), nameof(Name), nameof(TypeName), nameof(TypeShorthand),
-        nameof(NameOrTypeName), nameof(Sprite), nameof(MapId), nameof(MapName), nameof(X), nameof(Y), nameof(Position),
-        nameof(IsHidden), nameof(IsGhost))]
+        nameof(NameOrTypeName), nameof(Sprite), nameof(SpriteColor), nameof(SpriteImage), nameof(SpriteFallbackText),
+        nameof(MapId), nameof(MapName), nameof(X), nameof(Y), nameof(Position), nameof(IsHidden), nameof(IsGhost))]
     [NotifyPropertyChangedFor(nameof(IsPlayer), nameof(IsMonster), nameof(IsMundane), nameof(IsItem),
-        nameof(IsReactor))]
+        nameof(IsReactor), nameof(IsCreature), nameof(ShowsSpritePreview))]
     private GameEntity _entity;
 
     [ObservableProperty] private double _opacity = 1;
@@ -45,6 +49,13 @@ public partial class EntityViewModel : ViewModelBase
     };
 
     public ushort Sprite => Entity.Sprite ?? 0;
+    public byte SpriteColor => Entity.Color ?? 0;
+    public IImage? SpriteImage => IsItem
+        ? _spriteService.GetItem(Sprite, SpriteColor)
+        : IsCreature
+            ? _spriteService.GetCreature(Sprite)
+            : null;
+    public string SpriteFallbackText => ShowsSpritePreview ? $"#{Sprite}" : string.Empty;
     public int MapId => Entity.MapId ?? 0;
     public string MapName => Entity.MapName ?? "Unknown Map";
     public int X => Entity.X;
@@ -61,9 +72,19 @@ public partial class EntityViewModel : ViewModelBase
     public bool IsMundane => Flags.HasFlag(EntityFlags.Mundane);
     public bool IsItem => Flags.HasFlag(EntityFlags.Item);
     public bool IsReactor => Flags.HasFlag(EntityFlags.Reactor);
+    public bool IsCreature => IsMonster || IsMundane;
+    public bool ShowsSpritePreview => IsCreature || IsItem;
 
     public EntityViewModel(GameEntity entity)
+        : this(entity, NullGameSpriteService.Instance)
+    {
+    }
+
+    public EntityViewModel(GameEntity entity, IGameSpriteService spriteService)
     {
         Entity = entity;
+        _spriteService = spriteService;
     }
+
+    public void RefreshSprite() => OnPropertyChanged(nameof(SpriteImage));
 }

--- a/Arbiter.App/Views/DialogManagerView.axaml
+++ b/Arbiter.App/Views/DialogManagerView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:Arbiter.App.ViewModels.Dialogs"
+             xmlns:controls="using:Arbiter.App.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="Arbiter.App.Views.DialogManagerView"
              x:DataType="vm:DialogManagerViewModel">
@@ -65,28 +66,25 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Bottom"
                         IsVisible="{Binding ActiveDialog, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue={x:False}}">
-                    <StackPanel Spacing="8" HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <Label Content="Sprite"
-                               FontSize="18"
-                               ToolTip.Tip="The sprite being displayed."
-                               Padding="0"/>
-                        <TextBlock Text="None"
-                                   TextAlignment="Center"
-                                   FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                   FontSize="18"
-                                   FontWeight="SemiBold"
-                                   Foreground="{StaticResource Talgonite.Color.LightGray}"
-                                   VerticalAlignment="Center"
-                                   IsVisible="{Binding ActiveDialog.Sprite, Converter={x:Static ObjectConverters.IsNull}, FallbackValue={x:True}}"/>
-                        <TextBlock Text="{Binding ActiveDialog.Sprite, FallbackValue=None}"
-                                   TextAlignment="Center"
-                                   FontFamily="{StaticResource Talgonite.Font.Monospace}"
-                                   FontSize="18"
-                                   FontWeight="SemiBold"
-                                   Foreground="{StaticResource Talgonite.TextBlock.Foreground}"
-                                   VerticalAlignment="Center"
-                                   IsVisible="{Binding ActiveDialog.Sprite, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue={x:False}}"/>
-                    </StackPanel>
+                    <Grid>
+                        <controls:SpritePresenter Source="{Binding ActiveDialog.SpriteImage}"
+                                                  FallbackText="{Binding ActiveDialog.SpriteFallbackText, FallbackValue=None}"
+                                                  IsEmpty="{Binding !ActiveDialog.HasSprite, FallbackValue={x:True}}"
+                                                  SpriteStretchDirection="DownOnly"/>
+
+                        <Border Background="#B0000000"
+                                Padding="3,1"
+                                CornerRadius="2"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Bottom"
+                                IsVisible="{Binding ActiveDialog.HasSprite, FallbackValue={x:False}}">
+                            <TextBlock Text="{Binding ActiveDialog.Sprite, StringFormat={}Sprite {0}}"
+                                       FontFamily="{StaticResource Talgonite.Font.Monospace}"
+                                       FontSize="11"
+                                       FontWeight="SemiBold"
+                                       Foreground="{StaticResource Talgonite.TextBlock.Foreground}"/>
+                        </Border>
+                    </Grid>
                 </Border>
                 
                 <!--Text Input -->
@@ -207,7 +205,7 @@
                                        VerticalAlignment="Center"
                                        Margin="0,4,0,0"
                                        IsVisible="{Binding ActiveDialog.EntityId, Converter={x:Static StringConverters.IsNotNullOrEmpty}, FallbackValue={x:Null}}"/>
-                            
+
                             <!-- Pursuit Id -->
                             <TextBlock Grid.Column="3"
                                        Text="{Binding ActiveDialog.PursuitId, StringFormat={}Pursuit {0}, FallbackValue={x:Null}}"

--- a/Arbiter.App/Views/EntityManagerView.axaml
+++ b/Arbiter.App/Views/EntityManagerView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:Arbiter.App.ViewModels.Entities"
              xmlns:converters="using:Arbiter.App.Converters"
+             xmlns:controls="using:Arbiter.App.Controls"
              mc:Ignorable="d" d:DesignWidth="340" d:DesignHeight="800"
              x:Class="Arbiter.App.Views.EntityManagerView"
              x:DataType="vm:EntityManagerViewModel">
@@ -135,9 +136,21 @@
                             <!-- Tooltip -->
                             <ToolTip.Tip>
                                 <Border Padding="4">
-                                    <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto"
-                                          RowSpacing="4" ColumnSpacing="8"
-                                          MinWidth="200">
+                                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                                        <controls:SpritePresenter Grid.Column="0"
+                                                                  Width="80"
+                                                                  Height="80"
+                                                                  Source="{Binding SpriteImage}"
+                                                                  FallbackText="{Binding SpriteFallbackText}"
+                                                                  SpriteStretchDirection="DownOnly"
+                                                                  IsVisible="{Binding ShowsSpritePreview}"/>
+
+                                        <Grid Grid.Column="1"
+                                              RowDefinitions="Auto,Auto,Auto,Auto"
+                                              ColumnDefinitions="*,Auto"
+                                              RowSpacing="4"
+                                              ColumnSpacing="8"
+                                              MinWidth="200">
                                         <!-- Name -->
                                         <TextBlock Grid.Row="0" Grid.Column="0"
                                                    Text="{Binding NameOrTypeName}"
@@ -205,6 +218,7 @@
                                                    FontSize="14"
                                                    FontFamily="{StaticResource Talgonite.Font.Monospace}"
                                                    VerticalAlignment="Center"/>
+                                        </Grid>
                                     </Grid>
                                 </Border>
                             </ToolTip.Tip>

--- a/Arbiter.Imaging.Tests/Formats/MpfFileTests.cs
+++ b/Arbiter.Imaging.Tests/Formats/MpfFileTests.cs
@@ -1,0 +1,100 @@
+using System.Buffers.Binary;
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Tests.Formats;
+
+public sealed class MpfFileTests
+{
+    [Test]
+    public void Should_Parse_Frames_Animation_Metadata_And_Palette_Record()
+    {
+        var bytes = TestImageData.Mpf(
+            8,
+            10,
+            [
+                new TestMpfFrame(1, 2, 2, 1, 4, 9, [1, 2]),
+                new TestMpfFrame(2, 3, 1, 2, 4, 9, [3, 4])
+            ],
+            paletteNumber: 17,
+            walkFrameIndex: 0,
+            walkFrameCount: 1,
+            standingFrameIndex: 1,
+            standingFrameCount: 1,
+            optionalAnimationFrameCount: 1,
+            optionalAnimationRatio: 4,
+            attackFrameIndex: 0,
+            attackFrameCount: 1);
+
+        var mpf = MpfFile.Parse(bytes);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mpf.HeaderType, Is.EqualTo(MpfHeaderType.None));
+            Assert.That(mpf.FormatType, Is.EqualTo(MpfFormatType.SingleAttack));
+            Assert.That(mpf.IdleType, Is.EqualTo(MpfIdleType.NormalIdle));
+            Assert.That(mpf.AnimationIntervalMs, Is.EqualTo(400));
+            Assert.That(mpf.PixelWidth, Is.EqualTo(8));
+            Assert.That(mpf.PixelHeight, Is.EqualTo(10));
+            Assert.That(mpf.PaletteNumber, Is.EqualTo(17));
+            Assert.That(mpf.Frames, Has.Count.EqualTo(2));
+            Assert.That(mpf.Frames[0]!.Left, Is.EqualTo(1));
+            Assert.That(mpf.Frames[0]!.Top, Is.EqualTo(2));
+            Assert.That(mpf.Frames[0]!.CenterX, Is.EqualTo(4));
+            Assert.That(mpf.Frames[0]!.CenterY, Is.EqualTo(9));
+            Assert.That(mpf.Frames[0]!.Pixels.ToArray(), Is.EqualTo(new byte[] { 1, 2 }));
+            Assert.That(mpf.Frames[1]!.Pixels.ToArray(), Is.EqualTo(new byte[] { 3, 4 }));
+        });
+    }
+
+    [Test]
+    public void Should_Parse_Variable_Unknown_Header_And_Multiple_Attacks()
+    {
+        var bytes = TestImageData.Mpf(
+            1,
+            1,
+            [new TestMpfFrame(0, 0, 1, 1, 0, 1, [5])],
+            standingFrameCount: 2,
+            optionalAnimationFrameCount: 1,
+            optionalAnimationRatio: 75,
+            attack2FrameIndex: 6,
+            attack2FrameCount: 2,
+            attack3FrameIndex: 8,
+            attack3FrameCount: 3,
+            multipleAttacks: true,
+            includePaletteRecord: false,
+            unknownHeader: true,
+            unknownHeaderFlags: 0x14,
+            unknownHeaderWordCount: 3);
+
+        var mpf = MpfFile.Parse(bytes);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mpf.HeaderType, Is.EqualTo(MpfHeaderType.Unknown));
+            Assert.That(mpf.UnknownHeaderBytes.Length, Is.EqualTo(20));
+            Assert.That(mpf.FormatType, Is.EqualTo(MpfFormatType.MultipleAttacks));
+            Assert.That(mpf.IdleType, Is.EqualTo(MpfIdleType.NormalPlusOptional));
+            Assert.That(mpf.OptionalAnimationProbability, Is.EqualTo(75));
+            Assert.That(mpf.Attack2FrameIndex, Is.EqualTo(6));
+            Assert.That(mpf.Attack2FrameCount, Is.EqualTo(2));
+            Assert.That(mpf.Attack3FrameIndex, Is.EqualTo(8));
+            Assert.That(mpf.Attack3FrameCount, Is.EqualTo(3));
+            Assert.That(mpf.PaletteNumber, Is.Zero);
+            Assert.That(mpf.Frames, Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Should_Reject_Frame_Data_Outside_The_File()
+    {
+        var bytes = TestImageData.Mpf(
+            1,
+            1,
+            [new TestMpfFrame(0, 0, 1, 1, 0, 1, [5])],
+            includePaletteRecord: false);
+        var frameStartOffset = bytes.Length - 1 - 16;
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(frameStartOffset + 12), int.MaxValue);
+
+        Assert.That(() => MpfFile.Parse(bytes), Throws.TypeOf<InvalidDataException>());
+    }
+}

--- a/Arbiter.Imaging.Tests/Formats/PaletteTests.cs
+++ b/Arbiter.Imaging.Tests/Formats/PaletteTests.cs
@@ -20,4 +20,15 @@ public sealed class PaletteTests
     {
         Assert.That(() => Palette.Parse(new byte[10]), Throws.TypeOf<InvalidDataException>());
     }
+
+    [Test]
+    public void Should_Parse_Windows_Riff_Palettes()
+    {
+        var palette = Palette.Parse(TestImageData.WindowsPalette((7, 12, 34, 56)));
+        Span<byte> rgba = stackalloc byte[4];
+
+        palette.GetColor(7, false, rgba);
+
+        Assert.That(rgba.ToArray(), Is.EqualTo(new byte[] { 12, 34, 56, 255 }));
+    }
 }

--- a/Arbiter.Imaging.Tests/Sprites/CreatureSpriteLoaderTests.cs
+++ b/Arbiter.Imaging.Tests/Sprites/CreatureSpriteLoaderTests.cs
@@ -1,0 +1,99 @@
+using Arbiter.IO.Assets;
+using Arbiter.Imaging.Sprites;
+
+namespace Arbiter.Imaging.Tests.Sprites;
+
+public sealed class CreatureSpriteLoaderTests
+{
+    private string _directory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "Arbiter.Imaging.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(_directory, true);
+    }
+
+    [Test]
+    public void Should_Load_South_Facing_Idle_Frame_With_Embedded_Palette_Number()
+    {
+        TestImageData.WriteDat(
+            _directory,
+            "mock.dat",
+            ("mns007.mpf", TestImageData.Mpf(
+                2,
+                1,
+                [
+                    new TestMpfFrame(0, 0, 2, 1, 1, 1, [1, 1]),
+                    new TestMpfFrame(0, 0, 2, 1, 1, 1, [2, 3])
+                ],
+                paletteNumber: 3,
+                walkFrameCount: 1,
+                standingFrameIndex: 1,
+                standingFrameCount: 1)),
+            ("mns003.pal", TestImageData.Palette(
+                (2, 10, 20, 30),
+                (3, 40, 50, 60))));
+        var loader = new CreatureSpriteLoader(DatAssetCatalog.Load(_directory));
+
+        var preview = loader.LoadPreview(7);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(preview, Is.Not.Null);
+            Assert.That(preview!.FrameCount, Is.EqualTo(1));
+            Assert.That(preview.Width, Is.EqualTo(2));
+            Assert.That(preview.Height, Is.EqualTo(1));
+            Assert.That(preview.SourceImageName, Does.Contain("mns007.mpf"));
+            Assert.That(preview.SourcePaletteName, Does.Contain("mns003.pal"));
+            Assert.That(preview.Pixels.ToArray(), Is.EqualTo(new byte[]
+            {
+                40, 50, 60, 255,
+                10, 20, 30, 255
+            }));
+        });
+    }
+
+    [Test]
+    public void Should_Use_Second_Standing_Direction_Block_For_South_Facing_Preview()
+    {
+        TestImageData.WriteDat(
+            _directory,
+            "mock.dat",
+            ("mns008.mpf", TestImageData.Mpf(
+                1,
+                1,
+                [
+                    new TestMpfFrame(0, 0, 1, 1, 0, 1, [1]),
+                    new TestMpfFrame(0, 0, 1, 1, 0, 1, [2]),
+                    new TestMpfFrame(0, 0, 1, 1, 0, 1, [3]),
+                    new TestMpfFrame(0, 0, 1, 1, 0, 1, [4])
+                ],
+                standingFrameIndex: 2,
+                standingFrameCount: 1,
+                optionalAnimationFrameCount: 1)),
+            ("mns000.pal", TestImageData.Palette(
+                (3, 30, 0, 0),
+                (4, 40, 0, 0))));
+        var loader = new CreatureSpriteLoader(DatAssetCatalog.Load(_directory));
+
+        var preview = loader.LoadPreview(8);
+
+        Assert.That(preview!.Pixels.ToArray(), Is.EqualTo(new byte[] { 40, 0, 0, 255 }));
+    }
+
+    [Test]
+    public void Should_Return_Null_When_Creature_Sprite_Is_Missing()
+    {
+        TestImageData.WriteDat(_directory, "mock.dat", ("mns000.pal", TestImageData.Palette()));
+        var loader = new CreatureSpriteLoader(DatAssetCatalog.Load(_directory));
+
+        Assert.That(loader.LoadPreview(99), Is.Null);
+    }
+}

--- a/Arbiter.Imaging.Tests/Sprites/GameSpriteDataLoaderTests.cs
+++ b/Arbiter.Imaging.Tests/Sprites/GameSpriteDataLoaderTests.cs
@@ -36,6 +36,7 @@ public sealed class GameSpriteDataLoaderTests
             Assert.That(data.SkillsOnCooldown, Is.Not.Null);
             Assert.That(data.Spells, Is.Null);
             Assert.That(data.Items, Is.Null);
+            Assert.That(data.Creatures, Is.Not.Null);
             Assert.That(data.Issues.Select(issue => issue.Category), Is.EquivalentTo(new[] { "spells", "items" }));
         });
     }

--- a/Arbiter.Imaging.Tests/TestImageData.cs
+++ b/Arbiter.Imaging.Tests/TestImageData.cs
@@ -77,6 +77,136 @@ internal static class TestImageData
         return bytes;
     }
 
+    public static byte[] WindowsPalette(params (byte Index, byte Red, byte Green, byte Blue)[] colors)
+    {
+        var rgb = colors.ToDictionary(color => color.Index);
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.ASCII, true))
+        {
+            writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+            writer.Write(16 + 256 * 4);
+            writer.Write(Encoding.ASCII.GetBytes("PAL "));
+            writer.Write(Encoding.ASCII.GetBytes("data"));
+            writer.Write(4 + 256 * 4);
+            writer.Write((ushort)0x0300);
+            writer.Write((ushort)256);
+            for (var index = 0; index < 256; index++)
+            {
+                var color = rgb.GetValueOrDefault((byte)index);
+                writer.Write(color.Red);
+                writer.Write(color.Green);
+                writer.Write(color.Blue);
+                writer.Write((byte)0);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    public static byte[] Mpf(
+        int pixelWidth,
+        int pixelHeight,
+        IReadOnlyList<TestMpfFrame> frames,
+        int paletteNumber = 0,
+        byte walkFrameIndex = 0,
+        byte walkFrameCount = 0,
+        byte standingFrameIndex = 0,
+        byte standingFrameCount = 0,
+        byte optionalAnimationFrameCount = 0,
+        byte optionalAnimationRatio = 0,
+        byte attackFrameIndex = 0,
+        byte attackFrameCount = 0,
+        byte attack2FrameIndex = 0,
+        byte attack2FrameCount = 0,
+        byte attack3FrameIndex = 0,
+        byte attack3FrameCount = 0,
+        bool multipleAttacks = false,
+        bool includePaletteRecord = true,
+        bool unknownHeader = false,
+        int unknownHeaderFlags = 0,
+        int unknownHeaderWordCount = 0)
+    {
+        var dataLength = frames.Sum(frame => frame.Pixels.Length);
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.ASCII, true))
+        {
+            if (unknownHeader)
+            {
+                writer.Write(-1);
+                writer.Write(unknownHeaderFlags);
+                if ((unknownHeaderFlags & 4) != 0)
+                {
+                    writer.Write(unknownHeaderWordCount);
+                    for (var index = 0; index < unknownHeaderWordCount; index++)
+                    {
+                        writer.Write(0x10203040 + index);
+                    }
+                }
+            }
+
+            writer.Write(checked((byte)(frames.Count + (includePaletteRecord ? 1 : 0))));
+            writer.Write(checked((short)pixelWidth));
+            writer.Write(checked((short)pixelHeight));
+            writer.Write(dataLength);
+            writer.Write(walkFrameIndex);
+            writer.Write(walkFrameCount);
+
+            if (multipleAttacks)
+            {
+                writer.Write((short)-1);
+                writer.Write(standingFrameIndex);
+                writer.Write(standingFrameCount);
+                writer.Write(optionalAnimationFrameCount);
+                writer.Write(optionalAnimationRatio);
+                writer.Write(attackFrameIndex);
+                writer.Write(attackFrameCount);
+                writer.Write(attack2FrameIndex);
+                writer.Write(attack2FrameCount);
+                writer.Write(attack3FrameIndex);
+                writer.Write(attack3FrameCount);
+            }
+            else
+            {
+                writer.Write(attackFrameIndex);
+                writer.Write(attackFrameCount);
+                writer.Write(standingFrameIndex);
+                writer.Write(standingFrameCount);
+                writer.Write(optionalAnimationFrameCount);
+                writer.Write(optionalAnimationRatio);
+            }
+
+            var startAddress = 0;
+            foreach (var frame in frames)
+            {
+                writer.Write(frame.Left);
+                writer.Write(frame.Top);
+                writer.Write(checked((short)(frame.Left + frame.Width)));
+                writer.Write(checked((short)(frame.Top + frame.Height)));
+                writer.Write(frame.CenterX);
+                writer.Write(frame.CenterY);
+                writer.Write(startAddress);
+                startAddress += frame.Pixels.Length;
+            }
+
+            if (includePaletteRecord)
+            {
+                for (var index = 0; index < 6; index++)
+                {
+                    writer.Write((short)-1);
+                }
+
+                writer.Write(paletteNumber);
+            }
+
+            foreach (var frame in frames)
+            {
+                writer.Write(frame.Pixels);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
     public static byte[] Text(string value) => Encoding.ASCII.GetBytes(value);
 
     private static void WriteDatTableEntry(byte[] bytes, int index, int offset, string name)
@@ -87,3 +217,12 @@ internal static class TestImageData
         nameBytes.AsSpan(0, Math.Min(nameBytes.Length, 13)).CopyTo(bytes.AsSpan(entryOffset + 4, 13));
     }
 }
+
+internal readonly record struct TestMpfFrame(
+    short Left,
+    short Top,
+    short Width,
+    short Height,
+    short CenterX,
+    short CenterY,
+    byte[] Pixels);

--- a/Arbiter.Imaging/Formats/MpfFile.cs
+++ b/Arbiter.Imaging/Formats/MpfFile.cs
@@ -1,0 +1,317 @@
+using System.Buffers.Binary;
+
+namespace Arbiter.Imaging.Formats;
+
+// The MPF layout is adapted from DALib's MIT-licensed MpfFile and MpfView implementations.
+public sealed class MpfFile
+{
+    private const int FrameTableEntrySize = 16;
+    private const int StaticNoIdleIntervalMs = 10_000;
+    private const int DefaultIdleIntervalMs = 300;
+    private const int MinimumNormalIdleIntervalMs = 100;
+
+    public MpfHeaderType HeaderType { get; }
+    public MpfFormatType FormatType { get; }
+    public MpfIdleType IdleType { get; }
+    public int PixelWidth { get; }
+    public int PixelHeight { get; }
+    public int PaletteNumber { get; }
+    public int WalkFrameIndex { get; }
+    public int WalkFrameCount { get; }
+    public int StandingFrameIndex { get; }
+    public int StandingFrameCount { get; }
+    public int OptionalAnimationFrameCount { get; }
+    public int OptionalAnimationProbability { get; }
+    public int AnimationIntervalMs { get; }
+    public int AttackFrameIndex { get; }
+    public int AttackFrameCount { get; }
+    public int Attack2FrameIndex { get; }
+    public int Attack2FrameCount { get; }
+    public int Attack3FrameIndex { get; }
+    public int Attack3FrameCount { get; }
+    public ReadOnlyMemory<byte> UnknownHeaderBytes { get; }
+    public IReadOnlyList<MpfFrame?> Frames { get; }
+
+    private MpfFile(
+        MpfHeaderType headerType,
+        MpfFormatType formatType,
+        int pixelWidth,
+        int pixelHeight,
+        int paletteNumber,
+        int walkFrameIndex,
+        int walkFrameCount,
+        int standingFrameIndex,
+        int standingFrameCount,
+        int optionalAnimationFrameCount,
+        int rawOptionalAnimationRatio,
+        int attackFrameIndex,
+        int attackFrameCount,
+        int attack2FrameIndex,
+        int attack2FrameCount,
+        int attack3FrameIndex,
+        int attack3FrameCount,
+        byte[] unknownHeaderBytes,
+        IReadOnlyList<MpfFrame?> frames)
+    {
+        HeaderType = headerType;
+        FormatType = formatType;
+        PixelWidth = pixelWidth;
+        PixelHeight = pixelHeight;
+        PaletteNumber = paletteNumber;
+        WalkFrameIndex = walkFrameIndex;
+        WalkFrameCount = walkFrameCount;
+        StandingFrameIndex = standingFrameIndex;
+        StandingFrameCount = standingFrameCount;
+        OptionalAnimationFrameCount = optionalAnimationFrameCount;
+        AttackFrameIndex = attackFrameIndex;
+        AttackFrameCount = attackFrameCount;
+        Attack2FrameIndex = attack2FrameIndex;
+        Attack2FrameCount = attack2FrameCount;
+        Attack3FrameIndex = attack3FrameIndex;
+        Attack3FrameCount = attack3FrameCount;
+        UnknownHeaderBytes = unknownHeaderBytes;
+        Frames = frames;
+
+        IdleType = DetectIdleType(standingFrameCount, optionalAnimationFrameCount);
+        switch (IdleType)
+        {
+            case MpfIdleType.StaticNoIdle:
+                AnimationIntervalMs = StaticNoIdleIntervalMs;
+                break;
+            case MpfIdleType.NormalIdle:
+                AnimationIntervalMs = rawOptionalAnimationRatio > 0
+                    ? Math.Max(MinimumNormalIdleIntervalMs, rawOptionalAnimationRatio * 100)
+                    : DefaultIdleIntervalMs;
+                break;
+            case MpfIdleType.NormalPlusOptional:
+                AnimationIntervalMs = DefaultIdleIntervalMs;
+                OptionalAnimationProbability = rawOptionalAnimationRatio;
+                break;
+        }
+    }
+
+    public static MpfFile Load(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return Parse(buffer.ToArray());
+    }
+
+    public static MpfFile Parse(ReadOnlySpan<byte> bytes)
+    {
+        var offset = 0;
+        var headerType = MpfHeaderType.None;
+        byte[] unknownHeaderBytes = [];
+        if (bytes.Length >= sizeof(int) && ReadInt32(bytes, 0) == (int)MpfHeaderType.Unknown)
+        {
+            headerType = MpfHeaderType.Unknown;
+            offset += sizeof(int);
+            var unknownHeaderStart = offset;
+            var flags = ReadInt32(bytes, offset);
+            offset += sizeof(int);
+            if ((flags & 4) != 0)
+            {
+                var count = ReadNonNegativeInt32(bytes, offset, "extended header count");
+                offset += sizeof(int);
+                var extraLength = checked(count * sizeof(int));
+                EnsureAvailable(bytes, offset, extraLength, "extended header data");
+                offset += extraLength;
+            }
+
+            unknownHeaderBytes = bytes[unknownHeaderStart..offset].ToArray();
+        }
+
+        var declaredFrameCount = ReadByte(bytes, ref offset, "frame count");
+        var pixelWidth = ReadNonNegativeInt16(bytes, ref offset, "pixel width");
+        var pixelHeight = ReadNonNegativeInt16(bytes, ref offset, "pixel height");
+        var dataLength = ReadNonNegativeInt32(bytes, offset, "data length");
+        offset += sizeof(int);
+        var walkFrameIndex = ReadByte(bytes, ref offset, "walk frame index");
+        var walkFrameCount = ReadByte(bytes, ref offset, "walk frame count");
+
+        var formatMarkerOffset = offset;
+        var formatMarker = ReadInt16(bytes, ref offset, "format type");
+        var formatType = formatMarker == (short)MpfFormatType.MultipleAttacks
+            ? MpfFormatType.MultipleAttacks
+            : MpfFormatType.SingleAttack;
+
+        int standingFrameIndex;
+        int standingFrameCount;
+        int optionalAnimationFrameCount;
+        int rawOptionalAnimationRatio;
+        int attackFrameIndex;
+        int attackFrameCount;
+        var attack2FrameIndex = 0;
+        var attack2FrameCount = 0;
+        var attack3FrameIndex = 0;
+        var attack3FrameCount = 0;
+
+        if (formatType == MpfFormatType.MultipleAttacks)
+        {
+            standingFrameIndex = ReadByte(bytes, ref offset, "standing frame index");
+            standingFrameCount = ReadByte(bytes, ref offset, "standing frame count");
+            optionalAnimationFrameCount = ReadByte(bytes, ref offset, "optional animation frame count");
+            rawOptionalAnimationRatio = ReadByte(bytes, ref offset, "optional animation ratio");
+            attackFrameIndex = ReadByte(bytes, ref offset, "attack frame index");
+            attackFrameCount = ReadByte(bytes, ref offset, "attack frame count");
+            attack2FrameIndex = ReadByte(bytes, ref offset, "second attack frame index");
+            attack2FrameCount = ReadByte(bytes, ref offset, "second attack frame count");
+            attack3FrameIndex = ReadByte(bytes, ref offset, "third attack frame index");
+            attack3FrameCount = ReadByte(bytes, ref offset, "third attack frame count");
+        }
+        else
+        {
+            offset = formatMarkerOffset;
+            attackFrameIndex = ReadByte(bytes, ref offset, "attack frame index");
+            attackFrameCount = ReadByte(bytes, ref offset, "attack frame count");
+            standingFrameIndex = ReadByte(bytes, ref offset, "standing frame index");
+            standingFrameCount = ReadByte(bytes, ref offset, "standing frame count");
+            optionalAnimationFrameCount = ReadByte(bytes, ref offset, "optional animation frame count");
+            rawOptionalAnimationRatio = ReadByte(bytes, ref offset, "optional animation ratio");
+        }
+
+        var dataStart = bytes.Length - dataLength;
+        if (dataStart < offset)
+        {
+            throw new InvalidDataException("The MPF data segment overlaps its header.");
+        }
+
+        var tableLength = checked(declaredFrameCount * FrameTableEntrySize);
+        if (offset > dataStart - tableLength)
+        {
+            throw new InvalidDataException("The MPF frame table exceeds the file bounds.");
+        }
+
+        var paletteNumber = 0;
+        var frames = new List<MpfFrame?>(declaredFrameCount);
+        for (var frameIndex = 0; frameIndex < declaredFrameCount; frameIndex++)
+        {
+            var entryOffset = checked(offset + frameIndex * FrameTableEntrySize);
+            var left = ReadInt16(bytes, entryOffset);
+            var top = ReadInt16(bytes, entryOffset + 2);
+            var right = ReadInt16(bytes, entryOffset + 4);
+            var bottom = ReadInt16(bytes, entryOffset + 6);
+            var centerX = ReadInt16(bytes, entryOffset + 8);
+            var centerY = ReadInt16(bytes, entryOffset + 10);
+            var startAddress = ReadInt32(bytes, entryOffset + 12);
+
+            if (left == -1 && top == -1)
+            {
+                paletteNumber = startAddress;
+                continue;
+            }
+
+            var width = right - left;
+            var height = bottom - top;
+            if (width == 0 || height == 0)
+            {
+                frames.Add(null);
+                continue;
+            }
+
+            if (left < 0 || top < 0 || width < 0 || height < 0)
+            {
+                throw new InvalidDataException($"MPF frame {frameIndex} has invalid dimensions.");
+            }
+
+            var frameDataLength = checked(width * height);
+            if (startAddress < 0 || startAddress > dataLength - frameDataLength)
+            {
+                throw new InvalidDataException($"MPF frame {frameIndex} data exceeds the file bounds.");
+            }
+
+            frames.Add(new MpfFrame(
+                left,
+                top,
+                width,
+                height,
+                centerX,
+                centerY,
+                bytes.Slice(dataStart + startAddress, frameDataLength).ToArray()));
+        }
+
+        return new MpfFile(
+            headerType,
+            formatType,
+            pixelWidth,
+            pixelHeight,
+            paletteNumber,
+            walkFrameIndex,
+            walkFrameCount,
+            standingFrameIndex,
+            standingFrameCount,
+            optionalAnimationFrameCount,
+            rawOptionalAnimationRatio,
+            attackFrameIndex,
+            attackFrameCount,
+            attack2FrameIndex,
+            attack2FrameCount,
+            attack3FrameIndex,
+            attack3FrameCount,
+            unknownHeaderBytes,
+            frames);
+    }
+
+    public static MpfIdleType DetectIdleType(int standingFrameCount, int optionalAnimationFrameCount)
+    {
+        if (optionalAnimationFrameCount == 0)
+        {
+            return MpfIdleType.StaticNoIdle;
+        }
+
+        return standingFrameCount == 0 || standingFrameCount == optionalAnimationFrameCount
+            ? MpfIdleType.NormalIdle
+            : MpfIdleType.NormalPlusOptional;
+    }
+
+    private static byte ReadByte(ReadOnlySpan<byte> bytes, ref int offset, string fieldName)
+    {
+        EnsureAvailable(bytes, offset, sizeof(byte), fieldName);
+        return bytes[offset++];
+    }
+
+    private static int ReadNonNegativeInt16(ReadOnlySpan<byte> bytes, ref int offset, string fieldName)
+    {
+        var value = ReadInt16(bytes, ref offset, fieldName);
+        return value < 0
+            ? throw new InvalidDataException($"The MPF {fieldName} cannot be negative.")
+            : value;
+    }
+
+    private static int ReadNonNegativeInt32(ReadOnlySpan<byte> bytes, int offset, string fieldName)
+    {
+        var value = ReadInt32(bytes, offset);
+        return value < 0
+            ? throw new InvalidDataException($"The MPF {fieldName} cannot be negative.")
+            : value;
+    }
+
+    private static short ReadInt16(ReadOnlySpan<byte> bytes, ref int offset, string fieldName)
+    {
+        EnsureAvailable(bytes, offset, sizeof(short), fieldName);
+        var value = BinaryPrimitives.ReadInt16LittleEndian(bytes[offset..]);
+        offset += sizeof(short);
+        return value;
+    }
+
+    private static short ReadInt16(ReadOnlySpan<byte> bytes, int offset)
+    {
+        EnsureAvailable(bytes, offset, sizeof(short), "frame table value");
+        return BinaryPrimitives.ReadInt16LittleEndian(bytes[offset..]);
+    }
+
+    private static int ReadInt32(ReadOnlySpan<byte> bytes, int offset)
+    {
+        EnsureAvailable(bytes, offset, sizeof(int), "Int32 value");
+        return BinaryPrimitives.ReadInt32LittleEndian(bytes[offset..]);
+    }
+
+    private static void EnsureAvailable(ReadOnlySpan<byte> bytes, int offset, int length, string fieldName)
+    {
+        if (offset < 0 || length < 0 || offset > bytes.Length - length)
+        {
+            throw new InvalidDataException($"The MPF is missing its {fieldName}.");
+        }
+    }
+}

--- a/Arbiter.Imaging/Formats/MpfFormatType.cs
+++ b/Arbiter.Imaging/Formats/MpfFormatType.cs
@@ -1,0 +1,7 @@
+namespace Arbiter.Imaging.Formats;
+
+public enum MpfFormatType
+{
+    MultipleAttacks = -1,
+    SingleAttack = 0
+}

--- a/Arbiter.Imaging/Formats/MpfFrame.cs
+++ b/Arbiter.Imaging/Formats/MpfFrame.cs
@@ -1,0 +1,32 @@
+namespace Arbiter.Imaging.Formats;
+
+public sealed class MpfFrame
+{
+    private readonly byte[] _pixels;
+
+    public int Left { get; }
+    public int Top { get; }
+    public int Width { get; }
+    public int Height { get; }
+    public int CenterX { get; }
+    public int CenterY { get; }
+    public ReadOnlyMemory<byte> Pixels => _pixels;
+
+    internal MpfFrame(
+        int left,
+        int top,
+        int width,
+        int height,
+        int centerX,
+        int centerY,
+        byte[] pixels)
+    {
+        Left = left;
+        Top = top;
+        Width = width;
+        Height = height;
+        CenterX = centerX;
+        CenterY = centerY;
+        _pixels = pixels;
+    }
+}

--- a/Arbiter.Imaging/Formats/MpfHeaderType.cs
+++ b/Arbiter.Imaging/Formats/MpfHeaderType.cs
@@ -1,0 +1,7 @@
+namespace Arbiter.Imaging.Formats;
+
+public enum MpfHeaderType
+{
+    Unknown = -1,
+    None = 0
+}

--- a/Arbiter.Imaging/Formats/MpfIdleType.cs
+++ b/Arbiter.Imaging/Formats/MpfIdleType.cs
@@ -1,0 +1,8 @@
+namespace Arbiter.Imaging.Formats;
+
+public enum MpfIdleType
+{
+    StaticNoIdle,
+    NormalIdle,
+    NormalPlusOptional
+}

--- a/Arbiter.Imaging/Formats/Palette.cs
+++ b/Arbiter.Imaging/Formats/Palette.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+
 namespace Arbiter.Imaging.Formats;
 
 public sealed class Palette
@@ -22,12 +24,12 @@ public sealed class Palette
 
     public static Palette Parse(ReadOnlySpan<byte> bytes)
     {
-        if (bytes.Length != ByteLength)
+        if (bytes.Length == ByteLength)
         {
-            throw new InvalidDataException($"A palette must contain exactly {ByteLength} bytes.");
+            return new Palette(bytes.ToArray());
         }
 
-        return new Palette(bytes.ToArray());
+        return ParseRiff(bytes);
     }
 
     public void GetColor(byte index, bool useLuminanceAlpha, Span<byte> rgba)
@@ -92,6 +94,63 @@ public sealed class Palette
         var linearLuminance = 0.299 * linearRed + 0.587 * linearGreen + 0.114 * linearBlue;
         var luminance = Math.Pow(linearLuminance, 1.0 / gamma) * 255.0;
         return (byte)Math.Clamp(Math.Round(luminance), byte.MinValue, byte.MaxValue);
+    }
+
+    private static Palette ParseRiff(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < 12 || !bytes[..4].SequenceEqual("RIFF"u8) ||
+            !bytes.Slice(8, 4).SequenceEqual("PAL "u8))
+        {
+            throw new InvalidDataException(
+                $"A palette must be a {ByteLength}-byte RGB palette or a RIFF PAL file.");
+        }
+
+        var riffLength = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[4..]) + 8);
+        if (riffLength > bytes.Length)
+        {
+            throw new InvalidDataException("The RIFF palette exceeds the file bounds.");
+        }
+
+        var offset = 12;
+        while (offset <= riffLength - 8)
+        {
+            var chunkName = bytes.Slice(offset, 4);
+            var chunkLength = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 4)..]));
+            var chunkOffset = offset + 8;
+            if (chunkOffset > riffLength - chunkLength)
+            {
+                throw new InvalidDataException("A RIFF palette chunk exceeds the file bounds.");
+            }
+
+            if (chunkName.SequenceEqual("data"u8))
+            {
+                if (chunkLength < 4)
+                {
+                    throw new InvalidDataException("The RIFF palette data chunk is incomplete.");
+                }
+
+                var colorCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(chunkOffset + 2)..]);
+                var requiredLength = checked(4 + colorCount * 4);
+                if (colorCount > ColorCount || chunkLength < requiredLength)
+                {
+                    throw new InvalidDataException("The RIFF palette contains invalid color data.");
+                }
+
+                var colors = new byte[ByteLength];
+                for (var index = 0; index < colorCount; index++)
+                {
+                    var sourceOffset = chunkOffset + 4 + index * 4;
+                    var targetOffset = index * 3;
+                    bytes.Slice(sourceOffset, 3).CopyTo(colors.AsSpan(targetOffset, 3));
+                }
+
+                return new Palette(colors);
+            }
+
+            offset = checked(chunkOffset + chunkLength + (chunkLength & 1));
+        }
+
+        throw new InvalidDataException("The RIFF palette does not contain a data chunk.");
     }
 }
 

--- a/Arbiter.Imaging/Sprites/CreatureSpriteLoader.cs
+++ b/Arbiter.Imaging/Sprites/CreatureSpriteLoader.cs
@@ -1,0 +1,127 @@
+using Arbiter.IO.Assets;
+using Arbiter.Imaging.Formats;
+
+namespace Arbiter.Imaging.Sprites;
+
+public sealed class CreatureSpriteLoader
+{
+    private const string ImagePrefix = "mns";
+    private const string ImageSuffix = ".mpf";
+    private const string PaletteSuffix = ".pal";
+
+    private readonly DatAssetCatalog _catalog;
+
+    public CreatureSpriteLoader(DatAssetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    public SpriteAtlas? LoadPreview(ushort sprite)
+    {
+        if (sprite == 0)
+        {
+            return null;
+        }
+
+        var imageName = $"{ImagePrefix}{sprite:D3}{ImageSuffix}";
+        if (!_catalog.TryGet(imageName, out var imageAsset))
+        {
+            return null;
+        }
+
+        using var imageStream = imageAsset.OpenRead();
+        var mpf = MpfFile.Load(imageStream);
+        var (frame, flipHorizontally) = GetSouthFacingPreviewFrame(mpf);
+        if (frame is null)
+        {
+            return null;
+        }
+
+        var paletteName = $"{ImagePrefix}{mpf.PaletteNumber:D3}{PaletteSuffix}";
+        if (!_catalog.TryGet(paletteName, out var paletteAsset))
+        {
+            throw new FileNotFoundException($"Asset '{paletteName}' was not found.", paletteName);
+        }
+
+        using var paletteStream = paletteAsset.OpenRead();
+        var palette = Palette.Load(paletteStream);
+        return BuildPreview(
+            frame,
+            palette,
+            $"{imageAsset.Name} ({imageAsset.ArchiveName})",
+            $"{paletteAsset.Name} ({paletteAsset.ArchiveName})",
+            flipHorizontally);
+    }
+
+    private static (MpfFrame? Frame, bool FlipHorizontally) GetSouthFacingPreviewFrame(MpfFile mpf)
+    {
+        var baseIndex = mpf.OptionalAnimationFrameCount == 0
+            ? mpf.WalkFrameIndex
+            : mpf.StandingFrameIndex;
+        var directionOffset = mpf.OptionalAnimationFrameCount == 0
+            ? mpf.WalkFrameCount
+            : mpf.OptionalAnimationFrameCount;
+        if (baseIndex + directionOffset >= mpf.Frames.Count)
+        {
+            directionOffset = 0;
+        }
+
+        if (GetFrame(mpf, baseIndex + directionOffset) is { } southFacing)
+        {
+            return (southFacing, true);
+        }
+
+        if (mpf.StandingFrameCount > 0 && GetFrame(mpf, mpf.StandingFrameIndex) is { } standing)
+        {
+            return (standing, true);
+        }
+
+        if (mpf.WalkFrameCount > 0 && GetFrame(mpf, mpf.WalkFrameIndex) is { } walking)
+        {
+            return (walking, true);
+        }
+
+        return (mpf.Frames.FirstOrDefault(frame => frame is not null), true);
+    }
+
+    private static MpfFrame? GetFrame(MpfFile mpf, int index)
+    {
+        return index >= 0 && index < mpf.Frames.Count ? mpf.Frames[index] : null;
+    }
+
+    private static SpriteAtlas BuildPreview(
+        MpfFrame frame,
+        Palette palette,
+        string sourceImageName,
+        string sourcePaletteName,
+        bool flipHorizontally)
+    {
+        var pixels = new byte[checked(frame.Width * frame.Height * 4)];
+        var indexedPixels = frame.Pixels.Span;
+        Span<byte> rgba = stackalloc byte[4];
+        for (var y = 0; y < frame.Height; y++)
+        {
+            for (var x = 0; x < frame.Width; x++)
+            {
+                var sourceX = flipHorizontally ? frame.Width - x - 1 : x;
+                var sourceIndex = y * frame.Width + sourceX;
+                var targetIndex = (y * frame.Width + x) * 4;
+                palette.GetColor(indexedPixels[sourceIndex], false, rgba);
+                rgba.CopyTo(pixels.AsSpan(targetIndex, 4));
+            }
+        }
+
+        var region = new SpriteAtlasRegion(0, 0, frame.Width, frame.Height);
+        return new SpriteAtlas(
+            sourceImageName,
+            sourcePaletteName,
+            frame.Width,
+            frame.Height,
+            frame.Width,
+            frame.Height,
+            pixels,
+            [region],
+            [region]);
+    }
+}

--- a/Arbiter.Imaging/Sprites/GameSpriteData.cs
+++ b/Arbiter.Imaging/Sprites/GameSpriteData.cs
@@ -7,6 +7,7 @@ public sealed class GameSpriteData
     public SpriteAtlas? Spells { get; }
     public SpriteAtlas? SpellsOnCooldown { get; }
     public ItemSpriteAtlasCollection? Items { get; }
+    public CreatureSpriteLoader Creatures { get; }
     public IReadOnlyList<GameSpriteLoadIssue> Issues { get; }
 
     internal GameSpriteData(
@@ -15,6 +16,7 @@ public sealed class GameSpriteData
         SpriteAtlas? spells,
         SpriteAtlas? spellsOnCooldown,
         ItemSpriteAtlasCollection? items,
+        CreatureSpriteLoader creatures,
         IReadOnlyList<GameSpriteLoadIssue> issues)
     {
         Skills = skills;
@@ -22,6 +24,7 @@ public sealed class GameSpriteData
         Spells = spells;
         SpellsOnCooldown = spellsOnCooldown;
         Items = items;
+        Creatures = creatures;
         Issues = issues;
     }
 }

--- a/Arbiter.Imaging/Sprites/GameSpriteDataLoader.cs
+++ b/Arbiter.Imaging/Sprites/GameSpriteDataLoader.cs
@@ -36,7 +36,14 @@ public static class GameSpriteDataLoader
             issues.Add(new GameSpriteLoadIssue("items", exception));
         }
 
-        return new GameSpriteData(skills, skillsOnCooldown, spells, spellsOnCooldown, items, issues);
+        return new GameSpriteData(
+            skills,
+            skillsOnCooldown,
+            spells,
+            spellsOnCooldown,
+            items,
+            new CreatureSpriteLoader(catalog),
+            issues);
     }
 
     private static (SpriteAtlas? Normal, SpriteAtlas? Cooldown) LoadAbility(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add reusable IO and imaging libraries for reading game data archives, decoding EPF and palette data, resolving item dyes, and building sprite atlases
+- Decode MPF creature animation files and raw or RIFF palettes with reusable imaging APIs and lazy preview loading
 - Render full-color inventory sprites and grayscale skill and spell sprites from the configured game client's data archives, with numeric fallbacks when sprites cannot be resolved
+- Render monster, NPC, and full-color ground-item sprites in entity tooltips, with numeric fallbacks when assets cannot be resolved
 - Reserve inventory slot 60 for the player's gold bag and show the current gold count in its tooltip
 - Show blue-tinted skill and spell sprites with centered, compact countdowns while cooldowns are active
 - Configure default client and server packet filters that apply on startup and can be restored while tracing
@@ -21,8 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hide the trace client filter when only one client is present
 - Keep inventory sprites centered at their natural size instead of scaling them up to fill their slots
 - Show item, skill, and spell icons to the left of their names in tooltips
+- Render creature and item sprites in dialog portraits with the sprite ID overlaid in the portrait's bottom-right corner
 - Show item quantities greater than one as bottom-aligned `(xN)` labels and format gold as a comma-separated yellow tooltip line
 - Improve slot readability with translucent slot-number backgrounds and white borders on mouseover
+- Use south-facing idle frames for creature previews in entity tooltips and dialog portraits
+- Keep entity row containers stable during active-map updates so mouseover tooltips and selection are not reset by movement packets
 - Treat every cooldown packet as authoritative, replacing the active deadline and latest reported duration while keeping the tooltip duration separate from the ticking countdown
 
 ## [1.8.2] - 2026-07-09

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,27 @@
+# Third-Party Notices
+
+## DALib
+
+The MPF format decoder in `Arbiter.Imaging` is adapted from the `MpfFile` and `MpfView` implementations in [eriscorp/dalib](https://github.com/eriscorp/dalib).
+
+MIT License
+
+Copyright (c) 2017 Kyle Speck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add reusable, bounds-checked MPF parsing to `Arbiter.Imaging`, based on DALib's MIT-licensed implementation, including single/multi-attack headers, variable extended headers, animation metadata, frame anchors, palette records, and raw or RIFF palettes.
- Load creature previews lazily from the configured game directory and cache the resulting Avalonia images without adding game assets to the repository.
- Render south-facing monster/NPC previews and full-color dyed ground-item sprites in entity tooltips.
- Render creature/item sprites in dialog portraits, preserve numeric fallbacks, and overlay `Sprite N` in the portrait's bottom-right corner.
- Reconcile active entity filters incrementally so movement packets do not reset list rows, mouseover tooltips, or selection.
- Add DALib attribution, focused reusable/app tests, and complete Unreleased changelog entries.

## Why

Arbiter could decode EPF assets but not MPF creature animations, so monster and NPC portraits were limited to numeric sprite IDs. Dialog packets also discarded sprite type and dye color even though both were available on the wire.

The active entity list had a separate stability problem: entity and player movement scheduled a full filtered-collection refresh. That emitted a collection `Reset`, causing Avalonia to discard and recreate every row container. Hover state, tooltip timers, and selection consequently lost their visual anchor during active map traffic.

## Implementation details

- Creature sprite `N` resolves to `mnsN.mpf`; the MPF palette record resolves to `mnsNNN.pal`, defaulting to `mns000.pal`.
- Static previews follow the game's directional layout: select the second idle direction block and mirror it horizontally for a south-facing pose.
- Preview loading prefers standing frames, then walking/first valid frames, and retains `#ID` fallbacks for missing or malformed assets.
- Existing entity view models and row containers remain stable. Incremental reconciliation only adds or removes entities that genuinely cross the current map/nearby/type filter boundary.
- The DALib MIT notice is included in source and copied to application output.

## Validation

- `dotnet build Arbiter.sln -c Release --no-restore`: succeeded with 0 warnings and 0 errors
- `dotnet test Arbiter.sln -c Release --no-build --no-restore`: 119 passed, 0 failed
  - Arbiter.App.Tests: 54
  - Arbiter.Net.Tests: 44
  - Arbiter.Imaging.Tests: 16
  - Arbiter.IO.Tests: 5
- Read-only smoke test against the configured game archives: all 958 numeric MPFs decoded, 0 missing, 0 errors
- Verified that no DAT, MPF, PAL, or TBL game assets are included
