### PR TITLE
Release 1.9.6 client quality-of-life patches

### DIFF
--- a/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
+++ b/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
@@ -14,6 +14,7 @@ public sealed class ArbiterSettingsTests
         {
             Assert.That(settings?.TraceDetailedView, Is.True);
             Assert.That(settings?.ApplyModifiersKeyFix, Is.True);
+            Assert.That(settings?.SkipQuantityPromptInExchange, Is.True);
         });
     }
 
@@ -35,5 +36,15 @@ public sealed class ArbiterSettingsTests
         var clone = (ArbiterSettings)settings.Clone();
 
         Assert.That(clone.ApplyModifiersKeyFix, Is.False);
+    }
+
+    [Test]
+    public void Should_Preserve_Exchange_Quantity_Prompt_Preference_When_Cloned()
+    {
+        var settings = new ArbiterSettings { SkipQuantityPromptInExchange = false };
+
+        var clone = (ArbiterSettings)settings.Clone();
+
+        Assert.That(clone.SkipQuantityPromptInExchange, Is.False);
     }
 }

--- a/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
+++ b/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
@@ -15,6 +15,7 @@ public sealed class ArbiterSettingsTests
             Assert.That(settings?.TraceDetailedView, Is.True);
             Assert.That(settings?.ApplyModifiersKeyFix, Is.True);
             Assert.That(settings?.SkipQuantityPromptInExchange, Is.True);
+            Assert.That(settings?.ShowItemQuantityInDialogs, Is.True);
         });
     }
 
@@ -46,5 +47,15 @@ public sealed class ArbiterSettingsTests
         var clone = (ArbiterSettings)settings.Clone();
 
         Assert.That(clone.SkipQuantityPromptInExchange, Is.False);
+    }
+
+    [Test]
+    public void Should_Preserve_Dialog_Item_Quantity_Preference_When_Cloned()
+    {
+        var settings = new ArbiterSettings { ShowItemQuantityInDialogs = false };
+
+        var clone = (ArbiterSettings)settings.Clone();
+
+        Assert.That(clone.ShowItemQuantityInDialogs, Is.False);
     }
 }

--- a/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
+++ b/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
@@ -14,6 +14,7 @@ public sealed class ArbiterSettingsTests
         {
             Assert.That(settings?.TraceDetailedView, Is.True);
             Assert.That(settings?.ApplyModifiersKeyFix, Is.True);
+            Assert.That(settings?.AllowAltToShowGroundItems, Is.True);
             Assert.That(settings?.SkipQuantityPromptInExchange, Is.True);
             Assert.That(settings?.ShowItemQuantityInDialogs, Is.True);
         });
@@ -37,6 +38,16 @@ public sealed class ArbiterSettingsTests
         var clone = (ArbiterSettings)settings.Clone();
 
         Assert.That(clone.ApplyModifiersKeyFix, Is.False);
+    }
+
+    [Test]
+    public void Should_Preserve_Alt_Ground_Item_Preference_When_Cloned()
+    {
+        var settings = new ArbiterSettings { AllowAltToShowGroundItems = false };
+
+        var clone = (ArbiterSettings)settings.Clone();
+
+        Assert.That(clone.AllowAltToShowGroundItems, Is.False);
     }
 
     [Test]

--- a/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
+++ b/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
@@ -18,6 +18,10 @@ public class GameClientServiceTests
         "BuildSkipExchangeQuantityPromptStub", BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo BuildSkipExchangeQuantityPromptHook = typeof(GameClientService).GetMethod(
         "BuildSkipExchangeQuantityPromptHook", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildShowItemQuantityInDialogsStub = typeof(GameClientService).GetMethod(
+        "BuildShowItemQuantityInDialogsStub", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildShowItemQuantityInDialogsHook = typeof(GameClientService).GetMethod(
+        "BuildShowItemQuantityInDialogsHook", BindingFlags.NonPublic | BindingFlags.Static)!;
 
     [Test]
     public void Should_Replace_Expected_Login_Notification_Patches()
@@ -161,6 +165,67 @@ public class GameClientServiceTests
         });
     }
 
+    [Test]
+    public void Should_Build_Show_Item_Quantity_In_Dialogs_Stub_With_Resolved_Addresses()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x10000000;
+
+        var stub = (byte[])BuildShowItemQuantityInDialogsStub.Invoke(null,
+            [moduleBaseAddress, stubAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub, Has.Length.EqualTo(341));
+            Assert.That(stub[0x0C..0x23], Is.EqualTo(new byte[]
+            {
+                0x8B, 0x75, 0x10, 0x89, 0xB5, 0xD8, 0xFE, 0xFF, 0xFF, 0x8B, 0x7D, 0x00,
+                0x8B, 0x7F, 0xE8, 0x0F, 0xB6, 0x3F, 0x90, 0x90, 0x90, 0x90, 0x90,
+            }));
+            Assert.That(GetNearConditionalTarget(stub, 0x26), Is.EqualTo(0x139));
+            Assert.That(GetNearConditionalTarget(stub, 0x2F), Is.EqualTo(0x139));
+            Assert.That(GetNearConditionalTarget(stub, 0x3C), Is.EqualTo(0x139));
+            Assert.That(stub[0x72..0x7A],
+                Is.EqualTo(new byte[] { 0x49, 0x0F, 0x8E, 0xC0, 0x00, 0x00, 0x00, 0x41 }));
+            Assert.That(GetNearConditionalTarget(stub, 0x73), Is.EqualTo(0x139));
+            Assert.That(stub[0x36..0x3A], Is.EqualTo(new byte[] { 0x06, 0x9C, 0x5A, 0xF0 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x35), Is.EqualTo(0x005A9C40));
+            Assert.That(stub[0x99..0x9D], Is.EqualTo(new byte[] { 0x80, 0x93, 0x66, 0x00 }));
+            Assert.That(BitConverter.ToUInt32(stub, 0x99), Is.EqualTo(0x00669380));
+            Assert.That(BitConverter.ToInt32(stub, 0xCC), Is.EqualTo(20));
+            Assert.That(stub[0xDA..0xDD], Is.EqualTo(new byte[] { 0x83, 0xEA, 0x02 }));
+            Assert.That(stub[0x109..0x115], Is.EqualTo(new byte[]
+            {
+                0x66, 0xC7, 0x07, 0x2E, 0x2E, 0x90, 0x90, 0x90, 0x90, 0x83, 0xC7, 0x02,
+            }));
+            Assert.That(stub[0xF4..0xF8], Is.EqualTo(new byte[] { 0x78, 0xD5, 0x47, 0xF0 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0xF3), Is.EqualTo(0x0047D670));
+            Assert.That(stub[0x133..0x139], Is.EqualTo(new byte[] { 0x89, 0x85, 0xD8, 0xFE, 0xFF, 0xFF }));
+            Assert.That(stub[0x139..0x145], Is.EqualTo(new byte[]
+            {
+                0xFF, 0xB5, 0xD8, 0xFE, 0xFF, 0xFF, 0xFF, 0x75, 0x0C, 0xFF, 0x75, 0x08,
+            }));
+            Assert.That(stub[0x146..0x14A], Is.EqualTo(new byte[] { 0x7A, 0x27, 0x62, 0xF0 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x145), Is.EqualTo(0x006228C4));
+            Assert.That(stub[^8..], Is.EqualTo(new byte[] { 0x8D, 0x65, 0xF4, 0x5F, 0x5E, 0x5B, 0x5D, 0xC3 }));
+        });
+    }
+
+    [Test]
+    public void Should_Build_Only_A_Five_Byte_Call_To_The_Dialog_Item_Quantity_Stub()
+    {
+        var hookAddress = (IntPtr)0x0053609C;
+        var stubAddress = (IntPtr)0x10000000;
+
+        var hook = (byte[])BuildShowItemQuantityInDialogsHook.Invoke(null, [hookAddress, stubAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hook, Is.EqualTo(new byte[] { 0xE8, 0x5F, 0x9F, 0xAC, 0x0F }));
+            Assert.That(GetRelativeTarget(hook, hookAddress, 0), Is.EqualTo(stubAddress.ToInt64()));
+        });
+    }
+
     private static void ApplyPatch(byte[] memory)
     {
         using var stream = new MemoryStream(memory, writable: true);
@@ -177,4 +242,7 @@ public class GameClientServiceTests
 
     private static int GetShortTarget(byte[] code, int instructionOffset) =>
         instructionOffset + 2 + unchecked((sbyte)code[instructionOffset + 1]);
+
+    private static int GetNearConditionalTarget(byte[] code, int instructionOffset) =>
+        instructionOffset + 6 + BitConverter.ToInt32(code, instructionOffset + 2);
 }

--- a/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
+++ b/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
@@ -14,6 +14,10 @@ public class GameClientServiceTests
         "BuildStuckModifierFixStub", BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo BuildStuckModifierCall = typeof(GameClientService).GetMethod(
         "BuildStuckModifierCall", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildSkipExchangeQuantityPromptStub = typeof(GameClientService).GetMethod(
+        "BuildSkipExchangeQuantityPromptStub", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildSkipExchangeQuantityPromptHook = typeof(GameClientService).GetMethod(
+        "BuildSkipExchangeQuantityPromptHook", BindingFlags.NonPublic | BindingFlags.Static)!;
 
     [Test]
     public void Should_Replace_Expected_Login_Notification_Patches()
@@ -113,6 +117,47 @@ public class GameClientServiceTests
             Assert.That(call, Has.Length.EqualTo(5));
             Assert.That(call[0], Is.EqualTo(0xE8));
             Assert.That(GetRelativeTarget(call, callAddress, 0), Is.EqualTo(stubAddress.ToInt64()));
+        });
+    }
+
+    [Test]
+    public void Should_Build_Skip_Exchange_Quantity_Prompt_Stub_With_Resolved_Addresses()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x0066867A;
+
+        var stub = (byte[])BuildSkipExchangeQuantityPromptStub.Invoke(null,
+            [moduleBaseAddress, stubAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub, Has.Length.EqualTo(125));
+            Assert.That(stub[0..16], Is.EqualTo(new byte[]
+            {
+                0x53, 0x56, 0x57, 0x89, 0xCE, 0x8B, 0x7C, 0x24,
+                0x10, 0x0F, 0xB6, 0x5F, 0x02, 0x84, 0xDB, 0x74,
+            }));
+            Assert.That(stub[0x17..0x1B], Is.EqualTo(new byte[] { 0xAB, 0x15, 0xF4, 0xFF }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x16), Is.EqualTo(0x005A9C40));
+            Assert.That(stub[0x5D..0x61], Is.EqualTo(new byte[] { 0xC5, 0x3B, 0xE0, 0xFF }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x5C), Is.EqualTo(0x0046C2A0));
+            Assert.That(stub[0x79..0x7D], Is.EqualTo(new byte[] { 0x9E, 0x1F, 0xE0, 0xFF }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x78), Is.EqualTo(0x0046A695));
+        });
+    }
+
+    [Test]
+    public void Should_Build_Only_A_Five_Byte_Jump_To_The_Exchange_Quantity_Prompt_Stub()
+    {
+        var hookAddress = (IntPtr)0x0046A690;
+        var stubAddress = (IntPtr)0x0066867A;
+
+        var hook = (byte[])BuildSkipExchangeQuantityPromptHook.Invoke(null, [hookAddress, stubAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hook, Is.EqualTo(new byte[] { 0xE9, 0xE5, 0xDF, 0x1F, 0x00 }));
+            Assert.That(GetRelativeTarget(hook, hookAddress, 0), Is.EqualTo(stubAddress.ToInt64()));
         });
     }
 

--- a/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
+++ b/Arbiter.App.Tests/Services/Client/GameClientServiceTests.cs
@@ -14,6 +14,20 @@ public class GameClientServiceTests
         "BuildStuckModifierFixStub", BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo BuildStuckModifierCall = typeof(GameClientService).GetMethod(
         "BuildStuckModifierCall", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildGroundItemCollectorStub = typeof(GameClientService).GetMethod(
+        "BuildGroundItemCollectorStub", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildGroundItemFrameStub = typeof(GameClientService).GetMethod(
+        "BuildGroundItemFrameStub", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildGroundItemKeyTransitionStub = typeof(GameClientService).GetMethod(
+        "BuildGroundItemKeyTransitionStub", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo BuildGroundItemHook = typeof(GameClientService).GetMethod(
+        "BuildGroundItemHook", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly FieldInfo GroundItemKeyDownStubTemplate = typeof(GameClientService).GetField(
+        "GroundItemKeyDownStubTemplate", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly FieldInfo GroundItemKeyUpStubTemplate = typeof(GameClientService).GetField(
+        "GroundItemKeyUpStubTemplate", BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly FieldInfo ExpectedStaticRenderModeSelector = typeof(GameClientService).GetField(
+        "ExpectedStaticRenderModeSelector", BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo BuildSkipExchangeQuantityPromptStub = typeof(GameClientService).GetMethod(
         "BuildSkipExchangeQuantityPromptStub", BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo BuildSkipExchangeQuantityPromptHook = typeof(GameClientService).GetMethod(
@@ -121,6 +135,122 @@ public class GameClientServiceTests
             Assert.That(call, Has.Length.EqualTo(5));
             Assert.That(call[0], Is.EqualTo(0xE8));
             Assert.That(GetRelativeTarget(call, callAddress, 0), Is.EqualTo(stubAddress.ToInt64()));
+        });
+    }
+
+    [Test]
+    public void Should_Build_255_Item_Collector_Stub_With_Resolved_Addresses()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x10000000;
+        var stateAddress = (IntPtr)0x00B70000;
+
+        var stub = (byte[])BuildGroundItemCollectorStub.Invoke(null,
+            [moduleBaseAddress, stubAddress, stateAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub, Has.Length.EqualTo(157));
+            Assert.That(stub[0..11], Is.EqualTo(new byte[]
+            {
+                0x55, 0x89, 0xE5, 0x83, 0xEC, 0x08, 0x53, 0x56, 0x57, 0x89, 0xCE,
+            }));
+            Assert.That(BitConverter.ToUInt32(stub, 0x3A), Is.EqualTo(0x0068B1AC));
+            Assert.That(BitConverter.ToUInt32(stub, 0x4A), Is.EqualTo(0x00B70000));
+            Assert.That(stub[0x4E..0x53], Is.EqualTo(new byte[] { 0x3D, 0xFF, 0x00, 0x00, 0x00 }));
+            Assert.That(BitConverter.ToUInt32(stub, 0x5A), Is.EqualTo(0x00B70100));
+            Assert.That(BitConverter.ToUInt32(stub, 0x70), Is.EqualTo(0x00B70000));
+            Assert.That(BitConverter.ToUInt32(stub, 0x76), Is.EqualTo(0x00B70004));
+            Assert.That(BitConverter.ToUInt32(stub, 0x7E), Is.EqualTo(0x00B70008));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x98), Is.EqualTo(0x005D3745));
+        });
+    }
+
+    [Test]
+    public void Should_Build_Final_Frame_Replay_Stub_With_Resolved_Addresses()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x20000000;
+        var stateAddress = (IntPtr)0x00B70000;
+
+        var stub = (byte[])BuildGroundItemFrameStub.Invoke(null,
+            [moduleBaseAddress, stubAddress, stateAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub, Has.Length.EqualTo(186));
+            Assert.That(BitConverter.ToUInt32(stub, 0x0D), Is.EqualTo(0x00B70028));
+            Assert.That(BitConverter.ToUInt32(stub, 0x13), Is.EqualTo(0x00B70000));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x25), Is.EqualTo(0x00427380));
+            Assert.That(stub[0x2E..0x35],
+                Is.EqualTo(new byte[] { 0xF6, 0x80, 0x34, 0x04, 0x00, 0x00, 0x01 }));
+            Assert.That(BitConverter.ToUInt32(stub, 0x3B), Is.EqualTo(0x00B70000));
+            Assert.That(BitConverter.ToUInt32(stub, 0x46), Is.EqualTo(0x00B70100));
+            Assert.That(BitConverter.ToUInt32(stub, 0x52), Is.EqualTo(0x0068B1AC));
+            Assert.That(BitConverter.ToUInt32(stub, 0x79), Is.EqualTo(0x00B70004));
+            Assert.That(BitConverter.ToUInt32(stub, 0x8D), Is.EqualTo(0x00B70008));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x91), Is.EqualTo(0x005D3190));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0xB5), Is.EqualTo(0x005CE286));
+        });
+    }
+
+    [TestCase(false, 0x00067C10, 0x00467C15)]
+    [TestCase(true, 0x00067E30, 0x00467E35)]
+    public void Should_Build_Raw_Alt_Key_Invalidation_Stubs_With_Resolved_Addresses(bool keyUp, int hookRva,
+        int expectedContinuation)
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x20000000;
+        var stateAddress = (IntPtr)0x00B70000;
+        var templateField = keyUp ? GroundItemKeyUpStubTemplate : GroundItemKeyDownStubTemplate;
+        var template = (byte[])templateField.GetValue(null)!;
+
+        var stub = (byte[])BuildGroundItemKeyTransitionStub.Invoke(null,
+            [moduleBaseAddress, stubAddress, stateAddress, hookRva, template])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub, Has.Length.EqualTo(84));
+            Assert.That(stub[0x1F..0x2C], Is.EqualTo(new byte[]
+            {
+                0x0F, 0xB6, 0x45, 0x08, 0x83, 0xF8, 0x38, 0x74, 0x07, 0x3D, 0xB8, 0x00, 0x00,
+            }));
+            Assert.That(BitConverter.ToUInt32(stub, 0x31), Is.EqualTo(0x00B70028));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x3B), Is.EqualTo(0x00549F60));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x4F), Is.EqualTo(expectedContinuation));
+        });
+    }
+
+    [Test]
+    public void Should_Leave_The_Static_Render_Mode_Selector_Unchanged()
+    {
+        var expected = (byte[])ExpectedStaticRenderModeSelector.GetValue(null)!;
+
+        Assert.That(expected, Is.EqualTo(new byte[]
+        {
+            0x8B, 0x55, 0xD0, 0x0F, 0xB6, 0x82, 0xB9, 0x00, 0x00, 0x00, 0x25, 0x80, 0x00, 0x00, 0x00, 0x74,
+            0x09, 0xC7, 0x45, 0xE8, 0x6D, 0x00, 0x00, 0x00, 0xEB, 0x16, 0x8B, 0x4D, 0xD0, 0x0F, 0xB6, 0x91,
+            0xB9, 0x00, 0x00, 0x00, 0x83, 0xE2, 0x40, 0x74, 0x07, 0xC7, 0x45, 0xE8, 0x03, 0x00, 0x00, 0x00,
+        }));
+    }
+
+    [Test]
+    public void Should_Build_Padded_Jumps_To_The_Ground_Item_Wrappers()
+    {
+        var hookAddress = (IntPtr)0x005D3740;
+        var stubAddress = (IntPtr)0x10000000;
+
+        var fiveByteHook = (byte[])BuildGroundItemHook.Invoke(null, [hookAddress, stubAddress, 5])!;
+        var sixByteHook = (byte[])BuildGroundItemHook.Invoke(null, [hookAddress, stubAddress, 6])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fiveByteHook, Has.Length.EqualTo(5));
+            Assert.That(fiveByteHook[0], Is.EqualTo(0xE9));
+            Assert.That(GetRelativeTarget(fiveByteHook, hookAddress, 0), Is.EqualTo(stubAddress.ToInt64()));
+            Assert.That(sixByteHook, Has.Length.EqualTo(6));
+            Assert.That(sixByteHook[5], Is.EqualTo(0x90));
+            Assert.That(GetRelativeTarget(sixByteHook, hookAddress, 0), Is.EqualTo(stubAddress.ToInt64()));
         });
     }
 

--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -9,9 +9,9 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <Company>Erik 'SiLo' Rogers</Company>
         <Product>Arbiter</Product>
-        <Version>1.9.5</Version>
-        <AssemblyVersion>1.9.5</AssemblyVersion>
-        <FileVersion>1.9.5</FileVersion>
+        <Version>1.9.6</Version>
+        <AssemblyVersion>1.9.6</AssemblyVersion>
+        <FileVersion>1.9.6</FileVersion>
         <ApplicationIcon>Assets\arbiter.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/Arbiter.App/Models/LaunchClientOptions.cs
+++ b/Arbiter.App/Models/LaunchClientOptions.cs
@@ -1,4 +1,4 @@
 ﻿namespace Arbiter.App.Models;
 
 public record LaunchClientOptions(int LocalPort = 2610, bool SkipIntroVideo = true, bool SuppressLoginNotice = true,
-    bool ApplyModifiersKeyFix = true);
+    bool ApplyModifiersKeyFix = true, bool SkipQuantityPromptInExchange = true);

--- a/Arbiter.App/Models/LaunchClientOptions.cs
+++ b/Arbiter.App/Models/LaunchClientOptions.cs
@@ -1,4 +1,5 @@
 ﻿namespace Arbiter.App.Models;
 
 public record LaunchClientOptions(int LocalPort = 2610, bool SkipIntroVideo = true, bool SuppressLoginNotice = true,
-    bool ApplyModifiersKeyFix = true, bool SkipQuantityPromptInExchange = true);
+    bool ApplyModifiersKeyFix = true, bool SkipQuantityPromptInExchange = true,
+    bool ShowItemQuantityInDialogs = true);

--- a/Arbiter.App/Models/LaunchClientOptions.cs
+++ b/Arbiter.App/Models/LaunchClientOptions.cs
@@ -1,5 +1,5 @@
 ﻿namespace Arbiter.App.Models;
 
 public record LaunchClientOptions(int LocalPort = 2610, bool SkipIntroVideo = true, bool SuppressLoginNotice = true,
-    bool ApplyModifiersKeyFix = true, bool SkipQuantityPromptInExchange = true,
+    bool ApplyModifiersKeyFix = true, bool AllowAltToShowGroundItems = true, bool SkipQuantityPromptInExchange = true,
     bool ShowItemQuantityInDialogs = true);

--- a/Arbiter.App/Models/Settings/ArbiterSettings.cs
+++ b/Arbiter.App/Models/Settings/ArbiterSettings.cs
@@ -14,6 +14,7 @@ public class ArbiterSettings : ICloneable
     public bool SkipIntroVideo { get; set; } = true;
     public bool SuppressLoginNotice { get; set; } = true;
     public bool ApplyModifiersKeyFix { get; set; } = true;
+    public bool AllowAltToShowGroundItems { get; set; } = true;
     public bool SkipQuantityPromptInExchange { get; set; } = true;
     public bool ShowItemQuantityInDialogs { get; set; } = true;
 
@@ -48,6 +49,7 @@ public class ArbiterSettings : ICloneable
         SkipIntroVideo = SkipIntroVideo,
         SuppressLoginNotice = SuppressLoginNotice,
         ApplyModifiersKeyFix = ApplyModifiersKeyFix,
+        AllowAltToShowGroundItems = AllowAltToShowGroundItems,
         SkipQuantityPromptInExchange = SkipQuantityPromptInExchange,
         ShowItemQuantityInDialogs = ShowItemQuantityInDialogs,
         LocalPort = LocalPort,

--- a/Arbiter.App/Models/Settings/ArbiterSettings.cs
+++ b/Arbiter.App/Models/Settings/ArbiterSettings.cs
@@ -15,6 +15,7 @@ public class ArbiterSettings : ICloneable
     public bool SuppressLoginNotice { get; set; } = true;
     public bool ApplyModifiersKeyFix { get; set; } = true;
     public bool SkipQuantityPromptInExchange { get; set; } = true;
+    public bool ShowItemQuantityInDialogs { get; set; } = true;
 
     public int LocalPort { get; set; } = 2610;
 
@@ -48,6 +49,7 @@ public class ArbiterSettings : ICloneable
         SuppressLoginNotice = SuppressLoginNotice,
         ApplyModifiersKeyFix = ApplyModifiersKeyFix,
         SkipQuantityPromptInExchange = SkipQuantityPromptInExchange,
+        ShowItemQuantityInDialogs = ShowItemQuantityInDialogs,
         LocalPort = LocalPort,
         RemoteServerAddress = RemoteServerAddress,
         RemoteServerPort = RemoteServerPort,

--- a/Arbiter.App/Models/Settings/ArbiterSettings.cs
+++ b/Arbiter.App/Models/Settings/ArbiterSettings.cs
@@ -14,6 +14,7 @@ public class ArbiterSettings : ICloneable
     public bool SkipIntroVideo { get; set; } = true;
     public bool SuppressLoginNotice { get; set; } = true;
     public bool ApplyModifiersKeyFix { get; set; } = true;
+    public bool SkipQuantityPromptInExchange { get; set; } = true;
 
     public int LocalPort { get; set; } = 2610;
 
@@ -46,6 +47,7 @@ public class ArbiterSettings : ICloneable
         SkipIntroVideo = SkipIntroVideo,
         SuppressLoginNotice = SuppressLoginNotice,
         ApplyModifiersKeyFix = ApplyModifiersKeyFix,
+        SkipQuantityPromptInExchange = SkipQuantityPromptInExchange,
         LocalPort = LocalPort,
         RemoteServerAddress = RemoteServerAddress,
         RemoteServerPort = RemoteServerPort,

--- a/Arbiter.App/Models/Settings/DebugSettings.cs
+++ b/Arbiter.App/Models/Settings/DebugSettings.cs
@@ -6,7 +6,6 @@ public class DebugSettings : ICloneable
 {
     public bool ShowDialogId { get; set; }
     public bool ShowPursuitId { get; set; }
-    public bool ShowDialogItemQuantity { get; set; }
     public bool ShowEquipmentDurability { get; set; }
     public bool ShowNpcId { get; set; }
     public bool ShowMonsterId { get; set; }
@@ -27,7 +26,6 @@ public class DebugSettings : ICloneable
     {
         ShowDialogId = ShowDialogId,
         ShowPursuitId = ShowPursuitId,
-        ShowDialogItemQuantity = ShowDialogItemQuantity,
         ShowEquipmentDurability = ShowEquipmentDurability,
         ShowNpcId = ShowNpcId,
         ShowMonsterId = ShowMonsterId,

--- a/Arbiter.App/Services/Client/GameClientService.Dialogs.cs
+++ b/Arbiter.App/Services/Client/GameClientService.Dialogs.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using System.Linq;
+using Arbiter.Interop.Process;
+
+namespace Arbiter.App.Services.Client;
+
+public partial class GameClientService
+{
+    private const int DialogItemLabelMaxBytes = 20;
+    private const int ItemQuantityDialogHookRva = 0x0013609C;
+    private const int DialogItemNameCopyRva = 0x002228C4;
+    private const int DialogUiGetGuiBackPaneRva = 0x001A9C40;
+    private const int UiTextTruncateDbcsSafeRva = 0x0007D670;
+    private const int WsprintfImportAddressRva = 0x00269380;
+
+    private static readonly byte[] ExpectedItemQuantityDialogHook = [0xE8, 0x23, 0xC8, 0x0E, 0x00];
+    private static readonly byte[] ShowItemQuantityInDialogsStubTemplate =
+    [
+        0x55, 0x89, 0xE5, 0x53, 0x56, 0x57, 0x81, 0xEC, 0x20, 0x01, 0x00, 0x00, 0x8B, 0x75, 0x10, 0x89,
+        0xB5, 0xD8, 0xFE, 0xFF, 0xFF, 0x8B, 0x7D, 0x00, 0x8B, 0x7F, 0xE8, 0x0F, 0xB6, 0x3F, 0x90, 0x90,
+        0x90, 0x90, 0x90, 0x83, 0xFF, 0x01, 0x0F, 0x82, 0x0D, 0x01, 0x00, 0x00, 0x83, 0xFF, 0x3C, 0x0F,
+        0x87, 0x04, 0x01, 0x00, 0x00, 0xE8, 0x00, 0x00, 0x00, 0x00, 0x85, 0xC0, 0x0F, 0x84, 0xF7, 0x00,
+        0x00, 0x00, 0x8B, 0x80, 0x88, 0x4F, 0x00, 0x00, 0x85, 0xC0, 0x0F, 0x84, 0xE9, 0x00, 0x00, 0x00,
+        0x8B, 0x84, 0xB8, 0x9C, 0x01, 0x00, 0x00, 0x85, 0xC0, 0x0F, 0x84, 0xDA, 0x00, 0x00, 0x00, 0x80,
+        0xB8, 0x44, 0x02, 0x00, 0x00, 0x00, 0x0F, 0x84, 0xCD, 0x00, 0x00, 0x00, 0x8B, 0x88, 0x40, 0x02,
+        0x00, 0x00, 0x49, 0x0F, 0x8E, 0xC0, 0x00, 0x00, 0x00, 0x41, 0x89, 0x8D, 0xD4, 0xFE, 0xFF, 0xFF,
+        0xE8, 0x06, 0x00, 0x00, 0x00, 0x20, 0x28, 0x25, 0x75, 0x29, 0x00, 0x58, 0xFF, 0xB5, 0xD4, 0xFE,
+        0xFF, 0xFF, 0x50, 0x8D, 0x45, 0xE4, 0x50, 0xFF, 0x15, 0x00, 0x00, 0x00, 0x00, 0x83, 0xC4, 0x0C,
+        0x83, 0xF8, 0x01, 0x0F, 0x8E, 0x90, 0x00, 0x00, 0x00, 0x83, 0xF8, 0x0F, 0x0F, 0x83, 0x87, 0x00,
+        0x00, 0x00, 0x89, 0x85, 0xE0, 0xFE, 0xFF, 0xFF, 0x31, 0xC9, 0x81, 0xF9, 0x00, 0x01, 0x00, 0x00,
+        0x73, 0x09, 0x80, 0x3C, 0x0E, 0x00, 0x74, 0x03, 0x41, 0xEB, 0xEF, 0xBA, 0x00, 0x00, 0x00, 0x00,
+        0x2B, 0x95, 0xE0, 0xFE, 0xFF, 0xFF, 0x39, 0xD1, 0x76, 0x3D, 0x83, 0xEA, 0x02, 0x8D, 0xBD, 0xE4,
+        0xFE, 0xFF, 0xFF, 0x89, 0xD1, 0xFC, 0xF3, 0xA4, 0xC6, 0x07, 0x00, 0x52, 0x8D, 0x85, 0xE4, 0xFE,
+        0xFF, 0xFF, 0x50, 0xE8, 0x00, 0x00, 0x00, 0x00, 0x83, 0xC4, 0x08, 0x8D, 0xBD, 0xE4, 0xFE, 0xFF,
+        0xFF, 0x80, 0x3F, 0x00, 0x74, 0x03, 0x47, 0xEB, 0xF8, 0x66, 0xC7, 0x07, 0x2E, 0x2E, 0x90, 0x90,
+        0x90, 0x90, 0x83, 0xC7, 0x02, 0xEB, 0x09, 0x8D, 0xBD, 0xE4, 0xFE, 0xFF, 0xFF, 0xFC, 0xF3, 0xA4,
+        0x8D, 0x75, 0xE4, 0x8B, 0x8D, 0xE0, 0xFE, 0xFF, 0xFF, 0x41, 0xFC, 0xF3, 0xA4, 0x8D, 0x85, 0xE4,
+        0xFE, 0xFF, 0xFF, 0x89, 0x85, 0xD8, 0xFE, 0xFF, 0xFF, 0xFF, 0xB5, 0xD8, 0xFE, 0xFF, 0xFF, 0xFF,
+        0x75, 0x0C, 0xFF, 0x75, 0x08, 0xE8, 0x00, 0x00, 0x00, 0x00, 0x83, 0xC4, 0x0C, 0x8D, 0x65, 0xF4,
+        0x5F, 0x5E, 0x5B, 0x5D, 0xC3,
+    ];
+
+    private static void ApplyShowItemQuantityInDialogsPatch(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr moduleBaseAddress)
+    {
+        var stage = "verify the dialog item-quantity hook";
+        var stubAddress = IntPtr.Zero;
+        var hookWriteStarted = false;
+
+        try
+        {
+            var hookAddress = Add(moduleBaseAddress, ItemQuantityDialogHookRva);
+            var actualHook = ReadRemoteBytes(writer, hookAddress, ExpectedItemQuantityDialogHook.Length);
+            if (!actualHook.SequenceEqual(ExpectedItemQuantityDialogHook))
+            {
+                throw new InvalidDataException($"Unexpected client bytes at 0x{hookAddress.ToInt64():X}: " +
+                                               $"expected {Convert.ToHexString(ExpectedItemQuantityDialogHook)}, " +
+                                               $"found {Convert.ToHexString(actualHook)}.");
+            }
+
+            stage = "allocate the dialog item-quantity stub";
+            stubAddress = allocator.AllocMemory(_ => { }, ShowItemQuantityInDialogsStubTemplate.Length);
+            var stub = BuildShowItemQuantityInDialogsStub(moduleBaseAddress, stubAddress);
+
+            stage = "write the dialog item-quantity stub";
+            writer.BaseStream.Position = stubAddress.ToInt64();
+            writer.Write(stub);
+
+            stage = "protect and verify the dialog item-quantity stub";
+            allocator.MakeExecutable(stubAddress, stub.Length);
+            VerifyRemoteBytes(writer, stubAddress, stub);
+            allocator.FlushInstructionCache(stubAddress, stub.Length);
+
+            var replacementHook = BuildShowItemQuantityInDialogsHook(hookAddress, stubAddress);
+
+            stage = "write the dialog item-quantity hook";
+            using (allocator.MakeWritable(hookAddress, replacementHook.Length))
+            {
+                hookWriteStarted = true;
+                writer.BaseStream.Position = hookAddress.ToInt64();
+                writer.Write(replacementHook);
+                allocator.FlushInstructionCache(hookAddress, replacementHook.Length);
+            }
+
+            stage = "verify the dialog item-quantity hook";
+            VerifyRemoteBytes(writer, hookAddress, replacementHook);
+        }
+        catch (Exception exception)
+        {
+            Exception? cleanupException = null;
+            var hookRestored = !hookWriteStarted;
+            var hookAddress = Add(moduleBaseAddress, ItemQuantityDialogHookRva);
+
+            if (hookWriteStarted)
+            {
+                try
+                {
+                    RestoreItemQuantityDialogHook(writer, allocator, hookAddress);
+                    hookRestored = true;
+                }
+                catch (Exception rollbackException)
+                {
+                    cleanupException = rollbackException;
+                }
+            }
+
+            if (stubAddress != IntPtr.Zero && hookRestored)
+            {
+                try
+                {
+                    allocator.FreeMemory(stubAddress);
+                }
+                catch (Exception freeException)
+                {
+                    cleanupException = freeException;
+                }
+            }
+
+            var innerException = cleanupException is null
+                ? exception
+                : new AggregateException(exception, cleanupException);
+            throw new InvalidOperationException($"Failed to {stage}: {exception.Message}", innerException);
+        }
+    }
+
+    private static byte[] BuildShowItemQuantityInDialogsStub(IntPtr moduleBaseAddress, IntPtr stubAddress)
+    {
+        var stub = ShowItemQuantityInDialogsStubTemplate.ToArray();
+
+        WriteInt32(stub, 0x36, GetRelativeOffset(Add(stubAddress, 0x36), sizeof(int),
+            Add(moduleBaseAddress, DialogUiGetGuiBackPaneRva)));
+        WriteUInt32(stub, 0x99, checked((uint)Add(moduleBaseAddress, WsprintfImportAddressRva).ToInt64()));
+        WriteInt32(stub, 0xCC, DialogItemLabelMaxBytes);
+        WriteInt32(stub, 0xF4, GetRelativeOffset(Add(stubAddress, 0xF4), sizeof(int),
+            Add(moduleBaseAddress, UiTextTruncateDbcsSafeRva)));
+        WriteInt32(stub, 0x146, GetRelativeOffset(Add(stubAddress, 0x146), sizeof(int),
+            Add(moduleBaseAddress, DialogItemNameCopyRva)));
+
+        return stub;
+    }
+
+    private static byte[] BuildShowItemQuantityInDialogsHook(IntPtr hookAddress, IntPtr stubAddress)
+    {
+        var hook = new byte[ExpectedItemQuantityDialogHook.Length];
+        hook[0] = 0xE8;
+        WriteInt32(hook, 1, GetRelativeOffset(hookAddress, hook.Length, stubAddress));
+        return hook;
+    }
+
+    private static void RestoreItemQuantityDialogHook(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr hookAddress)
+    {
+        using (allocator.MakeWritable(hookAddress, ExpectedItemQuantityDialogHook.Length))
+        {
+            writer.BaseStream.Position = hookAddress.ToInt64();
+            writer.Write(ExpectedItemQuantityDialogHook);
+            allocator.FlushInstructionCache(hookAddress, ExpectedItemQuantityDialogHook.Length);
+        }
+
+        VerifyRemoteBytes(writer, hookAddress, ExpectedItemQuantityDialogHook);
+    }
+
+    private static void WriteUInt32(byte[] buffer, int offset, uint value)
+    {
+        buffer[offset] = (byte)value;
+        buffer[offset + 1] = (byte)(value >> 8);
+        buffer[offset + 2] = (byte)(value >> 16);
+        buffer[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/Arbiter.App/Services/Client/GameClientService.Exchange.cs
+++ b/Arbiter.App/Services/Client/GameClientService.Exchange.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Linq;
+using Arbiter.Interop.Process;
+
+namespace Arbiter.App.Services.Client;
+
+public partial class GameClientService
+{
+    private const int ExchangeQuantityPromptHookRva = 0x0006A690;
+    private const int ExchangeQuantityPromptContinuationRva = 0x0006A695;
+    private const int UiGetGuiBackPaneRva = 0x001A9C40;
+    private const int ExchangeCountBuilderRva = 0x0006C2A0;
+
+    private static readonly byte[] ExpectedExchangeQuantityPromptHook = [0x55, 0x8B, 0xEC, 0x6A, 0xFF];
+    private static readonly byte[] SkipExchangeQuantityPromptStubTemplate =
+    [
+        0x53, 0x56, 0x57, 0x89, 0xCE, 0x8B, 0x7C, 0x24, 0x10, 0x0F, 0xB6, 0x5F, 0x02, 0x84, 0xDB, 0x74,
+        0x5F, 0x80, 0xFB, 0x3C, 0x77, 0x5A, 0xE8, 0x00, 0x00, 0x00, 0x00, 0x85, 0xC0, 0x74, 0x51, 0x8B,
+        0x80, 0x88, 0x4F, 0x00, 0x00, 0x85, 0xC0, 0x74, 0x47, 0x0F, 0xB6, 0xCB, 0x49, 0x8B, 0x84, 0x88,
+        0xA0, 0x01, 0x00, 0x00, 0x85, 0xC0, 0x74, 0x38, 0x80, 0xB8, 0x44, 0x02, 0x00, 0x00, 0x00, 0x74,
+        0x2F, 0x83, 0xB8, 0x40, 0x02, 0x00, 0x00, 0x01, 0x75, 0x26, 0x0F, 0xB6, 0x86, 0x34, 0x06, 0x00,
+        0x00, 0x50, 0x88, 0x9E, 0x34, 0x06, 0x00, 0x00, 0x6A, 0x01, 0x89, 0xF1, 0xE8, 0x00, 0x00, 0x00,
+        0x00, 0x5A, 0x88, 0x96, 0x34, 0x06, 0x00, 0x00, 0x5F, 0x5E, 0x5B, 0x31, 0xC0, 0xC2, 0x04, 0x00,
+        0x5F, 0x5E, 0x5B, 0x55, 0x89, 0xE5, 0x6A, 0xFF, 0xE9, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    private static void ApplySkipExchangeQuantityPromptPatch(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr moduleBaseAddress)
+    {
+        var stage = "verify the exchange quantity-prompt hook";
+        var stubAddress = IntPtr.Zero;
+        var hookWriteStarted = false;
+
+        try
+        {
+            var hookAddress = Add(moduleBaseAddress, ExchangeQuantityPromptHookRva);
+            var actualHook = ReadRemoteBytes(writer, hookAddress, ExpectedExchangeQuantityPromptHook.Length);
+            if (!actualHook.SequenceEqual(ExpectedExchangeQuantityPromptHook))
+            {
+                throw new InvalidDataException($"Unexpected client bytes at 0x{hookAddress.ToInt64():X}: " +
+                                               $"expected {Convert.ToHexString(ExpectedExchangeQuantityPromptHook)}, " +
+                                               $"found {Convert.ToHexString(actualHook)}.");
+            }
+
+            stage = "allocate the exchange quantity-prompt stub";
+            stubAddress = allocator.AllocMemory(_ => { }, SkipExchangeQuantityPromptStubTemplate.Length);
+            var stub = BuildSkipExchangeQuantityPromptStub(moduleBaseAddress, stubAddress);
+
+            stage = "write the exchange quantity-prompt stub";
+            writer.BaseStream.Position = stubAddress.ToInt64();
+            writer.Write(stub);
+
+            stage = "protect and verify the exchange quantity-prompt stub";
+            allocator.MakeExecutable(stubAddress, stub.Length);
+            VerifyRemoteBytes(writer, stubAddress, stub);
+            allocator.FlushInstructionCache(stubAddress, stub.Length);
+
+            var replacementHook = BuildSkipExchangeQuantityPromptHook(hookAddress, stubAddress);
+
+            stage = "write the exchange quantity-prompt hook";
+            using (allocator.MakeWritable(hookAddress, replacementHook.Length))
+            {
+                hookWriteStarted = true;
+                writer.BaseStream.Position = hookAddress.ToInt64();
+                writer.Write(replacementHook);
+                allocator.FlushInstructionCache(hookAddress, replacementHook.Length);
+            }
+
+            stage = "verify the exchange quantity-prompt hook";
+            VerifyRemoteBytes(writer, hookAddress, replacementHook);
+        }
+        catch (Exception exception)
+        {
+            Exception? cleanupException = null;
+            var hookRestored = !hookWriteStarted;
+            var hookAddress = Add(moduleBaseAddress, ExchangeQuantityPromptHookRva);
+
+            if (hookWriteStarted)
+            {
+                try
+                {
+                    RestoreExchangeQuantityPromptHook(writer, allocator, hookAddress);
+                    hookRestored = true;
+                }
+                catch (Exception rollbackException)
+                {
+                    cleanupException = rollbackException;
+                }
+            }
+
+            if (stubAddress != IntPtr.Zero && hookRestored)
+            {
+                try
+                {
+                    allocator.FreeMemory(stubAddress);
+                }
+                catch (Exception freeException)
+                {
+                    cleanupException = freeException;
+                }
+            }
+
+            var innerException = cleanupException is null
+                ? exception
+                : new AggregateException(exception, cleanupException);
+            throw new InvalidOperationException($"Failed to {stage}: {exception.Message}", innerException);
+        }
+    }
+
+    private static byte[] BuildSkipExchangeQuantityPromptStub(IntPtr moduleBaseAddress, IntPtr stubAddress)
+    {
+        var stub = SkipExchangeQuantityPromptStubTemplate.ToArray();
+
+        WriteInt32(stub, 0x17, GetRelativeOffset(Add(stubAddress, 0x17), sizeof(int),
+            Add(moduleBaseAddress, UiGetGuiBackPaneRva)));
+        WriteInt32(stub, 0x5D, GetRelativeOffset(Add(stubAddress, 0x5D), sizeof(int),
+            Add(moduleBaseAddress, ExchangeCountBuilderRva)));
+        WriteInt32(stub, 0x79, GetRelativeOffset(Add(stubAddress, 0x79), sizeof(int),
+            Add(moduleBaseAddress, ExchangeQuantityPromptContinuationRva)));
+
+        return stub;
+    }
+
+    private static byte[] BuildSkipExchangeQuantityPromptHook(IntPtr hookAddress, IntPtr stubAddress)
+    {
+        var hook = new byte[ExpectedExchangeQuantityPromptHook.Length];
+        hook[0] = 0xE9;
+        WriteInt32(hook, 1, GetRelativeOffset(hookAddress, hook.Length, stubAddress));
+        return hook;
+    }
+
+    private static void RestoreExchangeQuantityPromptHook(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr hookAddress)
+    {
+        using (allocator.MakeWritable(hookAddress, ExpectedExchangeQuantityPromptHook.Length))
+        {
+            writer.BaseStream.Position = hookAddress.ToInt64();
+            writer.Write(ExpectedExchangeQuantityPromptHook);
+            allocator.FlushInstructionCache(hookAddress, ExpectedExchangeQuantityPromptHook.Length);
+        }
+
+        VerifyRemoteBytes(writer, hookAddress, ExpectedExchangeQuantityPromptHook);
+    }
+}

--- a/Arbiter.App/Services/Client/GameClientService.GroundItems.cs
+++ b/Arbiter.App/Services/Client/GameClientService.GroundItems.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Arbiter.Interop.Process;
+
+namespace Arbiter.App.Services.Client;
+
+public partial class GameClientService
+{
+    private const int GroundItemCapacity = 255;
+    private const int GroundItemStateEntryOffset = 0x100;
+    private const int GroundItemStatePaneOffset = 0x28;
+    private const int GroundItemStateSize = GroundItemStateEntryOffset + GroundItemCapacity * 12;
+
+    private const int GroundItemCollectorHookRva = 0x001D3740;
+    private const int GroundItemFrameHookRva = 0x001CE280;
+    private const int GroundItemKeyDownHookRva = 0x00067C10;
+    private const int GroundItemKeyUpHookRva = 0x00067E30;
+    private const int StaticRenderModeSelectorRva = 0x001E487D;
+    private const int RenderWorldObjectRva = 0x001D3190;
+    private const int UiPaneInvalidateRva = 0x00149F60;
+    private const int WorldItemVtableRva = 0x0028B1AC;
+
+    private static readonly byte[] ExpectedGroundItemCollectorHook = [0x55, 0x8B, 0xEC, 0x6A, 0xFF];
+    private static readonly byte[] ExpectedGroundItemFrameHook = [0x55, 0x8B, 0xEC, 0x83, 0xEC, 0x1C];
+    private static readonly byte[] ExpectedGroundItemKeyDownHook = [0x55, 0x8B, 0xEC, 0x6A, 0xFF];
+    private static readonly byte[] ExpectedGroundItemKeyUpHook = [0x55, 0x8B, 0xEC, 0x6A, 0xFF];
+    private static readonly byte[] ExpectedStaticRenderModeSelector =
+    [
+        0x8B, 0x55, 0xD0, 0x0F, 0xB6, 0x82, 0xB9, 0x00, 0x00, 0x00, 0x25, 0x80, 0x00, 0x00, 0x00, 0x74,
+        0x09, 0xC7, 0x45, 0xE8, 0x6D, 0x00, 0x00, 0x00, 0xEB, 0x16, 0x8B, 0x4D, 0xD0, 0x0F, 0xB6, 0x91,
+        0xB9, 0x00, 0x00, 0x00, 0x83, 0xE2, 0x40, 0x74, 0x07, 0xC7, 0x45, 0xE8, 0x03, 0x00, 0x00, 0x00,
+    ];
+
+    private static readonly byte[] GroundItemCollectorStubTemplate = Convert.FromHexString(
+        "5589E583EC0853565789CEFF7518FF7514FF7510FF750CFF750889F1E8720000008945FC8BBEE00000003BBEE4000000" +
+        "73558B1785D2744A813A78563412754283BAB0000000017539A1001011113DFF00000073326BD80C81C3001111118B0F" +
+        "890B8B4F04894B048B4F08894B08FF05001011118935041011118B4508A30810111183C70CEBA38B45FC5F5E5B89EC" +
+        "5DC214005589E56AFFE963FFFF11");
+
+    private static readonly byte[] GroundItemFrameStubTemplate = Convert.FromHexString(
+        "5589E583EC1053565789CE893528101111C705001011110000000089F1E88D0000008945FCE8D6FFFFEF85C07477F680" +
+        "3404000001746E31FF3B3D0010111173646BC70C8D98001111118B1385D27452813A78563412754A83BAB00000000175" +
+        "418955F48B82B00000008945F8C782B0000000030000008B0D041011118B81BC0200008B55F403422C5053FF35081011" +
+        "11E86AFFFFF08B55F48B45F88982B000000047EB948B45FC5F5E5B89EC5DC35589E583EC1CE946FFFFF1");
+
+    private static readonly byte[] GroundItemKeyDownStubTemplate = Convert.FromHexString(
+        "5589E583EC085689CEFF7514FF7510FF750CFF750889F1E82E0000008945FC0FB6450883F83874073DB800000075118B" +
+        "0D2810111185C974076A00E8C0FFFFE28B45FC5E89EC5DC210005589E56AFFE9ACFFFFE3");
+
+    private static readonly byte[] GroundItemKeyUpStubTemplate = Convert.FromHexString(
+        "5589E583EC085689CEFF7514FF7510FF750CFF750889F1E82E0000008945FC0FB6450883F83874073DB800000075118B" +
+        "0D2810111185C974076A00E8C0FFFFE18B45FC5E89EC5DC210005589E56AFFE9ACFFFFE3");
+
+    private static void ApplyAllowAltToShowGroundItemsPatch(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr moduleBaseAddress)
+    {
+        var stage = "verify the ground-item hooks";
+        var stateAddress = IntPtr.Zero;
+        var collectorStubAddress = IntPtr.Zero;
+        var frameStubAddress = IntPtr.Zero;
+        var keyDownStubAddress = IntPtr.Zero;
+        var keyUpStubAddress = IntPtr.Zero;
+        var collectorHookWriteStarted = false;
+        var frameHookWriteStarted = false;
+        var keyDownHookWriteStarted = false;
+        var keyUpHookWriteStarted = false;
+
+        try
+        {
+            var collectorHookAddress = Add(moduleBaseAddress, GroundItemCollectorHookRva);
+            var frameHookAddress = Add(moduleBaseAddress, GroundItemFrameHookRva);
+            var keyDownHookAddress = Add(moduleBaseAddress, GroundItemKeyDownHookRva);
+            var keyUpHookAddress = Add(moduleBaseAddress, GroundItemKeyUpHookRva);
+
+            VerifyExpectedBytes(writer, collectorHookAddress, ExpectedGroundItemCollectorHook);
+            VerifyExpectedBytes(writer, frameHookAddress, ExpectedGroundItemFrameHook);
+            VerifyExpectedBytes(writer, keyDownHookAddress, ExpectedGroundItemKeyDownHook);
+            VerifyExpectedBytes(writer, keyUpHookAddress, ExpectedGroundItemKeyUpHook);
+
+            stage = "verify the original static render-mode selector";
+            VerifyExpectedBytes(writer, Add(moduleBaseAddress, StaticRenderModeSelectorRva),
+                ExpectedStaticRenderModeSelector);
+
+            stage = "allocate the ground-item state and stubs";
+            stateAddress = allocator.AllocMemory(_ => { }, GroundItemStateSize);
+            collectorStubAddress = allocator.AllocMemory(_ => { }, GroundItemCollectorStubTemplate.Length);
+            frameStubAddress = allocator.AllocMemory(_ => { }, GroundItemFrameStubTemplate.Length);
+            keyDownStubAddress = allocator.AllocMemory(_ => { }, GroundItemKeyDownStubTemplate.Length);
+            keyUpStubAddress = allocator.AllocMemory(_ => { }, GroundItemKeyUpStubTemplate.Length);
+
+            var collectorStub = BuildGroundItemCollectorStub(moduleBaseAddress, collectorStubAddress, stateAddress);
+            var frameStub = BuildGroundItemFrameStub(moduleBaseAddress, frameStubAddress, stateAddress);
+            var keyDownStub = BuildGroundItemKeyTransitionStub(moduleBaseAddress, keyDownStubAddress, stateAddress,
+                GroundItemKeyDownHookRva, GroundItemKeyDownStubTemplate);
+            var keyUpStub = BuildGroundItemKeyTransitionStub(moduleBaseAddress, keyUpStubAddress, stateAddress,
+                GroundItemKeyUpHookRva, GroundItemKeyUpStubTemplate);
+
+            stage = "write the ground-item stubs";
+            WriteGroundItemStub(writer, collectorStubAddress, collectorStub);
+            WriteGroundItemStub(writer, frameStubAddress, frameStub);
+            WriteGroundItemStub(writer, keyDownStubAddress, keyDownStub);
+            WriteGroundItemStub(writer, keyUpStubAddress, keyUpStub);
+
+            stage = "protect and verify the ground-item stubs";
+            ProtectGroundItemStub(writer, allocator, collectorStubAddress, collectorStub);
+            ProtectGroundItemStub(writer, allocator, frameStubAddress, frameStub);
+            ProtectGroundItemStub(writer, allocator, keyDownStubAddress, keyDownStub);
+            ProtectGroundItemStub(writer, allocator, keyUpStubAddress, keyUpStub);
+            VerifyRemoteBytes(writer, stateAddress, new byte[GroundItemStateSize]);
+
+            var collectorHook = BuildGroundItemHook(collectorHookAddress, collectorStubAddress,
+                ExpectedGroundItemCollectorHook.Length);
+            var frameHook = BuildGroundItemHook(frameHookAddress, frameStubAddress,
+                ExpectedGroundItemFrameHook.Length);
+            var keyDownHook = BuildGroundItemHook(keyDownHookAddress, keyDownStubAddress,
+                ExpectedGroundItemKeyDownHook.Length);
+            var keyUpHook = BuildGroundItemHook(keyUpHookAddress, keyUpStubAddress,
+                ExpectedGroundItemKeyUpHook.Length);
+
+            stage = "write the ground-item collector hook";
+            WriteGroundItemHook(writer, allocator, collectorHookAddress, collectorHook,
+                ref collectorHookWriteStarted);
+
+            stage = "write the ground-item frame hook";
+            WriteGroundItemHook(writer, allocator, frameHookAddress, frameHook, ref frameHookWriteStarted);
+
+            stage = "write the ground-item key-down hook";
+            WriteGroundItemHook(writer, allocator, keyDownHookAddress, keyDownHook, ref keyDownHookWriteStarted);
+
+            stage = "write the ground-item key-up hook";
+            WriteGroundItemHook(writer, allocator, keyUpHookAddress, keyUpHook, ref keyUpHookWriteStarted);
+
+            stage = "verify the ground-item hooks";
+            VerifyRemoteBytes(writer, collectorHookAddress, collectorHook);
+            VerifyRemoteBytes(writer, frameHookAddress, frameHook);
+            VerifyRemoteBytes(writer, keyDownHookAddress, keyDownHook);
+            VerifyRemoteBytes(writer, keyUpHookAddress, keyUpHook);
+        }
+        catch (Exception exception)
+        {
+            var cleanupExceptions = new List<Exception>();
+            var collectorHookRestored = !collectorHookWriteStarted;
+            var frameHookRestored = !frameHookWriteStarted;
+            var keyDownHookRestored = !keyDownHookWriteStarted;
+            var keyUpHookRestored = !keyUpHookWriteStarted;
+
+            TryRestoreGroundItemHook(writer, allocator, Add(moduleBaseAddress, GroundItemKeyUpHookRva),
+                ExpectedGroundItemKeyUpHook, keyUpHookWriteStarted, cleanupExceptions, ref keyUpHookRestored);
+            TryRestoreGroundItemHook(writer, allocator, Add(moduleBaseAddress, GroundItemKeyDownHookRva),
+                ExpectedGroundItemKeyDownHook, keyDownHookWriteStarted, cleanupExceptions, ref keyDownHookRestored);
+            TryRestoreGroundItemHook(writer, allocator, Add(moduleBaseAddress, GroundItemFrameHookRva),
+                ExpectedGroundItemFrameHook, frameHookWriteStarted, cleanupExceptions, ref frameHookRestored);
+            TryRestoreGroundItemHook(writer, allocator, Add(moduleBaseAddress, GroundItemCollectorHookRva),
+                ExpectedGroundItemCollectorHook, collectorHookWriteStarted, cleanupExceptions,
+                ref collectorHookRestored);
+
+            TryFreeGroundItemAllocation(allocator, keyUpStubAddress, keyUpHookRestored, cleanupExceptions);
+            TryFreeGroundItemAllocation(allocator, keyDownStubAddress, keyDownHookRestored, cleanupExceptions);
+            TryFreeGroundItemAllocation(allocator, frameStubAddress, frameHookRestored, cleanupExceptions);
+            TryFreeGroundItemAllocation(allocator, collectorStubAddress, collectorHookRestored, cleanupExceptions);
+            TryFreeGroundItemAllocation(allocator, stateAddress,
+                collectorHookRestored && frameHookRestored && keyDownHookRestored && keyUpHookRestored,
+                cleanupExceptions);
+
+            var innerException = cleanupExceptions.Count == 0
+                ? exception
+                : new AggregateException([exception, .. cleanupExceptions]);
+            throw new InvalidOperationException($"Failed to {stage}: {exception.Message}", innerException);
+        }
+    }
+
+    private static byte[] BuildGroundItemCollectorStub(IntPtr moduleBaseAddress, IntPtr stubAddress,
+        IntPtr stateAddress)
+    {
+        var stub = GroundItemCollectorStubTemplate.ToArray();
+
+        WriteUInt32(stub, 0x3A, checked((uint)Add(moduleBaseAddress, WorldItemVtableRva).ToInt64()));
+        WriteUInt32(stub, 0x4A, checked((uint)stateAddress.ToInt64()));
+        WriteInt32(stub, 0x4F, GroundItemCapacity);
+        WriteUInt32(stub, 0x5A, checked((uint)Add(stateAddress, GroundItemStateEntryOffset).ToInt64()));
+        WriteUInt32(stub, 0x70, checked((uint)stateAddress.ToInt64()));
+        WriteUInt32(stub, 0x76, checked((uint)Add(stateAddress, 0x04).ToInt64()));
+        WriteUInt32(stub, 0x7E, checked((uint)Add(stateAddress, 0x08).ToInt64()));
+        WriteInt32(stub, 0x99, GetRelativeOffset(Add(stubAddress, 0x99), sizeof(int),
+            Add(moduleBaseAddress, GroundItemCollectorHookRva + ExpectedGroundItemCollectorHook.Length)));
+
+        return stub;
+    }
+
+    private static byte[] BuildGroundItemFrameStub(IntPtr moduleBaseAddress, IntPtr stubAddress,
+        IntPtr stateAddress)
+    {
+        var stub = GroundItemFrameStubTemplate.ToArray();
+
+        WriteUInt32(stub, 0x0D, checked((uint)Add(stateAddress, GroundItemStatePaneOffset).ToInt64()));
+        WriteUInt32(stub, 0x13, checked((uint)stateAddress.ToInt64()));
+        WriteInt32(stub, 0x26, GetRelativeOffset(Add(stubAddress, 0x26), sizeof(int),
+            Add(moduleBaseAddress, InputGetEventManagerRva)));
+        WriteUInt32(stub, 0x3B, checked((uint)stateAddress.ToInt64()));
+        WriteUInt32(stub, 0x46, checked((uint)Add(stateAddress, GroundItemStateEntryOffset).ToInt64()));
+        WriteUInt32(stub, 0x52, checked((uint)Add(moduleBaseAddress, WorldItemVtableRva).ToInt64()));
+        WriteUInt32(stub, 0x79, checked((uint)Add(stateAddress, 0x04).ToInt64()));
+        WriteUInt32(stub, 0x8D, checked((uint)Add(stateAddress, 0x08).ToInt64()));
+        WriteInt32(stub, 0x92, GetRelativeOffset(Add(stubAddress, 0x92), sizeof(int),
+            Add(moduleBaseAddress, RenderWorldObjectRva)));
+        WriteInt32(stub, 0xB6, GetRelativeOffset(Add(stubAddress, 0xB6), sizeof(int),
+            Add(moduleBaseAddress, GroundItemFrameHookRva + ExpectedGroundItemFrameHook.Length)));
+
+        return stub;
+    }
+
+    private static byte[] BuildGroundItemKeyTransitionStub(IntPtr moduleBaseAddress, IntPtr stubAddress,
+        IntPtr stateAddress, int hookRva, byte[] template)
+    {
+        var stub = template.ToArray();
+
+        WriteUInt32(stub, 0x31, checked((uint)Add(stateAddress, GroundItemStatePaneOffset).ToInt64()));
+        WriteInt32(stub, 0x3C, GetRelativeOffset(Add(stubAddress, 0x3C), sizeof(int),
+            Add(moduleBaseAddress, UiPaneInvalidateRva)));
+        WriteInt32(stub, 0x50, GetRelativeOffset(Add(stubAddress, 0x50), sizeof(int),
+            Add(moduleBaseAddress, hookRva + ExpectedGroundItemKeyDownHook.Length)));
+
+        return stub;
+    }
+
+    private static byte[] BuildGroundItemHook(IntPtr hookAddress, IntPtr stubAddress, int hookLength)
+    {
+        var hook = Enumerable.Repeat((byte)0x90, hookLength).ToArray();
+        hook[0] = 0xE9;
+        WriteInt32(hook, 1, GetRelativeOffset(hookAddress, 5, stubAddress));
+        return hook;
+    }
+
+    private static void WriteGroundItemStub(BinaryWriter writer, IntPtr address, byte[] stub)
+    {
+        writer.BaseStream.Position = address.ToInt64();
+        writer.Write(stub);
+    }
+
+    private static void ProtectGroundItemStub(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr address, byte[] stub)
+    {
+        allocator.MakeExecutable(address, stub.Length);
+        VerifyRemoteBytes(writer, address, stub);
+        allocator.FlushInstructionCache(address, stub.Length);
+    }
+
+    private static void WriteGroundItemHook(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr address, byte[] hook, ref bool writeStarted)
+    {
+        using (allocator.MakeWritable(address, hook.Length))
+        {
+            writeStarted = true;
+            writer.BaseStream.Position = address.ToInt64();
+            writer.Write(hook);
+            allocator.FlushInstructionCache(address, hook.Length);
+        }
+    }
+
+    private static void VerifyExpectedBytes(BinaryWriter writer, IntPtr address, byte[] expected)
+    {
+        var actual = ReadRemoteBytes(writer, address, expected.Length);
+        if (!actual.SequenceEqual(expected))
+        {
+            throw new InvalidDataException($"Unexpected client bytes at 0x{address.ToInt64():X}: " +
+                                           $"expected {Convert.ToHexString(expected)}, " +
+                                           $"found {Convert.ToHexString(actual)}.");
+        }
+    }
+
+    private static void TryRestoreGroundItemHook(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr hookAddress, byte[] expected, bool writeStarted, List<Exception> cleanupExceptions,
+        ref bool restored)
+    {
+        if (!writeStarted)
+        {
+            return;
+        }
+
+        try
+        {
+            using (allocator.MakeWritable(hookAddress, expected.Length))
+            {
+                writer.BaseStream.Position = hookAddress.ToInt64();
+                writer.Write(expected);
+                allocator.FlushInstructionCache(hookAddress, expected.Length);
+            }
+
+            VerifyRemoteBytes(writer, hookAddress, expected);
+            restored = true;
+        }
+        catch (Exception exception)
+        {
+            cleanupExceptions.Add(exception);
+        }
+    }
+
+    private static void TryFreeGroundItemAllocation(ProcessMemoryAllocator allocator, IntPtr address,
+        bool safeToFree, List<Exception> cleanupExceptions)
+    {
+        if (address == IntPtr.Zero || !safeToFree)
+        {
+            return;
+        }
+
+        try
+        {
+            allocator.FreeMemory(address);
+        }
+        catch (Exception exception)
+        {
+            cleanupExceptions.Add(exception);
+        }
+    }
+}

--- a/Arbiter.App/Services/Client/GameClientService.cs
+++ b/Arbiter.App/Services/Client/GameClientService.cs
@@ -41,7 +41,7 @@ public partial class GameClientService : IGameClientService
             throw new ArgumentOutOfRangeException(nameof(options), "Port must be between 1 and 65535");
         }
 
-        if (options.ApplyModifiersKeyFix)
+        if (options.ApplyModifiersKeyFix || options.SkipQuantityPromptInExchange)
         {
             VerifySupportedClient(clientExecutablePath);
         }
@@ -70,10 +70,18 @@ public partial class GameClientService : IGameClientService
 
                 ApplyServerEndpointPatch(writer, hostnamePointer, options.LocalPort);
 
-                if (options.ApplyModifiersKeyFix)
+                if (options.ApplyModifiersKeyFix || options.SkipQuantityPromptInExchange)
                 {
                     var moduleBaseAddress = process.GetImageBaseAddress();
-                    ApplyStuckModifierFix(writer, allocator, moduleBaseAddress);
+                    if (options.ApplyModifiersKeyFix)
+                    {
+                        ApplyStuckModifierFix(writer, allocator, moduleBaseAddress);
+                    }
+
+                    if (options.SkipQuantityPromptInExchange)
+                    {
+                        ApplySkipExchangeQuantityPromptPatch(writer, allocator, moduleBaseAddress);
+                    }
                 }
             }
 

--- a/Arbiter.App/Services/Client/GameClientService.cs
+++ b/Arbiter.App/Services/Client/GameClientService.cs
@@ -41,7 +41,9 @@ public partial class GameClientService : IGameClientService
             throw new ArgumentOutOfRangeException(nameof(options), "Port must be between 1 and 65535");
         }
 
-        if (options.ApplyModifiersKeyFix || options.SkipQuantityPromptInExchange)
+        var hasRuntimePatches = options.ApplyModifiersKeyFix || options.SkipQuantityPromptInExchange ||
+                                options.ShowItemQuantityInDialogs;
+        if (hasRuntimePatches)
         {
             VerifySupportedClient(clientExecutablePath);
         }
@@ -70,7 +72,7 @@ public partial class GameClientService : IGameClientService
 
                 ApplyServerEndpointPatch(writer, hostnamePointer, options.LocalPort);
 
-                if (options.ApplyModifiersKeyFix || options.SkipQuantityPromptInExchange)
+                if (hasRuntimePatches)
                 {
                     var moduleBaseAddress = process.GetImageBaseAddress();
                     if (options.ApplyModifiersKeyFix)
@@ -81,6 +83,11 @@ public partial class GameClientService : IGameClientService
                     if (options.SkipQuantityPromptInExchange)
                     {
                         ApplySkipExchangeQuantityPromptPatch(writer, allocator, moduleBaseAddress);
+                    }
+
+                    if (options.ShowItemQuantityInDialogs)
+                    {
+                        ApplyShowItemQuantityInDialogsPatch(writer, allocator, moduleBaseAddress);
                     }
                 }
             }

--- a/Arbiter.App/Services/Client/GameClientService.cs
+++ b/Arbiter.App/Services/Client/GameClientService.cs
@@ -41,7 +41,8 @@ public partial class GameClientService : IGameClientService
             throw new ArgumentOutOfRangeException(nameof(options), "Port must be between 1 and 65535");
         }
 
-        var hasRuntimePatches = options.ApplyModifiersKeyFix || options.SkipQuantityPromptInExchange ||
+        var shouldApplyModifierFix = options.ApplyModifiersKeyFix || options.AllowAltToShowGroundItems;
+        var hasRuntimePatches = shouldApplyModifierFix || options.SkipQuantityPromptInExchange ||
                                 options.ShowItemQuantityInDialogs;
         if (hasRuntimePatches)
         {
@@ -75,9 +76,14 @@ public partial class GameClientService : IGameClientService
                 if (hasRuntimePatches)
                 {
                     var moduleBaseAddress = process.GetImageBaseAddress();
-                    if (options.ApplyModifiersKeyFix)
+                    if (shouldApplyModifierFix)
                     {
                         ApplyStuckModifierFix(writer, allocator, moduleBaseAddress);
+                    }
+
+                    if (options.AllowAltToShowGroundItems)
+                    {
+                        ApplyAllowAltToShowGroundItemsPatch(writer, allocator, moduleBaseAddress);
                     }
 
                     if (options.SkipQuantityPromptInExchange)

--- a/Arbiter.App/ViewModels/MainWindowViewModel.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.cs
@@ -93,7 +93,8 @@ public partial class MainWindowViewModel : ViewModelBase
             var clientExecutablePath = Settings.ClientExecutablePath;
             var options = new LaunchClientOptions(Settings.LocalPort, Settings.SkipIntroVideo,
                 Settings.SuppressLoginNotice, Settings.ApplyModifiersKeyFix,
-                Settings.SkipQuantityPromptInExchange, Settings.ShowItemQuantityInDialogs);
+                Settings.AllowAltToShowGroundItems, Settings.SkipQuantityPromptInExchange,
+                Settings.ShowItemQuantityInDialogs);
 
             await _gameClientService.LaunchLoopbackClient(clientExecutablePath, options);
         }

--- a/Arbiter.App/ViewModels/MainWindowViewModel.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.cs
@@ -92,7 +92,8 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             var clientExecutablePath = Settings.ClientExecutablePath;
             var options = new LaunchClientOptions(Settings.LocalPort, Settings.SkipIntroVideo,
-                Settings.SuppressLoginNotice, Settings.ApplyModifiersKeyFix);
+                Settings.SuppressLoginNotice, Settings.ApplyModifiersKeyFix,
+                Settings.SkipQuantityPromptInExchange);
 
             await _gameClientService.LaunchLoopbackClient(clientExecutablePath, options);
         }

--- a/Arbiter.App/ViewModels/MainWindowViewModel.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.cs
@@ -93,7 +93,7 @@ public partial class MainWindowViewModel : ViewModelBase
             var clientExecutablePath = Settings.ClientExecutablePath;
             var options = new LaunchClientOptions(Settings.LocalPort, Settings.SkipIntroVideo,
                 Settings.SuppressLoginNotice, Settings.ApplyModifiersKeyFix,
-                Settings.SkipQuantityPromptInExchange);
+                Settings.SkipQuantityPromptInExchange, Settings.ShowItemQuantityInDialogs);
 
             await _gameClientService.LaunchLoopbackClient(clientExecutablePath, options);
         }

--- a/Arbiter.App/ViewModels/Proxy/ProxyViewModel.DialogFilters.cs
+++ b/Arbiter.App/ViewModels/Proxy/ProxyViewModel.DialogFilters.cs
@@ -1,13 +1,9 @@
 using System;
-using System.Linq;
-using Arbiter.App.Collections;
-using Arbiter.App.Models.Player;
 using Arbiter.App.Models.Settings;
 using Arbiter.Net;
 using Arbiter.Net.Filters;
 using Arbiter.Net.Proxy;
 using Arbiter.Net.Server.Messages;
-using Arbiter.Net.Types;
 
 namespace Arbiter.App.ViewModels.Proxy;
 
@@ -15,7 +11,6 @@ public partial class ProxyViewModel
 {
     private NetworkFilterRef? _debugDialogFilter;
     private NetworkFilterRef? _debugDialogMenuFilter;
-    private NetworkFilterRef? _debugDialogMenuItemQuantityFilter;
 
     private void AddDebugDialogFilters(DebugSettings settings)
     {
@@ -24,17 +19,12 @@ public partial class ProxyViewModel
 
         _debugDialogMenuFilter = _proxyServer.AddFilter<ServerScreenMenuMessage>(HandleDialogMenuMessage,
             $"{FilterPrefix}_Dialog_ServerShowDialogMenu", DebugFilterPriority, settings);
-
-        _debugDialogMenuItemQuantityFilter = _proxyServer.AddFilter<ServerScreenMenuMessage>(
-            HandleDialogItemQuantityMenuMessage,
-            $"{FilterPrefix}_Dialog_ItemQuantity_ServerShowDialogMenu", int.MinValue, settings);
     }
 
     private void RemoveDebugDialogFilters()
     {
         _debugDialogFilter?.Unregister();
         _debugDialogMenuFilter?.Unregister();
-        _debugDialogMenuItemQuantityFilter?.Unregister();
     }
 
     private static NetworkPacket HandleDialogMessage(ProxyConnection connection, ServerPursuitMessage message,
@@ -112,67 +102,4 @@ public partial class ProxyViewModel
         return hasChanges ? result.Replace(message) : result.Passthrough();
     }
 
-    private NetworkPacket HandleDialogItemQuantityMenuMessage(ProxyConnection connection,
-        ServerScreenMenuMessage message, object? parameter,
-        NetworkMessageFilterResult<ServerScreenMenuMessage> result)
-    {
-        if (parameter is not DebugSettings settings || settings is { ShowDialogItemQuantity: false } ||
-            message.MenuType != DialogMenuType.UserInventory)
-        {
-            return result.Passthrough();
-        }
-
-        // If unable to get the player OR no stackable items just passthrough
-        if (!_playerService.TryGetState(connection.Id, out var player) ||
-            !player.Inventory.Any(i => i.Value.IsStackable))
-        {
-            return result.Passthrough();
-        }
-
-        SendItemQuantityOverrides(connection, player.Inventory);
-        return result.Passthrough();
-    }
-
-    private static void SendItemQuantityOverrides(ProxyConnection connection,
-        ISlottedCollection<InventoryItem> inventory)
-    {
-        // First we update the client with the stack size in the name
-        var addItemMessages = inventory.Where(i => i.Value.IsStackable)
-            .Select(item =>
-            {
-                var baseName = InventoryItem.GetBaseName(item.Value.Name);
-                return new ServerAddInventoryMessage
-                {
-                    Slot = (byte)item.Slot,
-                    Name = $"{baseName} [{item.Value.Quantity}]",
-                    Sprite = item.Value!.Sprite,
-                    Color = (DyeColor)item.Value.Color,
-                    Quantity = (uint)item.Value.Quantity,
-                    IsStackable = item.Value.IsStackable,
-                    Durability = (uint)(item.Value.Durability ?? 0),
-                    MaxDurability = (uint)(item.Value.MaxDurability ?? 0)
-                };
-            });
-        connection.EnqueueMessages(addItemMessages, NetworkPriority.High);
-
-        // Then we revert it after a short delay which will happen after the dialog is shown
-        // This happens very quickly so its not noticeable to the user
-        var revertItemMessages = inventory.Where(i => i.Value.IsStackable)
-            .Select(item =>
-            {
-                var baseName = InventoryItem.GetBaseName(item.Value.Name);
-                return new ServerAddInventoryMessage
-                {
-                    Slot = (byte)item.Slot,
-                    Name = baseName,
-                    Sprite = item.Value!.Sprite,
-                    Color = (DyeColor)item.Value.Color,
-                    Quantity = (uint)item.Value.Quantity,
-                    IsStackable = item.Value.IsStackable,
-                    Durability = (uint)(item.Value.Durability ?? 0),
-                    MaxDurability = (uint)(item.Value.MaxDurability ?? 0)
-                };
-            });
-        connection.EnqueueMessagesAfter(revertItemMessages, TimeSpan.FromMilliseconds(100), NetworkPriority.High);
-    }
 }

--- a/Arbiter.App/ViewModels/Proxy/ProxyViewModel.ModMenuFilters.cs
+++ b/Arbiter.App/ViewModels/Proxy/ProxyViewModel.ModMenuFilters.cs
@@ -108,8 +108,6 @@ public partial class ProxyViewModel
             var inventory = player?.Inventory ?? new SlottedCollection<InventoryItem>(1);
             
             var destroyItemMenu = GetDestroyItemDialogForEntity(entity, inventory);
-            
-            SendItemQuantityOverrides(connection, inventory);
             connection.EnqueueMessage(destroyItemMenu);
             return result.Block();
         }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -44,7 +44,6 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     [NotifyPropertyChangedFor(nameof(TraceMaxHistory))]
     [NotifyPropertyChangedFor(nameof(DebugShowDialogId))]
     [NotifyPropertyChangedFor(nameof(DebugShowPursuitId))]
-    [NotifyPropertyChangedFor(nameof(DebugShowDialogItemQuantity))]
     [NotifyPropertyChangedFor(nameof(DebugShowEquipmentDurability))]
     [NotifyPropertyChangedFor(nameof(DebugShowNpcId))]
     [NotifyPropertyChangedFor(nameof(DebugShowMonsterId))]
@@ -236,17 +235,6 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         set
         {
             Settings.Debug.ShowPursuitId = value;
-            OnPropertyChanged();
-            HasChanges = true;
-        }
-    }
-
-    public bool DebugShowDialogItemQuantity
-    {
-        get => Settings.Debug.ShowDialogItemQuantity;
-        set
-        {
-            Settings.Debug.ShowDialogItemQuantity = value;
             OnPropertyChanged();
             HasChanges = true;
         }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -35,6 +35,7 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     [NotifyPropertyChangedFor(nameof(SuppressLoginNotice))]
     [NotifyPropertyChangedFor(nameof(ApplyModifiersKeyFix))]
     [NotifyPropertyChangedFor(nameof(SkipQuantityPromptInExchange))]
+    [NotifyPropertyChangedFor(nameof(ShowItemQuantityInDialogs))]
     [NotifyPropertyChangedFor(nameof(LocalPort))]
     [NotifyPropertyChangedFor(nameof(RemoteServerAddress))]
     [NotifyPropertyChangedFor(nameof(RemoteServerPort))]
@@ -131,6 +132,17 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         set
         {
             Settings.SkipQuantityPromptInExchange = value;
+            OnPropertyChanged();
+            HasChanges = true;
+        }
+    }
+
+    public bool ShowItemQuantityInDialogs
+    {
+        get => Settings.ShowItemQuantityInDialogs;
+        set
+        {
+            Settings.ShowItemQuantityInDialogs = value;
             OnPropertyChanged();
             HasChanges = true;
         }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -34,6 +34,7 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     [NotifyPropertyChangedFor(nameof(SkipIntroVideo))]
     [NotifyPropertyChangedFor(nameof(SuppressLoginNotice))]
     [NotifyPropertyChangedFor(nameof(ApplyModifiersKeyFix))]
+    [NotifyPropertyChangedFor(nameof(SkipQuantityPromptInExchange))]
     [NotifyPropertyChangedFor(nameof(LocalPort))]
     [NotifyPropertyChangedFor(nameof(RemoteServerAddress))]
     [NotifyPropertyChangedFor(nameof(RemoteServerPort))]
@@ -119,6 +120,17 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         set
         {
             Settings.ApplyModifiersKeyFix = value;
+            OnPropertyChanged();
+            HasChanges = true;
+        }
+    }
+
+    public bool SkipQuantityPromptInExchange
+    {
+        get => Settings.SkipQuantityPromptInExchange;
+        set
+        {
+            Settings.SkipQuantityPromptInExchange = value;
             OnPropertyChanged();
             HasChanges = true;
         }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -34,6 +34,7 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     [NotifyPropertyChangedFor(nameof(SkipIntroVideo))]
     [NotifyPropertyChangedFor(nameof(SuppressLoginNotice))]
     [NotifyPropertyChangedFor(nameof(ApplyModifiersKeyFix))]
+    [NotifyPropertyChangedFor(nameof(AllowAltToShowGroundItems))]
     [NotifyPropertyChangedFor(nameof(SkipQuantityPromptInExchange))]
     [NotifyPropertyChangedFor(nameof(ShowItemQuantityInDialogs))]
     [NotifyPropertyChangedFor(nameof(LocalPort))]
@@ -120,6 +121,17 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         set
         {
             Settings.ApplyModifiersKeyFix = value;
+            OnPropertyChanged();
+            HasChanges = true;
+        }
+    }
+
+    public bool AllowAltToShowGroundItems
+    {
+        get => Settings.AllowAltToShowGroundItems;
+        set
+        {
+            Settings.AllowAltToShowGroundItems = value;
             OnPropertyChanged();
             HasChanges = true;
         }

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -62,7 +62,7 @@
                     </TextBox>
                     
                     <!-- Options -->
-                    <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
+                    <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
                         <!-- Skip Intro Video  -->
                         <Label Grid.Row="0" Grid.Column="0"
                                Content="Skip Intro Video"
@@ -81,6 +81,12 @@
                                ToolTip.Tip="Clears held keys and modifiers when the client loses focus."/>
                         <ToggleSwitch Grid.Row="2" Grid.Column="1"
                                       IsChecked="{Binding ApplyModifiersKeyFix}"/>
+                        <!-- Skip Quantity Prompt in Exchange -->
+                        <Label Grid.Row="3" Grid.Column="0"
+                               Content="Skip Quantity Prompt in Exchange"
+                               ToolTip.Tip="Skips asking quantity for single item stacks in exchange window."/>
+                        <ToggleSwitch Grid.Row="3" Grid.Column="1"
+                                      IsChecked="{Binding SkipQuantityPromptInExchange}"/>
                     </Grid>
                 </StackPanel>
             </TabItem>

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -84,7 +84,7 @@
                         <!-- Allow Alt to Show Ground Items -->
                         <Label Grid.Row="3" Grid.Column="0"
                                Content="Allow Alt to Show Ground Items"
-                               ToolTip.Tip="Hold either Alt key to draw translucent hints for ground items hidden behind static map art. Enabling this also applies the modifier-key cleanup needed when focus changes."/>
+                               ToolTip.Tip="Hold either Alt key to reveal ground items through static map art. Also enables modifier cleanup on focus loss."/>
                         <ToggleSwitch Grid.Row="3" Grid.Column="1"
                                       IsChecked="{Binding AllowAltToShowGroundItems}"/>
                         <!-- Skip Quantity Prompt in Exchange -->

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -346,7 +346,7 @@
             <!-- Dialogs Settings Tab -->
             <TabItem Header="Dialogs">
                 <StackPanel Spacing="4" Margin="4">
-                    <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto" Margin="4">
+                    <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto" Margin="4">
                         <!-- Show Entity ID for Dialogs -->
                         <Label Grid.Row="0" Grid.Column="0"
                                Content="Show Entity ID in Dialogs"
@@ -360,13 +360,6 @@
                                ToolTip.Tip="Shows the pursuit ID within dialog menus (in-game)."/>
                         <ToggleSwitch Grid.Row="1" Grid.Column="1"
                                       IsChecked="{Binding DebugShowPursuitId}"/>
-                        
-                        <!-- Show Item Quantity for Dialogs -->
-                        <Label Grid.Row="2" Grid.Column="0"
-                               Content="Show Item Quantity in Sell / Deposit"
-                               ToolTip.Tip="Shows the item quantity along with item name in sell or deposit menus (in-game)."/>
-                        <ToggleSwitch Grid.Row="2" Grid.Column="1"
-                                      IsChecked="{Binding DebugShowDialogItemQuantity}"/>
                     </Grid>
                 </StackPanel>
             </TabItem>

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -62,7 +62,7 @@
                     </TextBox>
                     
                     <!-- Options -->
-                    <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
+                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
                         <!-- Skip Intro Video  -->
                         <Label Grid.Row="0" Grid.Column="0"
                                Content="Skip Intro Video"
@@ -87,6 +87,12 @@
                                ToolTip.Tip="Skips asking quantity for single item stacks in exchange window."/>
                         <ToggleSwitch Grid.Row="3" Grid.Column="1"
                                       IsChecked="{Binding SkipQuantityPromptInExchange}"/>
+                        <!-- Show Item Quantity in Dialogs -->
+                        <Label Grid.Row="4" Grid.Column="0"
+                               Content="Show Item Quantity in Dialogs"
+                               ToolTip.Tip="Adds the current quantity in parentheses to stackable item names in inventory-based merchant and storage dialogs."/>
+                        <ToggleSwitch Grid.Row="4" Grid.Column="1"
+                                      IsChecked="{Binding ShowItemQuantityInDialogs}"/>
                     </Grid>
                 </StackPanel>
             </TabItem>

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -62,7 +62,7 @@
                     </TextBox>
                     
                     <!-- Options -->
-                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
+                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="4">
                         <!-- Skip Intro Video  -->
                         <Label Grid.Row="0" Grid.Column="0"
                                Content="Skip Intro Video"
@@ -81,17 +81,23 @@
                                ToolTip.Tip="Clears held keys and modifiers when the client loses focus."/>
                         <ToggleSwitch Grid.Row="2" Grid.Column="1"
                                       IsChecked="{Binding ApplyModifiersKeyFix}"/>
-                        <!-- Skip Quantity Prompt in Exchange -->
+                        <!-- Allow Alt to Show Ground Items -->
                         <Label Grid.Row="3" Grid.Column="0"
+                               Content="Allow Alt to Show Ground Items"
+                               ToolTip.Tip="Hold either Alt key to draw translucent hints for ground items hidden behind static map art. Enabling this also applies the modifier-key cleanup needed when focus changes."/>
+                        <ToggleSwitch Grid.Row="3" Grid.Column="1"
+                                      IsChecked="{Binding AllowAltToShowGroundItems}"/>
+                        <!-- Skip Quantity Prompt in Exchange -->
+                        <Label Grid.Row="4" Grid.Column="0"
                                Content="Skip Quantity Prompt in Exchange"
                                ToolTip.Tip="Skips asking quantity for single item stacks in exchange window."/>
-                        <ToggleSwitch Grid.Row="3" Grid.Column="1"
+                        <ToggleSwitch Grid.Row="4" Grid.Column="1"
                                       IsChecked="{Binding SkipQuantityPromptInExchange}"/>
                         <!-- Show Item Quantity in Dialogs -->
-                        <Label Grid.Row="4" Grid.Column="0"
+                        <Label Grid.Row="5" Grid.Column="0"
                                Content="Show Item Quantity in Dialogs"
                                ToolTip.Tip="Adds the current quantity in parentheses to stackable item names in inventory-based merchant and storage dialogs."/>
-                        <ToggleSwitch Grid.Row="4" Grid.Column="1"
+                        <ToggleSwitch Grid.Row="5" Grid.Column="1"
                                       IsChecked="{Binding ShowItemQuantityInDialogs}"/>
                     </Grid>
                 </StackPanel>

--- a/Arbiter.Net.Tests/Proxy/ProxyServerTests.cs
+++ b/Arbiter.Net.Tests/Proxy/ProxyServerTests.cs
@@ -1,0 +1,29 @@
+using System.Net.Sockets;
+using System.Reflection;
+using Arbiter.Net.Proxy;
+
+namespace Arbiter.Net.Tests.Proxy;
+
+public class ProxyServerTests
+{
+    [Test]
+    public void Should_Return_A_Stable_Connection_Snapshot()
+    {
+        using var server = new ProxyServer();
+        using var client = new TcpClient();
+        using var connection = new ProxyConnection(1, client);
+
+        var connectionsField = typeof(ProxyServer).GetField("_connections",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var connections = connectionsField?.GetValue(server) as List<ProxyConnection>;
+
+        Assert.That(connections, Is.Not.Null);
+        connections!.Add(connection);
+
+        var snapshot = server.Connections;
+        connections.Clear();
+
+        Assert.That(snapshot, Is.EqualTo(new[] { connection }));
+        Assert.That(server.Connections, Is.Empty);
+    }
+}

--- a/Arbiter.Net/Proxy/ProxyServer.cs
+++ b/Arbiter.Net/Proxy/ProxyServer.cs
@@ -38,7 +38,14 @@ public partial class ProxyServer : IDisposable
     public event EventHandler<ProxyConnectionExceptionEventArgs>? PacketException;
     public event EventHandler<ProxyConnectionFilterEventArgs>? FilterException;
 
-    public IEnumerable<ProxyConnection> Connections => _connections;
+    public IEnumerable<ProxyConnection> Connections
+    {
+        get
+        {
+            using var _ = _connectionsLock.EnterScope();
+            return _connections.ToArray();
+        }
+    }
 
     public void Start(int listenPort, IPAddress remoteAddress, int remotePort) =>
         Start(listenPort, new IPEndPoint(remoteAddress, remotePort));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an enabled-by-default game client option that skips the exchange quantity prompt only for stackable items with a quantity of one
+
 ## [1.9.5] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add an enabled-by-default game client option that skips the exchange quantity prompt only for stackable items with a quantity of one
 - Add an enabled-by-default client patch that displays stack quantities greater than one in inventory-based merchant and storage dialogs, truncating long names with two dots to keep the quantity visible
+- Add an enabled-by-default client patch that replays up to 255 ground items as translucent hints after the completed world draw while either Alt key is held
 
 ### Removed
 
 - Remove the proxy-side inventory name overrides superseded by the client dialog quantity patch
+
+### Fixed
+
+- Prevent tracing client cleanup from enumerating the proxy connection list while it is being modified
 
 ## [1.9.5] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add an enabled-by-default game client option that skips the exchange quantity prompt only for stackable items with a quantity of one
-- Add an enabled-by-default client patch that displays stack quantities in inventory-based merchant and storage dialogs
+- Add an enabled-by-default client patch that displays stack quantities greater than one in inventory-based merchant and storage dialogs, truncating long names with two dots to keep the quantity visible
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.6] - 2026-07-18
+
 ### Added
 
 - Add an enabled-by-default game client option that skips the exchange quantity prompt only for stackable items with a quantity of one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an enabled-by-default game client option that skips the exchange quantity prompt only for stackable items with a quantity of one
 - Add an enabled-by-default client patch that displays stack quantities in inventory-based merchant and storage dialogs
 
+### Removed
+
+- Remove the proxy-side inventory name overrides superseded by the client dialog quantity patch
+
 ## [1.9.5] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add an enabled-by-default game client option that skips the exchange quantity prompt only for stackable items with a quantity of one
+- Add an enabled-by-default client patch that displays stack quantities in inventory-based merchant and storage dialogs
 
 ## [1.9.5] - 2026-07-17
 


### PR DESCRIPTION
## Summary

Prepare Arbiter 1.9.6 with three enabled-by-default Dark Ages client quality-of-life patches:

- Skip the exchange quantity prompt only when the selected stack contains one item.
- Show quantities greater than one in inventory-based merchant and storage dialogs, with bounded two-dot truncation for long item names.
- Reveal up to 255 ground items as translucent hints while either Alt key is held.

This also removes the superseded proxy-side dialog name overrides and updates the app, assembly, file, and changelog versions to 1.9.6.

## Fix

Tracing client cleanup could enumerate the proxy connection list while another thread modified it. `ProxyServer.Connections` now returns a lock-protected snapshot, preventing the disconnect-time `NullReferenceException`.

## Client impact

The runtime patches are applied only to the verified Dark Ages 7.41 executable while it is suspended. Hook fingerprints and stubs are verified, instruction caches are flushed, and installation fails closed on mismatches. Enabling the Alt option also enables the existing stuck-modifier cleanup.

## Validation

- Release build: succeeded with 0 warnings and 0 errors
- Tests: 182 passed
- Release `win-x64` single-file publish: succeeded
- Required packaged files: verified
- Runtime validation: confirmed on a fresh Dark Ages client, including the 255-item capture bound and all four Alt hooks
