### PR TITLE
Release 1.9.8 with improved auto-follow

### DIFF
--- a/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
+++ b/Arbiter.App.Tests/Models/Settings/ArbiterSettingsTests.cs
@@ -19,6 +19,7 @@ public sealed class ArbiterSettingsTests
             Assert.That(settings?.ShowItemQuantityInDialogs, Is.True);
             Assert.That(settings?.MakeExchangeDialogDraggable, Is.True);
             Assert.That(settings?.ShowExchangeResultsInMessageBar, Is.True);
+            Assert.That(settings?.ImprovedAutoFollow, Is.True);
         });
     }
 
@@ -88,5 +89,15 @@ public sealed class ArbiterSettingsTests
             Assert.That(clone.MakeExchangeDialogDraggable, Is.False);
             Assert.That(clone.ShowExchangeResultsInMessageBar, Is.False);
         });
+    }
+
+    [Test]
+    public void Should_Preserve_Improved_Auto_Follow_Preference_When_Cloned()
+    {
+        var settings = new ArbiterSettings { ImprovedAutoFollow = false };
+
+        var clone = (ArbiterSettings)settings.Clone();
+
+        Assert.That(clone.ImprovedAutoFollow, Is.False);
     }
 }

--- a/Arbiter.App.Tests/Services/Client/GameClientServiceAutoFollowTests.cs
+++ b/Arbiter.App.Tests/Services/Client/GameClientServiceAutoFollowTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Reflection;
+using Arbiter.App.Services.Client;
+
+namespace Arbiter.App.Tests.Services.Client;
+
+[TestFixture]
+public sealed class GameClientServiceAutoFollowTests
+{
+    private static readonly MethodInfo BuildImprovedAutoFollowState = GetMethod("BuildImprovedAutoFollowState");
+    private static readonly MethodInfo BuildImprovedAutoFollowStub = GetMethod("BuildImprovedAutoFollowStub");
+    private static readonly MethodInfo BuildImprovedAutoFollowHook = GetMethod("BuildImprovedAutoFollowHook");
+
+    [Test]
+    public void Should_Build_Improved_Auto_Follow_State_With_Three_Tile_Non_Attacking_Defaults()
+    {
+        var state = (byte[])BuildImprovedAutoFollowState.Invoke(null, null)!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(state, Has.Length.EqualTo(0x18));
+            Assert.That(BitConverter.ToInt32(state, 0x0C), Is.EqualTo(3));
+            Assert.That(BitConverter.ToInt32(state, 0x10), Is.EqualTo(3));
+            Assert.That(state[0x14], Is.Zero);
+            Assert.That(state[0x15], Is.Zero);
+            Assert.That(state[0x16], Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Should_Build_Improved_Auto_Follow_Stub_With_Resolved_State_Addresses()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x10000000;
+        var stateAddress = (IntPtr)0x00B70000;
+
+        var stub = (byte[])BuildImprovedAutoFollowStub.Invoke(null,
+            [moduleBaseAddress, stubAddress, stateAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub, Has.Length.EqualTo(0x1D5));
+            Assert.That(stub[0x000..0x009],
+                Is.EqualTo(new byte[] { 0x8B, 0x45, 0x0C, 0xF6, 0x40, 0x2C, 0x04, 0x74, 0x2F }));
+
+            AssertAbsoluteAddresses(stub, 0x00B70000, 0x00B, 0x04F, 0x080, 0x0B6, 0x126);
+            AssertAbsoluteAddresses(stub, 0x00B70004, 0x014, 0x08B, 0x0D7, 0x12E);
+            AssertAbsoluteAddresses(stub, 0x00B70008, 0x05D, 0x09B, 0x0C4, 0x0CC);
+            AssertAbsoluteAddresses(stub, 0x00B7000C, 0x01E, 0x0EE, 0x14E);
+            AssertAbsoluteAddresses(stub, 0x00B70010, 0x019);
+            AssertAbsoluteAddresses(stub, 0x00B70014, 0x02E, 0x03A, 0x046, 0x074, 0x0AA, 0x161, 0x179);
+            AssertAbsoluteAddresses(stub, 0x00B70015, 0x028, 0x065, 0x15B);
+            AssertAbsoluteAddresses(stub, 0x00B70016, 0x023);
+        });
+    }
+
+    [Test]
+    public void Should_Build_Improved_Auto_Follow_Stub_With_Resolved_Client_Targets()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x10000000;
+        var stateAddress = (IntPtr)0x00B70000;
+
+        var stub = (byte[])BuildImprovedAutoFollowStub.Invoke(null,
+            [moduleBaseAddress, stubAddress, stateAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            AssertRelativeTargets(stub, stubAddress, 0x005F4A70, 0x034, 0x040, 0x16D);
+            AssertRelativeTargets(stub, stubAddress, 0x005F44B0, 0x06E);
+            AssertRelativeTargets(stub, stubAddress, stubAddress.ToInt64() + 0x190, 0x0A4);
+            AssertRelativeTargets(stub, stubAddress, 0x005F4AAD, 0x192);
+            AssertRelativeTargets(stub, stubAddress, 0x005F4AA8, 0x197);
+            AssertRelativeTargets(stub, stubAddress, 0x005F4900, 0x106, 0x185);
+            AssertRelativeTargets(stub, stubAddress, 0x005F4A5B, 0x10B);
+            AssertRelativeTargets(stub, stubAddress, 0x005F49EF, 0x11A);
+            AssertRelativeTargets(stub, stubAddress, 0x005D48F1, 0x1A1, 0x1C2, 0x1CC);
+            AssertRelativeTargets(stub, stubAddress, 0x005D48E5, 0x1AB, 0x1B8, 0x1D1);
+        });
+    }
+
+    [Test]
+    public void Should_Replay_The_Generation_Branch_Outside_The_Overwritten_Hook()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x10000000;
+        var stateAddress = (IntPtr)0x00B70000;
+
+        var stub = (byte[])BuildImprovedAutoFollowStub.Invoke(null,
+            [moduleBaseAddress, stubAddress, stateAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub[0x09F..0x0A4], Is.EqualTo(new byte[] { 0x83, 0x7D, 0x08, 0x00, 0xE9 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x0A4),
+                Is.EqualTo(stubAddress.ToInt64() + 0x190));
+
+            Assert.That(stub[0x190..0x192], Is.EqualTo(new byte[] { 0x0F, 0x85 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x192), Is.EqualTo(0x005F4AAD));
+            Assert.That(stub[0x196], Is.EqualTo(0xE9));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x197), Is.EqualTo(0x005F4AA8));
+        });
+    }
+
+    [TestCase(0x005EF33A, 0x000, 0xE8, 5)]
+    [TestCase(0x005D48DF, 0x19B, 0xE9, 6)]
+    [TestCase(0x005F49E5, 0x0A8, 0xE9, 10)]
+    [TestCase(0x005F4AA2, 0x072, 0xE9, 6)]
+    [TestCase(0x005F4D0E, 0x044, 0xE8, 5)]
+    public void Should_Build_Improved_Auto_Follow_Hooks(int hookAddressValue, int stubOffset,
+        byte opcode, int hookLength)
+    {
+        var hookAddress = (IntPtr)hookAddressValue;
+        var stubAddress = (IntPtr)0x10000000;
+
+        var hook = (byte[])BuildImprovedAutoFollowHook.Invoke(null,
+            [hookAddress, stubAddress, stubOffset, opcode, hookLength])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hook, Has.Length.EqualTo(hookLength));
+            Assert.That(hook[0], Is.EqualTo(opcode));
+            Assert.That(GetRelativeTarget(hook, hookAddress, 1), Is.EqualTo(stubAddress.ToInt64() + stubOffset));
+            Assert.That(hook[5..], Is.All.EqualTo(0x90));
+        });
+    }
+
+    [Test]
+    public void Should_Allow_Only_Shift_Pursuit_Dispatch_For_Living_Objects()
+    {
+        var moduleBaseAddress = (IntPtr)0x00400000;
+        var stubAddress = (IntPtr)0x10000000;
+        var stateAddress = (IntPtr)0x00B70000;
+
+        var stub = (byte[])BuildImprovedAutoFollowStub.Invoke(null,
+            [moduleBaseAddress, stubAddress, stateAddress])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stub[0x19B..0x19F],
+                Is.EqualTo(new byte[] { 0x83, 0x7D, 0xA0, 0x08 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x1A1), Is.EqualTo(0x005D48F1));
+
+            Assert.That(stub[0x1A5..0x1A9],
+                Is.EqualTo(new byte[] { 0x80, 0x7D, 0xC3, 0x00 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x1AB), Is.EqualTo(0x005D48E5));
+
+            Assert.That(stub[0x1AF..0x1B6],
+                Is.EqualTo(new byte[] { 0x8B, 0x45, 0x0C, 0x80, 0x78, 0x0C, 0x05 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x1B8), Is.EqualTo(0x005D48E5));
+
+            Assert.That(stub[0x1BC..0x1C0],
+                Is.EqualTo(new byte[] { 0x83, 0x7D, 0xA0, 0x01 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x1C2), Is.EqualTo(0x005D48F1));
+            Assert.That(stub[0x1C6..0x1CA],
+                Is.EqualTo(new byte[] { 0x83, 0x7D, 0xA0, 0x02 }));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x1CC), Is.EqualTo(0x005D48F1));
+            Assert.That(stub[0x1D0], Is.EqualTo(0xE9));
+            Assert.That(GetRelativeTarget(stub, stubAddress, 0x1D1), Is.EqualTo(0x005D48E5));
+        });
+    }
+
+    private static void AssertAbsoluteAddresses(byte[] stub, uint expected, params int[] offsets)
+    {
+        foreach (var offset in offsets)
+        {
+            Assert.That(BitConverter.ToUInt32(stub, offset), Is.EqualTo(expected),
+                $"Absolute address at stub + 0x{offset:X3}");
+        }
+    }
+
+    private static void AssertRelativeTargets(byte[] stub, IntPtr stubAddress, long expected, params int[] offsets)
+    {
+        foreach (var offset in offsets)
+        {
+            Assert.That(GetRelativeTarget(stub, stubAddress, offset), Is.EqualTo(expected),
+                $"Relative target at stub + 0x{offset:X3}");
+        }
+    }
+
+    private static long GetRelativeTarget(byte[] code, IntPtr codeAddress, int operandOffset)
+    {
+        var relativeOffset = BitConverter.ToInt32(code, operandOffset);
+        return codeAddress.ToInt64() + operandOffset + sizeof(int) + relativeOffset;
+    }
+
+    private static MethodInfo GetMethod(string name) => typeof(GameClientService).GetMethod(name,
+        BindingFlags.NonPublic | BindingFlags.Static)!;
+}

--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -9,9 +9,9 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <Company>Erik 'SiLo' Rogers</Company>
         <Product>Arbiter</Product>
-        <Version>1.9.7</Version>
-        <AssemblyVersion>1.9.7</AssemblyVersion>
-        <FileVersion>1.9.7</FileVersion>
+        <Version>1.9.8</Version>
+        <AssemblyVersion>1.9.8</AssemblyVersion>
+        <FileVersion>1.9.8</FileVersion>
         <ApplicationIcon>Assets\arbiter.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/Arbiter.App/Models/LaunchClientOptions.cs
+++ b/Arbiter.App/Models/LaunchClientOptions.cs
@@ -3,4 +3,4 @@
 public record LaunchClientOptions(int LocalPort = 2610, bool SkipIntroVideo = true, bool SuppressLoginNotice = true,
     bool ApplyModifiersKeyFix = true, bool AllowAltToShowGroundItems = true, bool SkipQuantityPromptInExchange = true,
     bool ShowItemQuantityInDialogs = true, bool MakeExchangeDialogDraggable = true,
-    bool ShowExchangeResultsInMessageBar = true);
+    bool ShowExchangeResultsInMessageBar = true, bool ImprovedAutoFollow = true);

--- a/Arbiter.App/Models/Settings/ArbiterSettings.cs
+++ b/Arbiter.App/Models/Settings/ArbiterSettings.cs
@@ -19,6 +19,7 @@ public class ArbiterSettings : ICloneable
     public bool ShowItemQuantityInDialogs { get; set; } = true;
     public bool MakeExchangeDialogDraggable { get; set; } = true;
     public bool ShowExchangeResultsInMessageBar { get; set; } = true;
+    public bool ImprovedAutoFollow { get; set; } = true;
 
     public int LocalPort { get; set; } = 2610;
 
@@ -56,6 +57,7 @@ public class ArbiterSettings : ICloneable
         ShowItemQuantityInDialogs = ShowItemQuantityInDialogs,
         MakeExchangeDialogDraggable = MakeExchangeDialogDraggable,
         ShowExchangeResultsInMessageBar = ShowExchangeResultsInMessageBar,
+        ImprovedAutoFollow = ImprovedAutoFollow,
         LocalPort = LocalPort,
         RemoteServerAddress = RemoteServerAddress,
         RemoteServerPort = RemoteServerPort,

--- a/Arbiter.App/Services/Client/GameClientService.AutoFollow.cs
+++ b/Arbiter.App/Services/Client/GameClientService.AutoFollow.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Arbiter.Interop.Process;
+
+namespace Arbiter.App.Services.Client;
+
+public partial class GameClientService
+{
+    private const int AutoFollowStateSize = 0x18;
+    private const int AutoFollowActiveDistanceOffset = 0x0C;
+    private const int AutoFollowShiftDistanceOffset = 0x10;
+    private const int AutoFollowDefaultDistance = 3;
+
+    private const int AutoFollowSelectHookRva = 0x001EF33A;
+    private const int AutoFollowShiftDispatchHookRva = 0x001D48DF;
+    private const int AutoFollowRouteHookRva = 0x001F49E5;
+    private const int AutoFollowGenerationHookRva = 0x001F4AA2;
+    private const int AutoFollowAttackHookRva = 0x001F4D0E;
+
+    private const int AutoFollowSelectStubOffset = 0x000;
+    private const int AutoFollowAttackStubOffset = 0x044;
+    private const int AutoFollowGenerationStubOffset = 0x072;
+    private const int AutoFollowRouteStubOffset = 0x0A8;
+    private const int AutoFollowGenerationReplayStubOffset = 0x190;
+    private const int AutoFollowShiftDispatchStubOffset = 0x19B;
+
+    private const int AutoFollowPursuitRva = 0x001F4A70;
+    private const int AutoFollowSendAttackRva = 0x001F44B0;
+    private const int AutoFollowGenerationNonZeroRva = 0x001F4AAD;
+    private const int AutoFollowGenerationZeroRva = 0x001F4AA8;
+    private const int AutoFollowResetMovementRva = 0x001F4900;
+    private const int AutoFollowRouteEpilogueRva = 0x001F4A5B;
+    private const int AutoFollowRouteContinuationRva = 0x001F49EF;
+    private const int AutoFollowShiftDispatchAllowedRva = 0x001D48F1;
+    private const int AutoFollowShiftDispatchNativeFilterRva = 0x001D48E5;
+
+    private static readonly byte[] ExpectedAutoFollowSelectHook = [0xE8, 0x31, 0x57, 0x00, 0x00];
+    private static readonly byte[] ExpectedAutoFollowShiftDispatchHook = [0x83, 0x7D, 0xA0, 0x08, 0x74, 0x0C];
+    private static readonly byte[] ExpectedAutoFollowRouteHook =
+        [0x8B, 0x45, 0xE0, 0x83, 0xB8, 0xB8, 0x02, 0x00, 0x00, 0x00];
+    private static readonly byte[] ExpectedAutoFollowGenerationHook = [0x83, 0x7D, 0x08, 0x00, 0x75, 0x05];
+    private static readonly byte[] ExpectedAutoFollowAttackHook = [0xE8, 0x9D, 0xF7, 0xFF, 0xFF];
+
+    private static readonly byte[] AutoFollowStubTemplate = Convert.FromHexString(
+        "8B450CF6402C04742F890D000000008B442404A300000000A100000000A300000000A000000000A200000000C6050000000001E900000000C6050000000000E9" +
+        "00000000803D00000000007420390D0000000075188B81C80200003B0500000000750A803D00000000007501C3E900000000803D000000000074248B45B43B05" +
+        "0000000075198B45083B0500000000750E8B45B48B80C8020000A300000000837D0800E900000000803D0000000000745E8B45E03B050000000075538B90C802" +
+        "00003B150000000074198B0D000000004139CA753A8B0D000000003988BC020000752C8B90B802000083C2018B0D0000000083F9017D05B90100000039CA7F0F" +
+        "6A018B4DE0E800000000E9000000008B45E083B8B802000000E9000000005589E58B4D08890D000000008B450CA3000000008B551083FA017D05BA0100000081" +
+        "FAFF0000007E05BAFF0000008915000000008B451485C00F95C0A200000000C6050000000001FF750C8B4D08E80000000089EC5DC21000C60500000000008B4C" +
+        "24046A00E800000000C2040000000000" +
+        "0F8500000000E900000000" +
+        "837DA0080F8400000000807DC3000F84000000008B450C80780C050F8500000000837DA0010F8400000000837DA0020F8400000000E900000000");
+
+    private static void ApplyImprovedAutoFollowPatch(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr moduleBaseAddress)
+    {
+        var stage = "verify the improved auto-follow hooks";
+        var stateAddress = IntPtr.Zero;
+        var stubAddress = IntPtr.Zero;
+        var selectHookWriteStarted = false;
+        var shiftDispatchHookWriteStarted = false;
+        var routeHookWriteStarted = false;
+        var generationHookWriteStarted = false;
+        var attackHookWriteStarted = false;
+
+        try
+        {
+            var selectHookAddress = Add(moduleBaseAddress, AutoFollowSelectHookRva);
+            var shiftDispatchHookAddress = Add(moduleBaseAddress, AutoFollowShiftDispatchHookRva);
+            var routeHookAddress = Add(moduleBaseAddress, AutoFollowRouteHookRva);
+            var generationHookAddress = Add(moduleBaseAddress, AutoFollowGenerationHookRva);
+            var attackHookAddress = Add(moduleBaseAddress, AutoFollowAttackHookRva);
+
+            VerifyExpectedBytes(writer, selectHookAddress, ExpectedAutoFollowSelectHook);
+            VerifyExpectedBytes(writer, shiftDispatchHookAddress, ExpectedAutoFollowShiftDispatchHook);
+            VerifyExpectedBytes(writer, routeHookAddress, ExpectedAutoFollowRouteHook);
+            VerifyExpectedBytes(writer, generationHookAddress, ExpectedAutoFollowGenerationHook);
+            VerifyExpectedBytes(writer, attackHookAddress, ExpectedAutoFollowAttackHook);
+
+            stage = "allocate the improved auto-follow state and stub";
+            var expectedState = BuildImprovedAutoFollowState();
+            stateAddress = allocator.AllocMemory(stateWriter => stateWriter.Write(expectedState),
+                expectedState.Length);
+            stubAddress = allocator.AllocMemory(_ => { }, AutoFollowStubTemplate.Length);
+
+            var stub = BuildImprovedAutoFollowStub(moduleBaseAddress, stubAddress, stateAddress);
+
+            stage = "write the improved auto-follow stub";
+            writer.BaseStream.Position = stubAddress.ToInt64();
+            writer.Write(stub);
+
+            stage = "protect and verify the improved auto-follow state and stub";
+            allocator.MakeExecutable(stubAddress, stub.Length);
+            VerifyRemoteBytes(writer, stateAddress, expectedState);
+            VerifyRemoteBytes(writer, stubAddress, stub);
+            allocator.FlushInstructionCache(stubAddress, stub.Length);
+
+            var selectHook = BuildImprovedAutoFollowHook(selectHookAddress, stubAddress,
+                AutoFollowSelectStubOffset, 0xE8, ExpectedAutoFollowSelectHook.Length);
+            var shiftDispatchHook = BuildImprovedAutoFollowHook(shiftDispatchHookAddress, stubAddress,
+                AutoFollowShiftDispatchStubOffset, 0xE9, ExpectedAutoFollowShiftDispatchHook.Length);
+            var routeHook = BuildImprovedAutoFollowHook(routeHookAddress, stubAddress,
+                AutoFollowRouteStubOffset, 0xE9, ExpectedAutoFollowRouteHook.Length);
+            var generationHook = BuildImprovedAutoFollowHook(generationHookAddress, stubAddress,
+                AutoFollowGenerationStubOffset, 0xE9, ExpectedAutoFollowGenerationHook.Length);
+            var attackHook = BuildImprovedAutoFollowHook(attackHookAddress, stubAddress,
+                AutoFollowAttackStubOffset, 0xE8, ExpectedAutoFollowAttackHook.Length);
+
+            stage = "write the improved auto-follow selection hook";
+            WriteImprovedAutoFollowHook(writer, allocator, selectHookAddress, selectHook,
+                ref selectHookWriteStarted);
+
+            stage = "write the improved auto-follow route hook";
+            WriteImprovedAutoFollowHook(writer, allocator, routeHookAddress, routeHook,
+                ref routeHookWriteStarted);
+
+            stage = "write the improved auto-follow generation hook";
+            WriteImprovedAutoFollowHook(writer, allocator, generationHookAddress, generationHook,
+                ref generationHookWriteStarted);
+
+            stage = "write the improved auto-follow attack hook";
+            WriteImprovedAutoFollowHook(writer, allocator, attackHookAddress, attackHook,
+                ref attackHookWriteStarted);
+
+            stage = "write the improved auto-follow Shift dispatch hook";
+            WriteImprovedAutoFollowHook(writer, allocator, shiftDispatchHookAddress, shiftDispatchHook,
+                ref shiftDispatchHookWriteStarted);
+
+            stage = "verify the improved auto-follow hooks";
+            VerifyRemoteBytes(writer, selectHookAddress, selectHook);
+            VerifyRemoteBytes(writer, shiftDispatchHookAddress, shiftDispatchHook);
+            VerifyRemoteBytes(writer, routeHookAddress, routeHook);
+            VerifyRemoteBytes(writer, generationHookAddress, generationHook);
+            VerifyRemoteBytes(writer, attackHookAddress, attackHook);
+        }
+        catch (Exception exception)
+        {
+            var cleanupExceptions = new List<Exception>();
+            var selectHookRestored = !selectHookWriteStarted;
+            var shiftDispatchHookRestored = !shiftDispatchHookWriteStarted;
+            var routeHookRestored = !routeHookWriteStarted;
+            var generationHookRestored = !generationHookWriteStarted;
+            var attackHookRestored = !attackHookWriteStarted;
+
+            TryRestoreImprovedAutoFollowHook(writer, allocator,
+                Add(moduleBaseAddress, AutoFollowShiftDispatchHookRva),
+                ExpectedAutoFollowShiftDispatchHook, shiftDispatchHookWriteStarted, cleanupExceptions,
+                ref shiftDispatchHookRestored);
+            TryRestoreImprovedAutoFollowHook(writer, allocator, Add(moduleBaseAddress, AutoFollowAttackHookRva),
+                ExpectedAutoFollowAttackHook, attackHookWriteStarted, cleanupExceptions, ref attackHookRestored);
+            TryRestoreImprovedAutoFollowHook(writer, allocator, Add(moduleBaseAddress, AutoFollowGenerationHookRva),
+                ExpectedAutoFollowGenerationHook, generationHookWriteStarted, cleanupExceptions,
+                ref generationHookRestored);
+            TryRestoreImprovedAutoFollowHook(writer, allocator, Add(moduleBaseAddress, AutoFollowRouteHookRva),
+                ExpectedAutoFollowRouteHook, routeHookWriteStarted, cleanupExceptions, ref routeHookRestored);
+            TryRestoreImprovedAutoFollowHook(writer, allocator, Add(moduleBaseAddress, AutoFollowSelectHookRva),
+                ExpectedAutoFollowSelectHook, selectHookWriteStarted, cleanupExceptions, ref selectHookRestored);
+
+            var allHooksRestored = selectHookRestored && shiftDispatchHookRestored && routeHookRestored &&
+                                   generationHookRestored && attackHookRestored;
+            TryFreeImprovedAutoFollowAllocation(allocator, stubAddress, allHooksRestored, cleanupExceptions);
+            TryFreeImprovedAutoFollowAllocation(allocator, stateAddress, allHooksRestored, cleanupExceptions);
+
+            var innerException = cleanupExceptions.Count == 0
+                ? exception
+                : new AggregateException([exception, .. cleanupExceptions]);
+            throw new InvalidOperationException($"Failed to {stage}: {exception.Message}", innerException);
+        }
+    }
+
+    private static byte[] BuildImprovedAutoFollowState()
+    {
+        var state = new byte[AutoFollowStateSize];
+        WriteInt32(state, AutoFollowActiveDistanceOffset, AutoFollowDefaultDistance);
+        WriteInt32(state, AutoFollowShiftDistanceOffset, AutoFollowDefaultDistance);
+        return state;
+    }
+
+    private static byte[] BuildImprovedAutoFollowStub(IntPtr moduleBaseAddress, IntPtr stubAddress,
+        IntPtr stateAddress)
+    {
+        var stub = new byte[AutoFollowStubTemplate.Length];
+        AutoFollowStubTemplate.CopyTo(stub, 0);
+
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x00), 0x00B, 0x04F, 0x080, 0x0B6, 0x126);
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x04), 0x014, 0x08B, 0x0D7, 0x12E);
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x08), 0x05D, 0x09B, 0x0C4, 0x0CC);
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x0C), 0x01E, 0x0EE, 0x14E);
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x10), 0x019);
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x14),
+            0x02E, 0x03A, 0x046, 0x074, 0x0AA, 0x161, 0x179);
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x15), 0x028, 0x065, 0x15B);
+        WriteImprovedAutoFollowAddresses(stub, Add(stateAddress, 0x16), 0x023);
+
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowPursuitRva), 0x034, 0x040, 0x16D);
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowSendAttackRva), 0x06E);
+
+        // The documented 0x005F4AA6 continuation is inside the replaced generation hook.
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(stubAddress, AutoFollowGenerationReplayStubOffset), 0x0A4);
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowGenerationNonZeroRva), 0x192);
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowGenerationZeroRva), 0x197);
+
+        // Admit only the Shift-modified pursuit gesture for players and monsters.
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowShiftDispatchAllowedRva), 0x1A1, 0x1C2, 0x1CC);
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowShiftDispatchNativeFilterRva), 0x1AB, 0x1B8, 0x1D1);
+
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowResetMovementRva), 0x106, 0x185);
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowRouteEpilogueRva), 0x10B);
+        WriteImprovedAutoFollowRelativeOffsets(stub, stubAddress,
+            Add(moduleBaseAddress, AutoFollowRouteContinuationRva), 0x11A);
+
+        return stub;
+    }
+
+    private static byte[] BuildImprovedAutoFollowHook(IntPtr hookAddress, IntPtr stubAddress,
+        int stubOffset, byte opcode, int hookLength)
+    {
+        var hook = new byte[hookLength];
+        Array.Fill(hook, (byte)0x90);
+        hook[0] = opcode;
+        WriteInt32(hook, 1, GetRelativeOffset(hookAddress, 5, Add(stubAddress, stubOffset)));
+        return hook;
+    }
+
+    private static void WriteImprovedAutoFollowAddresses(byte[] stub, IntPtr address, params int[] offsets)
+    {
+        var absoluteAddress = checked((uint)address.ToInt64());
+        foreach (var offset in offsets)
+        {
+            WriteUInt32(stub, offset, absoluteAddress);
+        }
+    }
+
+    private static void WriteImprovedAutoFollowRelativeOffsets(byte[] stub, IntPtr stubAddress,
+        IntPtr targetAddress, params int[] offsets)
+    {
+        foreach (var offset in offsets)
+        {
+            WriteInt32(stub, offset,
+                GetRelativeOffset(Add(stubAddress, offset), sizeof(int), targetAddress));
+        }
+    }
+
+    private static void WriteImprovedAutoFollowHook(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr address, byte[] hook, ref bool writeStarted)
+    {
+        using (allocator.MakeWritable(address, hook.Length))
+        {
+            writeStarted = true;
+            writer.BaseStream.Position = address.ToInt64();
+            writer.Write(hook);
+            allocator.FlushInstructionCache(address, hook.Length);
+        }
+    }
+
+    private static void TryRestoreImprovedAutoFollowHook(BinaryWriter writer, ProcessMemoryAllocator allocator,
+        IntPtr hookAddress, byte[] expected, bool writeStarted, List<Exception> cleanupExceptions,
+        ref bool restored)
+    {
+        if (!writeStarted)
+        {
+            return;
+        }
+
+        try
+        {
+            using (allocator.MakeWritable(hookAddress, expected.Length))
+            {
+                writer.BaseStream.Position = hookAddress.ToInt64();
+                writer.Write(expected);
+                allocator.FlushInstructionCache(hookAddress, expected.Length);
+            }
+
+            VerifyRemoteBytes(writer, hookAddress, expected);
+            restored = true;
+        }
+        catch (Exception exception)
+        {
+            cleanupExceptions.Add(exception);
+        }
+    }
+
+    private static void TryFreeImprovedAutoFollowAllocation(ProcessMemoryAllocator allocator, IntPtr address,
+        bool safeToFree, List<Exception> cleanupExceptions)
+    {
+        if (address == IntPtr.Zero || !safeToFree)
+        {
+            return;
+        }
+
+        try
+        {
+            allocator.FreeMemory(address);
+        }
+        catch (Exception exception)
+        {
+            cleanupExceptions.Add(exception);
+        }
+    }
+}

--- a/Arbiter.App/Services/Client/GameClientService.cs
+++ b/Arbiter.App/Services/Client/GameClientService.cs
@@ -44,7 +44,7 @@ public partial class GameClientService : IGameClientService
         var shouldApplyModifierFix = options.ApplyModifiersKeyFix || options.AllowAltToShowGroundItems;
         var hasRuntimePatches = shouldApplyModifierFix || options.SkipQuantityPromptInExchange ||
                                 options.ShowItemQuantityInDialogs || options.MakeExchangeDialogDraggable ||
-                                options.ShowExchangeResultsInMessageBar;
+                                options.ShowExchangeResultsInMessageBar || options.ImprovedAutoFollow;
         if (hasRuntimePatches)
         {
             VerifySupportedClient(clientExecutablePath);
@@ -105,6 +105,11 @@ public partial class GameClientService : IGameClientService
                     if (options.ShowExchangeResultsInMessageBar)
                     {
                         ApplyShowExchangeResultsInMessageBarPatch(writer, allocator, moduleBaseAddress);
+                    }
+
+                    if (options.ImprovedAutoFollow)
+                    {
+                        ApplyImprovedAutoFollowPatch(writer, allocator, moduleBaseAddress);
                     }
 
                 }

--- a/Arbiter.App/Themes/TalgoniteTheme.axaml
+++ b/Arbiter.App/Themes/TalgoniteTheme.axaml
@@ -270,7 +270,7 @@
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.KnobBorderBrush" Color="#373d49"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.HoverBorderBrush" Color="#4d535d"/>
             <SolidColorBrush x:Key="Talgonite.ToggleSwitch.FocusBorderBrush" Color="#81b8f5"/>
-            <sys:Double x:Key="Talgonite.ToggleSwitch.KnobSize">28</sys:Double>
+            <sys:Double x:Key="Talgonite.ToggleSwitch.KnobSize">32</sys:Double>
             <CornerRadius x:Key="Talgonite.ToggleSwitch.KnobCornerRadius">2</CornerRadius>
             
             <!-- ToolTip Resources -->

--- a/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
+++ b/Arbiter.App/Themes/TalgoniteToggleSwitch.axaml
@@ -57,11 +57,10 @@
                                 BorderThickness="2"
                                 CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}">
                             <Panel>
-                                <!-- Inset fill to prevent checked color from peeking under sunken borders -->
+                                <!-- The border already insets its content, so fill that interior without exposing the track. -->
                                 <Border Name="SwitchTrackFill"
                                         Background="{StaticResource Talgonite.ToggleSwitch.TrackBackground}"
-                                        CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"
-                                        Margin="2"/>
+                                        CornerRadius="0"/>
                                 <Border Classes="sunken-shadow"
                                         CornerRadius="{StaticResource Talgonite.ToggleSwitch.KnobCornerRadius}"
                                         ZIndex="100"/>
@@ -73,9 +72,8 @@
                         
                         <Canvas Name="PART_SwitchKnob"
                                 Grid.Row="1" Grid.Column="0"
-                                Width="28"
+                                Width="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
                                 Height="{StaticResource Talgonite.ToggleSwitch.KnobSize}"
-                                Margin="2,0,0,0"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center">
                             
@@ -131,6 +129,7 @@
         
         <!-- Checked State -->
         <Style Selector="^:checked /template/ Border#SwitchTrackFill">
+            <Setter Property="Transitions" Value="{x:Null}"/>
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackCheckedBackground}"/>
         </Style>
         
@@ -142,12 +141,15 @@
             <Setter Property="IsVisible" Value="True"/>
         </Style>
         
-        <Style Selector="^:checked /template/ Canvas#PART_SwitchKnob">
-            <Setter Property="Margin" Value="6,0,0,0"/>
-        </Style>
-        
         <!-- Unchecked State -->
         <Style Selector="^:unchecked /template/ Border#SwitchTrackFill">
+            <Setter Property="Transitions">
+                <Transitions>
+                    <BrushTransition Property="Background"
+                                     Duration="0:0:0.150"
+                                     Easing="CubicEaseOut"/>
+                </Transitions>
+            </Setter>
             <Setter Property="Background" Value="{StaticResource Talgonite.ToggleSwitch.TrackBackground}"/>
         </Style>
         

--- a/Arbiter.App/ViewModels/MainWindowViewModel.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.cs
@@ -95,7 +95,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 Settings.SuppressLoginNotice, Settings.ApplyModifiersKeyFix,
                 Settings.AllowAltToShowGroundItems, Settings.SkipQuantityPromptInExchange,
                 Settings.ShowItemQuantityInDialogs, Settings.MakeExchangeDialogDraggable,
-                Settings.ShowExchangeResultsInMessageBar);
+                Settings.ShowExchangeResultsInMessageBar, Settings.ImprovedAutoFollow);
 
             await _gameClientService.LaunchLoopbackClient(clientExecutablePath, options);
         }

--- a/Arbiter.App/ViewModels/SettingsViewModel.cs
+++ b/Arbiter.App/ViewModels/SettingsViewModel.cs
@@ -39,6 +39,7 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
     [NotifyPropertyChangedFor(nameof(ShowItemQuantityInDialogs))]
     [NotifyPropertyChangedFor(nameof(MakeExchangeDialogDraggable))]
     [NotifyPropertyChangedFor(nameof(ShowExchangeResultsInMessageBar))]
+    [NotifyPropertyChangedFor(nameof(ImprovedAutoFollow))]
     [NotifyPropertyChangedFor(nameof(LocalPort))]
     [NotifyPropertyChangedFor(nameof(RemoteServerAddress))]
     [NotifyPropertyChangedFor(nameof(RemoteServerPort))]
@@ -178,6 +179,17 @@ public partial class SettingsViewModel : ViewModelBase, IDialogResult<ArbiterSet
         set
         {
             Settings.ShowExchangeResultsInMessageBar = value;
+            OnPropertyChanged();
+            HasChanges = true;
+        }
+    }
+
+    public bool ImprovedAutoFollow
+    {
+        get => Settings.ImprovedAutoFollow;
+        set
+        {
+            Settings.ImprovedAutoFollow = value;
             OnPropertyChanged();
             HasChanges = true;
         }

--- a/Arbiter.App/Views/SettingsWindow.axaml
+++ b/Arbiter.App/Views/SettingsWindow.axaml
@@ -60,9 +60,17 @@
                             </Button>
                         </TextBox.InnerRightContent>
                     </TextBox>
-                    
-                    <!-- Options -->
-                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="3">
+                </StackPanel>
+            </TabItem>
+
+            <!-- Client Patches Tab -->
+            <TabItem Header="Patches">
+                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled">
+                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                          ColumnDefinitions="*,Auto"
+                          RowSpacing="3"
+                          Margin="4,4,12,4">
                         <!-- Skip Intro Video  -->
                         <Label Grid.Row="0" Grid.Column="0"
                                Content="Skip Intro Video"
@@ -111,8 +119,14 @@
                                ToolTip.Tip="Shows final accepted and cancelled exchange messages in the floating message bar instead of popups."/>
                         <ToggleSwitch Grid.Row="7" Grid.Column="1"
                                       IsChecked="{Binding ShowExchangeResultsInMessageBar}"/>
+                        <!-- Improved Auto-Follow -->
+                        <Label Grid.Row="8" Grid.Column="0"
+                               Content="Improved Auto-Follow"
+                               ToolTip.Tip="Shift+right-click a player or monster to follow without attacking, stopping three route tiles away."/>
+                        <ToggleSwitch Grid.Row="8" Grid.Column="1"
+                                      IsChecked="{Binding ImprovedAutoFollow}"/>
                     </Grid>
-                </StackPanel>
+                </ScrollViewer>
             </TabItem>
             
             <!-- Network Settings Tab -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.8] - 2026-07-24
+
+### Added
+
+- Add an enabled-by-default Improved Auto-Follow client patch that makes Shift+right-click follow players and monsters without attacking, stopping at a shortest-path distance of three tiles
+
+### Changed
+
+- Move game client patch options into a dedicated scrollable Patches settings tab
+
+### Fixed
+
+- Make toggle-switch track fills sit flush against their borders without dark corner artifacts and fade briefly when switched off
+- Keep Improved Auto-Follow generation replay outside its overwritten hook bytes and let Shift-modified clicks reach player and monster targets
+
 ## [1.9.7] - 2026-07-18
 
 ### Added


### PR DESCRIPTION
## Summary

- add an enabled-by-default Improved Auto-Follow runtime patch for Shift+right-click pursuit without attacks, stopping at a three-tile route distance
- add a dedicated scrollable Patches settings tab for the growing client patch list
- make toggle-switch thumbs flush with their tracks and retain a brief fade when switching off
- bump the app, assembly, and file versions to 1.9.8 and add the 2026-07-24 changelog section

## Why

The reference auto-follow patch had two runtime issues. Its generation hook returned into bytes overwritten by its own jump, which caused normal pursuit to crash. It also assumed Shift-modified clicks reached living-object handlers, but the native dispatcher filters player and monster categories first.

This implementation replays the complete overwritten generation branch outside the hook. A fifth dispatch hook bypasses the Shift filter only for pointer type 5 on category 1 players or category 2 monsters/Mundanes. Category 8 item behavior and every other event continue through the native filter.

## Impact

Players can keep normal follow-and-attack behavior or hold Shift while right-clicking a living target to follow without attacking. Patch settings are easier to scan, and toggle switches no longer expose track colors around undersized thumbs.

## Validation

- `dotnet build Arbiter.sln -c Release --artifacts-path C:\Users\Erik\AppData\Local\Temp\arbiter-release-1.9.8-artifacts`
  - succeeded with 0 warnings and 0 errors
- `dotnet test Arbiter.App.Tests\Arbiter.App.Tests.csproj -c Release --no-restore --artifacts-path C:\Users\Erik\AppData\Local\Temp\arbiter-release-1.9.8-artifacts`
  - 125 passed, 0 failed
- verified the produced executable reports file version 1.9.8
- manually confirmed normal pursuit no longer crashes and retains native behavior

The final narrowed Shift-only dispatch should receive one in-game confirmation before merging and tagging the release.
