### PR TITLE
Release 1.9.4 login bypass patch

### DIFF
--- a/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
+++ b/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
@@ -12,13 +12,18 @@ public class GameClientServiceTests
         "ApplySuppressLoginNoticePatch", BindingFlags.NonPublic | BindingFlags.Static)!;
 
     [Test]
-    public void Should_Replace_Expected_Login_Notification_Jumps()
+    public void Should_Replace_Expected_Login_Notification_Patches()
     {
-        var memory = new byte[0x4B8AD1];
+        var memory = new byte[0x56485A];
         memory[0x4B897C] = 0x75;
         memory[0x4B897D] = 0x6C;
         memory[0x4B8ACF] = 0x75;
         memory[0x4B8AD0] = 0x6D;
+        memory[0x564855] = 0x68;
+        memory[0x564856] = 0xE8;
+        memory[0x564857] = 0x03;
+        memory[0x564858] = 0x00;
+        memory[0x564859] = 0x00;
 
         ApplyPatch(memory);
 
@@ -28,17 +33,31 @@ public class GameClientServiceTests
             Assert.That(memory[0x4B897D], Is.EqualTo(0x6C));
             Assert.That(memory[0x4B8ACF], Is.EqualTo(0xEB));
             Assert.That(memory[0x4B8AD0], Is.EqualTo(0x6D));
+            Assert.That(memory[0x564855], Is.EqualTo(0x68));
+            Assert.That(memory[0x564856], Is.EqualTo(0x00));
+            Assert.That(memory[0x564857], Is.EqualTo(0x00));
+            Assert.That(memory[0x564858], Is.EqualTo(0x00));
+            Assert.That(memory[0x564859], Is.EqualTo(0x00));
         });
     }
 
     [Test]
     public void Should_Reject_Unexpected_Login_Notification_Bytes()
     {
-        var memory = new byte[0x4B8AD1];
+        var memory = new byte[0x56485A];
+        memory[0x4B897C] = 0x75;
+        memory[0x4B897D] = 0x6C;
+        memory[0x4B8ACF] = 0x75;
+        memory[0x4B8AD0] = 0x6D;
 
         var exception = Assert.Throws<TargetInvocationException>(() => ApplyPatch(memory));
 
-        Assert.That(exception!.InnerException, Is.TypeOf<InvalidDataException>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception!.InnerException, Is.TypeOf<InvalidDataException>());
+            Assert.That(memory[0x4B897C], Is.EqualTo(0x75));
+            Assert.That(memory[0x4B8ACF], Is.EqualTo(0x75));
+        });
     }
 
     private static void ApplyPatch(byte[] memory)

--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -9,9 +9,9 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <Company>Erik 'SiLo' Rogers</Company>
         <Product>Arbiter</Product>
-        <Version>1.9.3</Version>
-        <AssemblyVersion>1.9.3</AssemblyVersion>
-        <FileVersion>1.9.3</FileVersion>
+        <Version>1.9.4</Version>
+        <AssemblyVersion>1.9.4</AssemblyVersion>
+        <FileVersion>1.9.4</FileVersion>
         <ApplicationIcon>Assets\arbiter.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/Arbiter.App/Services/Client/GameClientService.cs
+++ b/Arbiter.App/Services/Client/GameClientService.cs
@@ -26,6 +26,10 @@ public class GameClientService : IGameClientService
         (0x4B897C, [0x75, 0x6C], [0xEB, 0x6C]),
         (0x4B8ACF, [0x75, 0x6D], [0xEB, 0x6D]),
     ];
+    private static readonly (IntPtr Address, byte[] Expected, byte[] Replacement)[] LoginTransferDelayPatches =
+    [
+        (0x564855, [0x68, 0xE8, 0x03, 0x00, 0x00], [0x68, 0x00, 0x00, 0x00, 0x00]),
+    ];
     private static readonly IntPtr[] ServerHostnamePatchAddresses = [0x433392, 0x565628];
     private const IntPtr ServerFallbackIpPatchAddress = 0x4333C3;
     private const IntPtr ServerPortPatchAddress = 0x4333E3;
@@ -122,7 +126,9 @@ public class GameClientService : IGameClientService
 
     private static void ApplySuppressLoginNoticePatch(BinaryWriter writer)
     {
-        foreach (var patch in SuppressLoginNoticePatches)
+        var patches = SuppressLoginNoticePatches.Concat(LoginTransferDelayPatches);
+
+        foreach (var patch in patches)
         {
             writer.BaseStream.Position = patch.Address;
 
@@ -134,7 +140,10 @@ public class GameClientService : IGameClientService
                                                $"expected {Convert.ToHexString(patch.Expected)}, " +
                                                $"found {Convert.ToHexString(actual)}.");
             }
+        }
 
+        foreach (var patch in patches)
+        {
             writer.BaseStream.Position = patch.Address;
             writer.Write(patch.Replacement);
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.4] - 2026-07-16
+
+### Fixed
+
+- Skip the one-second client transfer delay after bypassing the stipulation login notification
+
 ## [1.9.3] - 2026-07-16
 
 ### Added


### PR DESCRIPTION
## Summary

- Add a verified PUSH 1000 to PUSH 0 patch to skip the client transfer delay after suppressing the stipulation notification.
- Keep the transfer-delay patch separate from the notification-jump patch collection while verifying all locations before any writes.
- Prepare the July 16, 2026 1.9.4 release metadata and changelog.

## Validation

- dotnet test Arbiter.App.Tests/Arbiter.App.Tests.csproj --no-restore -p:OutputPath=<temporary output>
- Verified generated AssemblyVersion and AssemblyFileVersion are both 1.9.4.