### PR TITLE
Release 1.9.5 with Dark Ages modifier key fix

### DIFF
--- a/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
+++ b/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
@@ -6,11 +6,15 @@ namespace Arbiter.App.Tests.Models.Settings;
 public sealed class ArbiterSettingsTests
 {
     [Test]
-    public void Should_Default_Legacy_Settings_To_Detailed_Trace_View()
+    public void Should_Default_Legacy_Settings_To_Current_Options()
     {
         var settings = JsonSerializer.Deserialize<ArbiterSettings>("{}");
 
-        Assert.That(settings?.TraceDetailedView, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(settings?.TraceDetailedView, Is.True);
+            Assert.That(settings?.ApplyModifiersKeyFix, Is.True);
+        });
     }
 
     [Test]
@@ -21,5 +25,15 @@ public sealed class ArbiterSettingsTests
         var clone = (ArbiterSettings)settings.Clone();
 
         Assert.That(clone.TraceDetailedView, Is.False);
+    }
+
+    [Test]
+    public void Should_Preserve_Modifiers_Key_Fix_Preference_When_Cloned()
+    {
+        var settings = new ArbiterSettings { ApplyModifiersKeyFix = false };
+
+        var clone = (ArbiterSettings)settings.Clone();
+
+        Assert.That(clone.ApplyModifiersKeyFix, Is.False);
     }
 }

--- a/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
+++ b/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
@@ -74,29 +74,29 @@ public class GameClientServiceTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(stub, Has.Length.EqualTo(69));
+            Assert.That(stub, Has.Length.EqualTo(68));
             Assert.That(stub[0..2], Is.EqualTo(new byte[] { 0x9C, 0x60 }));
             Assert.That(GetRelativeTarget(stub, stubAddress, 2), Is.EqualTo(0x00427380));
-            Assert.That(stub[7..13], Is.EqualTo(new byte[] { 0x85, 0xC0, 0x74, 0x33, 0x89, 0xC3 }));
-            Assert.That(GetShortTarget(stub, 9), Is.EqualTo(62));
-            Assert.That(stub[13..15], Is.EqualTo(new byte[] { 0xFF, 0x15 }));
-            Assert.That(BitConverter.ToUInt32(stub, 15), Is.EqualTo(0x0062006E));
-            Assert.That(stub[23..33],
+            Assert.That(stub[7..13], Is.EqualTo(new byte[] { 0x85, 0xC0, 0x74, 0x32, 0x89, 0xC3 }));
+            Assert.That(GetShortTarget(stub, 9), Is.EqualTo(61));
+            Assert.That(stub[13], Is.EqualTo(0xE8));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 13), Is.EqualTo(0x0062006E));
+            Assert.That(stub[22..32],
                 Is.EqualTo(new byte[] { 0xF6, 0x84, 0x33, 0x34, 0x03, 0x00, 0x00, 0x80, 0x74, 0x0D }));
-            Assert.That(GetShortTarget(stub, 31), Is.EqualTo(46));
-            Assert.That(stub[33..41],
+            Assert.That(GetShortTarget(stub, 30), Is.EqualTo(45));
+            Assert.That(stub[32..40],
                 Is.EqualTo(new byte[] { 0x6A, 0x00, 0x57, 0x6A, 0x00, 0x56, 0x89, 0xD9 }));
-            Assert.That(stub[41], Is.EqualTo(0xE8));
-            Assert.That(GetRelativeTarget(stub, stubAddress, 41), Is.EqualTo(0x00466E60));
-            Assert.That(stub[46..62], Is.EqualTo(new byte[]
+            Assert.That(stub[40], Is.EqualTo(0xE8));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 40), Is.EqualTo(0x00466E60));
+            Assert.That(stub[45..61], Is.EqualTo(new byte[]
             {
                 0x46, 0x81, 0xFE, 0x00, 0x01, 0x00, 0x00, 0x7C, 0xE0,
                 0xC6, 0x83, 0x34, 0x04, 0x00, 0x00, 0x00,
             }));
-            Assert.That(GetShortTarget(stub, 53), Is.EqualTo(23));
-            Assert.That(stub[62..64], Is.EqualTo(new byte[] { 0x61, 0x9D }));
-            Assert.That(stub[64], Is.EqualTo(0xE9));
-            Assert.That(GetRelativeTarget(stub, stubAddress, 64), Is.EqualTo(0x004AC950));
+            Assert.That(GetShortTarget(stub, 52), Is.EqualTo(22));
+            Assert.That(stub[61..63], Is.EqualTo(new byte[] { 0x61, 0x9D }));
+            Assert.That(stub[63], Is.EqualTo(0xE9));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 63), Is.EqualTo(0x004AC950));
         });
     }
 

--- a/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
+++ b/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
@@ -10,6 +10,10 @@ public class GameClientServiceTests
 {
     private static readonly MethodInfo ApplySuppressLoginNoticePatch = typeof(GameClientService).GetMethod(
         "ApplySuppressLoginNoticePatch", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildStuckModifierFixStub = typeof(GameClientService).GetMethod(
+        "BuildStuckModifierFixStub", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildStuckModifierCall = typeof(GameClientService).GetMethod(
+        "BuildStuckModifierCall", BindingFlags.NonPublic | BindingFlags.Static)!;
 
     [Test]
     public void Should_Replace_Expected_Login_Notification_Patches()
@@ -60,6 +64,58 @@ public class GameClientServiceTests
         });
     }
 
+    [Test]
+    public void Should_Build_Stuck_Modifier_Fix_Stub_With_Resolved_Addresses()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x01000000;
+
+        var stub = (byte[])BuildStuckModifierFixStub.Invoke(null, [moduleBaseAddress, stubAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub, Has.Length.EqualTo(69));
+            Assert.That(stub[0..2], Is.EqualTo(new byte[] { 0x9C, 0x60 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 2), Is.EqualTo(0x00427380));
+            Assert.That(stub[7..13], Is.EqualTo(new byte[] { 0x85, 0xC0, 0x74, 0x33, 0x89, 0xC3 }));
+            Assert.That(GetShortTarget(stub, 9), Is.EqualTo(62));
+            Assert.That(stub[13..15], Is.EqualTo(new byte[] { 0xFF, 0x15 }));
+            Assert.That(BitConverter.ToUInt32(stub, 15), Is.EqualTo(0x0062006E));
+            Assert.That(stub[23..33],
+                Is.EqualTo(new byte[] { 0xF6, 0x84, 0x33, 0x34, 0x03, 0x00, 0x00, 0x80, 0x74, 0x0D }));
+            Assert.That(GetShortTarget(stub, 31), Is.EqualTo(46));
+            Assert.That(stub[33..41],
+                Is.EqualTo(new byte[] { 0x6A, 0x00, 0x57, 0x6A, 0x00, 0x56, 0x89, 0xD9 }));
+            Assert.That(stub[41], Is.EqualTo(0xE8));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 41), Is.EqualTo(0x00466E60));
+            Assert.That(stub[46..62], Is.EqualTo(new byte[]
+            {
+                0x46, 0x81, 0xFE, 0x00, 0x01, 0x00, 0x00, 0x7C, 0xE0,
+                0xC6, 0x83, 0x34, 0x04, 0x00, 0x00, 0x00,
+            }));
+            Assert.That(GetShortTarget(stub, 53), Is.EqualTo(23));
+            Assert.That(stub[62..64], Is.EqualTo(new byte[] { 0x61, 0x9D }));
+            Assert.That(stub[64], Is.EqualTo(0xE9));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 64), Is.EqualTo(0x004AC950));
+        });
+    }
+
+    [Test]
+    public void Should_Build_Only_A_Five_Byte_Call_To_The_Stuck_Modifier_Stub()
+    {
+        var callAddress = (IntPtr)0x004A9D81;
+        var stubAddress = (IntPtr)0x01000000;
+
+        var call = (byte[])BuildStuckModifierCall.Invoke(null, [callAddress, stubAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(call, Has.Length.EqualTo(5));
+            Assert.That(call[0], Is.EqualTo(0xE8));
+            Assert.That(GetRelativeTarget(call, callAddress, 0), Is.EqualTo(stubAddress.ToInt64()));
+        });
+    }
+
     private static void ApplyPatch(byte[] memory)
     {
         using var stream = new MemoryStream(memory, writable: true);
@@ -67,4 +123,13 @@ public class GameClientServiceTests
 
         ApplySuppressLoginNoticePatch.Invoke(null, [writer]);
     }
+
+    private static long GetRelativeTarget(byte[] code, IntPtr codeAddress, int instructionOffset)
+    {
+        var relativeOffset = BitConverter.ToInt32(code, instructionOffset + 1);
+        return codeAddress.ToInt64() + instructionOffset + 5 + relativeOffset;
+    }
+
+    private static int GetShortTarget(byte[] code, int instructionOffset) =>
+        instructionOffset + 2 + unchecked((sbyte)code[instructionOffset + 1]);
 }

--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -9,9 +9,9 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <Company>Erik 'SiLo' Rogers</Company>
         <Product>Arbiter</Product>
-        <Version>1.9.4</Version>
-        <AssemblyVersion>1.9.4</AssemblyVersion>
-        <FileVersion>1.9.4</FileVersion>
+        <Version>1.9.5</Version>
+        <AssemblyVersion>1.9.5</AssemblyVersion>
+        <FileVersion>1.9.5</FileVersion>
         <ApplicationIcon>Assets\arbiter.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/Arbiter.App/Models/LaunchClientOptions.cs
+++ b/Arbiter.App/Models/LaunchClientOptions.cs
@@ -1,3 +1,4 @@
 ﻿namespace Arbiter.App.Models;
 
-public record LaunchClientOptions(int LocalPort = 2610, bool SkipIntroVideo = true, bool SuppressLoginNotice = true);
+public record LaunchClientOptions(int LocalPort = 2610, bool SkipIntroVideo = true, bool SuppressLoginNotice = true,
+    bool ApplyModifiersKeyFix = true);

--- a/Arbiter.App/Models/Settings/ArbiterSettings.cs
+++ b/Arbiter.App/Models/Settings/ArbiterSettings.cs
@@ -13,6 +13,7 @@ public class ArbiterSettings : ICloneable
     public string ClientExecutablePath { get; set; } = DefaultPath;
     public bool SkipIntroVideo { get; set; } = true;
     public bool SuppressLoginNotice { get; set; } = true;
+    public bool ApplyModifiersKeyFix { get; set; } = true;
 
     public int LocalPort { get; set; } = 2610;
 
@@ -44,6 +45,7 @@ public class ArbiterSettings : ICloneable
         ClientExecutablePath = ClientExecutablePath,
         SkipIntroVideo = SkipIntroVideo,
         SuppressLoginNotice = SuppressLoginNotice,
+        ApplyModifiersKeyFix = ApplyModifiersKeyFix,
         LocalPort = LocalPort,
         RemoteServerAddress = RemoteServerAddress,
         RemoteServerPort = RemoteServerPort,

--- a/Arbiter.App/Services/Client/GameClientService.Hotkeys.cs
+++ b/Arbiter.App/Services/Client/GameClientService.Hotkeys.cs
@@ -1,0 +1,191 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using Arbiter.Interop.Process;
+
+namespace Arbiter.App.Services.Client;
+
+public partial class GameClientService
+{
+    private const long SupportedClientSize = 3_112_960;
+    private const string SupportedClientSha256 =
+        "054A5D6ADC56099C6BFD9D2A58675AFF62DC788B63209A3D906492F5B89E96C6";
+
+    private const int StuckModifierCallRva = 0x000A9D81;
+    private const int InputGetEventManagerRva = 0x00027380;
+    private const int InputPostKeyUpRva = 0x00066E60;
+    private const int OriginalActivationFunctionRva = 0x000AC950;
+    private const int GetMessageTimeIatRva = 0x0022006E;
+
+    private static readonly byte[] ExpectedStuckModifierCall = [0xE8, 0xCA, 0x2B, 0x00, 0x00];
+    private const int PatchVerificationPadding = 8;
+    private const int StuckModifierFixStubSize = 69;
+
+    private static void VerifySupportedClient(string clientExecutablePath)
+    {
+        using var stream = File.OpenRead(clientExecutablePath);
+        if (stream.Length != SupportedClientSize)
+        {
+            throw new InvalidDataException(
+                $"Unsupported Dark Ages client size: expected {SupportedClientSize:N0} bytes, " +
+                $"found {stream.Length:N0} bytes.");
+        }
+
+        var actualHash = SHA256.HashData(stream);
+        if (!Convert.ToHexString(actualHash).Equals(SupportedClientSha256, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Unsupported Dark Ages client hash: expected {SupportedClientSha256}, " +
+                $"found {Convert.ToHexString(actualHash)}.");
+        }
+    }
+
+    private static void ApplyStuckModifierFix(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr moduleBaseAddress)
+    {
+        var stage = "verify the modifier-fix call site";
+        try
+        {
+            var callAddress = Add(moduleBaseAddress, StuckModifierCallRva);
+            var patchWindowAddress = Add(callAddress, -PatchVerificationPadding);
+            var originalPatchWindow = ReadRemoteBytes(writer, patchWindowAddress,
+                PatchVerificationPadding + ExpectedStuckModifierCall.Length + PatchVerificationPadding);
+
+            var actualCall = originalPatchWindow.AsSpan(PatchVerificationPadding, ExpectedStuckModifierCall.Length);
+            if (!actualCall.SequenceEqual(ExpectedStuckModifierCall))
+            {
+                throw new InvalidDataException($"Unexpected client bytes at 0x{callAddress.ToInt64():X}: " +
+                                               $"expected {Convert.ToHexString(ExpectedStuckModifierCall)}, " +
+                                               $"found {Convert.ToHexString(actualCall)}.");
+            }
+
+            stage = "allocate the modifier-fix stub";
+            var stubAddress = allocator.AllocMemory(_ => { }, StuckModifierFixStubSize);
+            var stub = BuildStuckModifierFixStub(moduleBaseAddress, stubAddress);
+
+            stage = "write the modifier-fix stub";
+            writer.BaseStream.Position = stubAddress.ToInt64();
+            writer.Write(stub);
+
+            stage = "protect and verify the modifier-fix stub";
+            allocator.MakeExecutable(stubAddress, stub.Length);
+            VerifyRemoteBytes(writer, stubAddress, stub);
+
+            var replacementCall = BuildStuckModifierCall(callAddress, stubAddress);
+
+            stage = "write the modifier-fix call";
+            using (allocator.MakeWritable(callAddress, replacementCall.Length))
+            {
+                writer.BaseStream.Position = callAddress.ToInt64();
+                writer.Write(replacementCall);
+            }
+
+            stage = "verify the modifier-fix call";
+            var expectedPatchWindow = originalPatchWindow.ToArray();
+            replacementCall.CopyTo(expectedPatchWindow, PatchVerificationPadding);
+            VerifyRemoteBytes(writer, patchWindowAddress, expectedPatchWindow);
+
+            stage = "flush the modifier-fix instruction cache";
+            allocator.FlushInstructionCache(stubAddress, stub.Length);
+            allocator.FlushInstructionCache(callAddress, replacementCall.Length);
+        }
+        catch (Exception exception)
+        {
+            throw new InvalidOperationException($"Failed to {stage}: {exception.Message}", exception);
+        }
+    }
+
+    private static byte[] BuildStuckModifierCall(IntPtr callAddress, IntPtr stubAddress)
+    {
+        var call = new byte[ExpectedStuckModifierCall.Length];
+        call[0] = 0xE8;
+        WriteInt32(call, 1, GetRelativeOffset(callAddress, call.Length, stubAddress));
+        return call;
+    }
+
+    private static byte[] BuildStuckModifierFixStub(IntPtr moduleBaseAddress, IntPtr stubAddress)
+    {
+        using var stream = new MemoryStream(StuckModifierFixStubSize);
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write((byte)0x9C); // PUSHFD
+        writer.Write((byte)0x60); // PUSHAD
+
+        writer.Write((byte)0xE8); // CALL input_get_event_manager
+        writer.Write(GetRelativeOffset(Add(stubAddress, checked((int)stream.Position)), sizeof(int),
+            Add(moduleBaseAddress, InputGetEventManagerRva)));
+
+        writer.Write([0x85, 0xC0]); // TEST EAX, EAX
+        writer.Write([0x74, 0x33]); // JZ cleanup complete
+        writer.Write([0x89, 0xC3]); // MOV EBX, EAX
+
+        writer.Write([0xFF, 0x15]); // CALL DWORD PTR [GetMessageTime]
+        writer.Write(checked((uint)Add(moduleBaseAddress, GetMessageTimeIatRva).ToInt64()));
+        writer.Write([0x89, 0xC7]); // MOV EDI, EAX
+        writer.Write([0x31, 0xF6]); // XOR ESI, ESI
+
+        writer.Write([0xF6, 0x84, 0x33, 0x34, 0x03, 0x00, 0x00, 0x80]);
+        writer.Write([0x74, 0x0D]); // JZ next scan code
+        writer.Write([0x6A, 0x00]); // PUSH 0
+        writer.Write((byte)0x57); // PUSH EDI
+        writer.Write([0x6A, 0x00]); // PUSH 0
+        writer.Write((byte)0x56); // PUSH ESI
+        writer.Write([0x89, 0xD9]); // MOV ECX, EBX
+
+        writer.Write((byte)0xE8); // CALL input_post_key_up
+        writer.Write(GetRelativeOffset(Add(stubAddress, checked((int)stream.Position)), sizeof(int),
+            Add(moduleBaseAddress, InputPostKeyUpRva)));
+
+        writer.Write((byte)0x46); // INC ESI
+        writer.Write([0x81, 0xFE, 0x00, 0x01, 0x00, 0x00]); // CMP ESI, 256
+        writer.Write([0x7C, 0xE0]); // JL scan loop
+        writer.Write([0xC6, 0x83, 0x34, 0x04, 0x00, 0x00, 0x00]); // MOV BYTE PTR [EBX + 0x434], 0
+
+        writer.Write((byte)0x61); // POPAD
+        writer.Write((byte)0x9D); // POPFD
+        writer.Write((byte)0xE9); // JMP original activation function
+        writer.Write(GetRelativeOffset(Add(stubAddress, checked((int)stream.Position)), sizeof(int),
+            Add(moduleBaseAddress, OriginalActivationFunctionRva)));
+
+        if (stream.Length != StuckModifierFixStubSize)
+        {
+            throw new InvalidOperationException(
+                $"Unexpected stuck-modifier stub size: expected {StuckModifierFixStubSize}, found {stream.Length}.");
+        }
+
+        return stream.ToArray();
+    }
+
+    private static IntPtr Add(IntPtr address, int offset) => checked((IntPtr)(address.ToInt64() + offset));
+
+    private static int GetRelativeOffset(IntPtr instructionAddress, int instructionSize, IntPtr targetAddress) =>
+        checked((int)(targetAddress.ToInt64() - instructionAddress.ToInt64() - instructionSize));
+
+    private static byte[] ReadRemoteBytes(BinaryWriter writer, IntPtr address, int size)
+    {
+        var bytes = new byte[size];
+        writer.BaseStream.Position = address.ToInt64();
+        writer.BaseStream.ReadExactly(bytes);
+        return bytes;
+    }
+
+    private static void VerifyRemoteBytes(BinaryWriter writer, IntPtr address, byte[] expected)
+    {
+        var actual = ReadRemoteBytes(writer, address, expected.Length);
+        if (!actual.SequenceEqual(expected))
+        {
+            throw new InvalidDataException($"Client memory verification failed at 0x{address.ToInt64():X}: " +
+                                           $"expected {Convert.ToHexString(expected)}, " +
+                                           $"found {Convert.ToHexString(actual)}.");
+        }
+    }
+
+    private static void WriteInt32(byte[] buffer, int offset, int value)
+    {
+        buffer[offset] = (byte)value;
+        buffer[offset + 1] = (byte)(value >> 8);
+        buffer[offset + 2] = (byte)(value >> 16);
+        buffer[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/Arbiter.App/Services/Client/GameClientService.Hotkeys.cs
+++ b/Arbiter.App/Services/Client/GameClientService.Hotkeys.cs
@@ -16,11 +16,11 @@ public partial class GameClientService
     private const int InputGetEventManagerRva = 0x00027380;
     private const int InputPostKeyUpRva = 0x00066E60;
     private const int OriginalActivationFunctionRva = 0x000AC950;
-    private const int GetMessageTimeIatRva = 0x0022006E;
+    private const int GetMessageTimeThunkRva = 0x0022006E;
 
     private static readonly byte[] ExpectedStuckModifierCall = [0xE8, 0xCA, 0x2B, 0x00, 0x00];
     private const int PatchVerificationPadding = 8;
-    private const int StuckModifierFixStubSize = 69;
+    private const int StuckModifierFixStubSize = 68;
 
     private static void VerifySupportedClient(string clientExecutablePath)
     {
@@ -117,11 +117,12 @@ public partial class GameClientService
             Add(moduleBaseAddress, InputGetEventManagerRva)));
 
         writer.Write([0x85, 0xC0]); // TEST EAX, EAX
-        writer.Write([0x74, 0x33]); // JZ cleanup complete
+        writer.Write([0x74, 0x32]); // JZ cleanup complete
         writer.Write([0x89, 0xC3]); // MOV EBX, EAX
 
-        writer.Write([0xFF, 0x15]); // CALL DWORD PTR [GetMessageTime]
-        writer.Write(checked((uint)Add(moduleBaseAddress, GetMessageTimeIatRva).ToInt64()));
+        writer.Write((byte)0xE8); // CALL GetMessageTime import thunk
+        writer.Write(GetRelativeOffset(Add(stubAddress, checked((int)stream.Position)), sizeof(int),
+            Add(moduleBaseAddress, GetMessageTimeThunkRva)));
         writer.Write([0x89, 0xC7]); // MOV EDI, EAX
         writer.Write([0x31, 0xF6]); // XOR ESI, ESI
 

--- a/Arbiter.App/Services/Client/GameClientService.cs
+++ b/Arbiter.App/Services/Client/GameClientService.cs
@@ -13,7 +13,7 @@ using Arbiter.Interop.Window;
 
 namespace Arbiter.App.Services.Client;
 
-public class GameClientService : IGameClientService
+public partial class GameClientService : IGameClientService
 {
     private const string DarkAgesWindowClassName = "Darkages";
     private const long CharacterNameAddress = 0x73d910; // 7.41
@@ -41,29 +41,54 @@ public class GameClientService : IGameClientService
             throw new ArgumentOutOfRangeException(nameof(options), "Port must be between 1 and 65535");
         }
 
+        if (options.ApplyModifiersKeyFix)
+        {
+            VerifySupportedClient(clientExecutablePath);
+        }
+
         using var process = SuspendedProcess.Start(clientExecutablePath);
-        await using var stream = process.GetProcessMemoryStream();
-        await using var writer = new BinaryWriter(stream, Encoding.UTF8);
-
-        // Allocate memory to write our hostname instead
-        using var allocator = process.GetProcessMemoryAllocator();
-        var hostnamePointer = allocator.AllocMemory(mem => { mem.WriteNullTerminated("localhost"); });
-
-        ApplyMultipleInstancePatch(writer);
-
-        if (options.SkipIntroVideo)
+        try
         {
-            ApplySkipIntroVideoPatch(writer);
-        }
+            await using (var stream = process.GetProcessMemoryStream())
+            await using (var writer = new BinaryWriter(stream, Encoding.UTF8))
+            using (var allocator = process.GetProcessMemoryAllocator())
+            {
+                // Allocate memory to write our hostname instead
+                var hostnamePointer = allocator.AllocMemory(mem => { mem.WriteNullTerminated("localhost"); });
 
-        if (options.SuppressLoginNotice)
+                ApplyMultipleInstancePatch(writer);
+
+                if (options.SkipIntroVideo)
+                {
+                    ApplySkipIntroVideoPatch(writer);
+                }
+
+                if (options.SuppressLoginNotice)
+                {
+                    ApplySuppressLoginNoticePatch(writer);
+                }
+
+                ApplyServerEndpointPatch(writer, hostnamePointer, options.LocalPort);
+
+                if (options.ApplyModifiersKeyFix)
+                {
+                    var moduleBaseAddress = process.GetImageBaseAddress();
+                    ApplyStuckModifierFix(writer, allocator, moduleBaseAddress);
+                }
+            }
+
+            process.Resume();
+            return process.ProcessId;
+        }
+        catch
         {
-            ApplySuppressLoginNoticePatch(writer);
+            if (process.IsSuspended)
+            {
+                process.Kill(1);
+            }
+
+            throw;
         }
-
-        ApplyServerEndpointPatch(writer, hostnamePointer, options.LocalPort);
-
-        return process.ProcessId;
     }
 
     public IEnumerable<GameClientWindow> GetGameClients()

--- a/Arbiter.App/ViewModels/MainWindowViewModel.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.cs
@@ -92,7 +92,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             var clientExecutablePath = Settings.ClientExecutablePath;
             var options = new LaunchClientOptions(Settings.LocalPort, Settings.SkipIntroVideo,
-                Settings.SuppressLoginNotice);
+                Settings.SuppressLoginNotice, Settings.ApplyModifiersKeyFix);
 
             await _gameClientService.LaunchLoopbackClient(clientExecutablePath, options);
         }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -33,6 +33,7 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     [NotifyPropertyChangedFor(nameof(ClientExecutablePath))]
     [NotifyPropertyChangedFor(nameof(SkipIntroVideo))]
     [NotifyPropertyChangedFor(nameof(SuppressLoginNotice))]
+    [NotifyPropertyChangedFor(nameof(ApplyModifiersKeyFix))]
     [NotifyPropertyChangedFor(nameof(LocalPort))]
     [NotifyPropertyChangedFor(nameof(RemoteServerAddress))]
     [NotifyPropertyChangedFor(nameof(RemoteServerPort))]
@@ -107,6 +108,17 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         set
         {
             Settings.SuppressLoginNotice = value;
+            OnPropertyChanged();
+            HasChanges = true;
+        }
+    }
+
+    public bool ApplyModifiersKeyFix
+    {
+        get => Settings.ApplyModifiersKeyFix;
+        set
+        {
+            Settings.ApplyModifiersKeyFix = value;
             OnPropertyChanged();
             HasChanges = true;
         }

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -62,7 +62,7 @@
                     </TextBox>
                     
                     <!-- Options -->
-                    <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
+                    <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
                         <!-- Skip Intro Video  -->
                         <Label Grid.Row="0" Grid.Column="0"
                                Content="Skip Intro Video"
@@ -75,6 +75,12 @@
                                ToolTip.Tip="Bypasses the login notification when starting the client."/>
                         <ToggleSwitch Grid.Row="1" Grid.Column="1"
                                       IsChecked="{Binding SuppressLoginNotice}"/>
+                        <!-- Apply Modifiers Key Fix -->
+                        <Label Grid.Row="2" Grid.Column="0"
+                               Content="Apply Modifiers Key Fix"
+                               ToolTip.Tip="Clears held keys and modifiers when the client loses focus."/>
+                        <ToggleSwitch Grid.Row="2" Grid.Column="1"
+                                      IsChecked="{Binding ApplyModifiersKeyFix}"/>
                     </Grid>
                 </StackPanel>
             </TabItem>

--- a/Arbiter.Interop/Process/ProcessMemoryAllocator.cs
+++ b/Arbiter.Interop/Process/ProcessMemoryAllocator.cs
@@ -5,6 +5,39 @@ namespace Arbiter.Interop.Process;
 
 public class ProcessMemoryAllocator : IDisposable
 {
+    private sealed class MemoryProtectionScope : IDisposable
+    {
+        private readonly IntPtr _processHandle;
+        private readonly IntPtr _address;
+        private readonly UIntPtr _size;
+        private readonly Win32MemoryProtection _originalProtection;
+        private bool _isDisposed;
+
+        public MemoryProtectionScope(IntPtr processHandle, IntPtr address, UIntPtr size,
+            Win32MemoryProtection originalProtection)
+        {
+            _processHandle = processHandle;
+            _address = address;
+            _size = size;
+            _originalProtection = originalProtection;
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (!NativeMethods.VirtualProtectEx(_processHandle, _address, _size, _originalProtection, out _))
+            {
+                throw new Win32Exception();
+            }
+
+            _isDisposed = true;
+        }
+    }
+
     private bool _isDisposed;
     private readonly bool _leaveOpen;
     
@@ -59,6 +92,44 @@ public class ProcessMemoryAllocator : IDisposable
         CheckIfDisposed();
         
         if (!NativeMethods.VirtualFreeEx(ProcessHandle, memPointer, UIntPtr.Zero, Win32FreeType.Release))
+        {
+            throw new Win32Exception();
+        }
+    }
+
+    public void MakeExecutable(IntPtr address, int size)
+    {
+        CheckIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+
+        if (!NativeMethods.VirtualProtectEx(ProcessHandle, address, (UIntPtr)size,
+                Win32MemoryProtection.ExecuteRead, out _))
+        {
+            throw new Win32Exception();
+        }
+    }
+
+    public IDisposable MakeWritable(IntPtr address, int size)
+    {
+        CheckIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+
+        var nativeSize = (UIntPtr)size;
+        if (!NativeMethods.VirtualProtectEx(ProcessHandle, address, nativeSize,
+                Win32MemoryProtection.ExecuteReadWrite, out var originalProtection))
+        {
+            throw new Win32Exception();
+        }
+
+        return new MemoryProtectionScope(ProcessHandle, address, nativeSize, originalProtection);
+    }
+
+    public void FlushInstructionCache(IntPtr address, int size)
+    {
+        CheckIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+
+        if (!NativeMethods.FlushInstructionCache(ProcessHandle, address, (UIntPtr)size))
         {
             throw new Win32Exception();
         }

--- a/Arbiter.Interop/Process/SuspendedProcess.cs
+++ b/Arbiter.Interop/Process/SuspendedProcess.cs
@@ -144,6 +144,46 @@ public class SuspendedProcess : IDisposable
         return new ProcessMemoryAllocator(newHandle);
     }
 
+    public IntPtr GetImageBaseAddress()
+    {
+        CheckIfDisposed();
+
+        IntPtr pebAddress;
+        if (Environment.Is64BitProcess)
+        {
+            var status = NativeMethods.NtQueryInformationProcess(ProcessHandle,
+                Win32ProcessInformationClass.Wow64Information, out pebAddress, IntPtr.Size, out _);
+            ThrowIfNtStatusFailed(status);
+
+            if (pebAddress == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("The suspended client is not a 32-bit process.");
+            }
+        }
+        else
+        {
+            var status = NativeMethods.NtQueryInformationProcess(ProcessHandle,
+                Win32ProcessInformationClass.BasicInformation, out Win32ProcessBasicInformation processInformation,
+                Marshal.SizeOf<Win32ProcessBasicInformation>(), out _);
+            ThrowIfNtStatusFailed(status);
+            pebAddress = processInformation.PebBaseAddress;
+        }
+
+        var imageBaseBytes = new byte[sizeof(uint)];
+        var imageBasePointerAddress = IntPtr.Add(pebAddress, 0x08);
+        if (!NativeMethods.ReadProcessMemory(ProcessHandle, imageBasePointerAddress, imageBaseBytes,
+                imageBaseBytes.Length, out var bytesRead) || bytesRead.ToInt64() != imageBaseBytes.Length)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(),
+                "Could not read the client image base from the suspended process.");
+        }
+
+        var imageBaseAddress = new IntPtr(BitConverter.ToUInt32(imageBaseBytes));
+        return imageBaseAddress != IntPtr.Zero
+            ? imageBaseAddress
+            : throw new InvalidOperationException("The suspended client image base is null.");
+    }
+
     public void Resume()
     {
         CheckIfDisposed();
@@ -175,6 +215,17 @@ public class SuspendedProcess : IDisposable
         ProcessId = 0;
         ThreadId = 0;
         IsSuspended = false;
+    }
+
+    private static void ThrowIfNtStatusFailed(int status)
+    {
+        if (status >= 0)
+        {
+            return;
+        }
+
+        var error = NativeMethods.RtlNtStatusToDosError(status);
+        throw new Win32Exception(checked((int)error));
     }
 
     private void CheckIfDisposed() => ObjectDisposedException.ThrowIf(_isDisposed, this);

--- a/Arbiter.Interop/Win32/NativeMethods.cs
+++ b/Arbiter.Interop/Win32/NativeMethods.cs
@@ -51,6 +51,19 @@ internal static class NativeMethods
     [DllImport("kernel32.dll", EntryPoint = "ResumeThread", SetLastError = true)]
     internal static extern uint ResumeThread(IntPtr hThread);
 
+    [DllImport("ntdll.dll", EntryPoint = "NtQueryInformationProcess")]
+    internal static extern int NtQueryInformationProcess(IntPtr processHandle,
+        Win32ProcessInformationClass processInformationClass, out IntPtr processInformation,
+        int processInformationLength, out int returnLength);
+
+    [DllImport("ntdll.dll", EntryPoint = "NtQueryInformationProcess")]
+    internal static extern int NtQueryInformationProcess(IntPtr processHandle,
+        Win32ProcessInformationClass processInformationClass, out Win32ProcessBasicInformation processInformation,
+        int processInformationLength, out int returnLength);
+
+    [DllImport("ntdll.dll", EntryPoint = "RtlNtStatusToDosError")]
+    internal static extern uint RtlNtStatusToDosError(int status);
+
     [DllImport("kernel32.dll", EntryPoint = "ReadProcessMemory", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr baseAddress, byte[] buffer, int size,
@@ -74,6 +87,10 @@ internal static class NativeMethods
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr baseAddress, UIntPtr size,
         Win32FreeType freeType);
+
+    [DllImport("kernel32.dll", EntryPoint = "FlushInstructionCache", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool FlushInstructionCache(IntPtr hProcess, IntPtr baseAddress, UIntPtr size);
 
     [DllImport("kernel32.dll", EntryPoint = "TerminateProcess", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/Arbiter.Interop/Win32/Win32ProcessBasicInformation.cs
+++ b/Arbiter.Interop/Win32/Win32ProcessBasicInformation.cs
@@ -1,0 +1,14 @@
+using System.Runtime.InteropServices;
+
+namespace Arbiter.Interop.Win32;
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct Win32ProcessBasicInformation
+{
+    public int ExitStatus;
+    public IntPtr PebBaseAddress;
+    public UIntPtr AffinityMask;
+    public int BasePriority;
+    public UIntPtr UniqueProcessId;
+    public UIntPtr InheritedFromUniqueProcessId;
+}

--- a/Arbiter.Interop/Win32/Win32ProcessInformationClass.cs
+++ b/Arbiter.Interop/Win32/Win32ProcessInformationClass.cs
@@ -1,0 +1,7 @@
+namespace Arbiter.Interop.Win32;
+
+internal enum Win32ProcessInformationClass
+{
+    BasicInformation = 0,
+    Wow64Information = 26,
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.5] - 2026-07-17
+
+### Fixed
+
+- Add an enabled-by-default launch option that clears pressed keys and modifiers when the Dark Ages client loses focus, using the suspended process image base directly
+
 ### Changed
 
 - Rename the client `PutGround` command and message to `RequestObject`


### PR DESCRIPTION
## Summary

- add a launch-time, memory-only Dark Ages 7.41 patch that releases pressed keys and clears modifier state on focus loss
- expose the patch through the default-enabled **Apply Modifiers Key Fix** setting
- verify the supported executable, original call site, written stub, and surrounding call-site bytes before resuming
- resolve the suspended x86 image base directly from the PEB and terminate the child on patch failure
- bump the application version to 1.9.5 and add the 2026-07-17 changelog section

## Why

Dark Ages retains its pressed-key array and modifier mask when focus moves to another window. Key releases then go to the other window, leaving client hotkeys stuck.

## Validation

- `dotnet build Arbiter.sln --configuration Release --no-restore`
- `dotnet test Arbiter.App.Tests/Arbiter.App.Tests.csproj --configuration Release --no-build`
- 96 application tests passed
- byte-level tests verify every stub branch and relative call target, including the direct call to the `GetMessageTime` import thunk

## Crash follow-up

Initial testing exposed an execute access violation at `0x936425FF` in the stub's `GetMessageTime` call. Crash dumps showed the failure before the scan loop with `EAX = EBX` holding the event manager and the original `ESI`, `EDI`, and `ECX` still intact.

RVA `0x0022006E` was originally mislabeled as an IAT slot. It is the executable import thunk:

```text
FF 25 64 93 66 00    jmp dword ptr [0x00669364]
```

The incorrect `CALL DWORD PTR [module_base + 0x0022006E]` interpreted the first four thunk bytes `FF 25 64 93` as the pointer `0x936425FF`, conclusively explaining the execute violation. Commit `b9c6af9` corrects the stub to use a direct `CALL rel32` to the thunk. The thunk then jumps through the loader-populated IAT slot and returns normally to the stub.

Local full dumps remain available under `%LOCALAPPDATA%\CrashDumps\Darkages.exe*.dmp` if further runtime analysis is needed.
