### PR TITLE
Release 1.9.9 stability fixes

### DIFF
--- a/Arbiter.App.Tests/Threading/DispatcherBatchQueueTests.cs
+++ b/Arbiter.App.Tests/Threading/DispatcherBatchQueueTests.cs
@@ -1,0 +1,51 @@
+using Arbiter.App.Threading;
+
+namespace Arbiter.App.Tests.Threading;
+
+public sealed class DispatcherBatchQueueTests
+{
+    [Test]
+    public void Should_Drop_Oldest_Pending_Items_When_Queue_Reaches_Its_Limit()
+    {
+        var appliedItems = new List<int>();
+        var queue = new DispatcherBatchQueue<int>(items => appliedItems.AddRange(items),
+            maxPendingItems: 3);
+
+        var droppedItems = Enumerable.Range(1, 5).Sum(queue.Enqueue);
+        queue.DrainAll();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(droppedItems, Is.EqualTo(2));
+            Assert.That(queue.DroppedItemCount, Is.EqualTo(2));
+            Assert.That(queue.PendingCount, Is.Zero);
+            Assert.That(appliedItems, Is.EqualTo(new[] { 3, 4, 5 }));
+        });
+    }
+
+    [Test]
+    public void Should_Keep_Pending_Items_Bounded_Under_Sustained_Producer_Load()
+    {
+        const int pendingLimit = 4096;
+        const int producedItems = 100_000;
+        var appliedItems = new List<int>();
+        var queue = new DispatcherBatchQueue<int>(items => appliedItems.AddRange(items),
+            maxPendingItems: pendingLimit);
+
+        for (var item = 1; item <= producedItems; item++)
+        {
+            queue.Enqueue(item);
+        }
+
+        Assert.That(queue.PendingCount, Is.EqualTo(pendingLimit));
+        queue.DrainAll();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(queue.DroppedItemCount, Is.EqualTo(producedItems - pendingLimit));
+            Assert.That(appliedItems, Has.Count.EqualTo(pendingLimit));
+            Assert.That(appliedItems[0], Is.EqualTo(producedItems - pendingLimit + 1));
+            Assert.That(appliedItems[^1], Is.EqualTo(producedItems));
+        });
+    }
+}

--- a/Arbiter.App/Arbiter.App.csproj
+++ b/Arbiter.App/Arbiter.App.csproj
@@ -9,9 +9,9 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <Company>Erik 'SiLo' Rogers</Company>
         <Product>Arbiter</Product>
-        <Version>1.9.8</Version>
-        <AssemblyVersion>1.9.8</AssemblyVersion>
-        <FileVersion>1.9.8</FileVersion>
+        <Version>1.9.9</Version>
+        <AssemblyVersion>1.9.9</AssemblyVersion>
+        <FileVersion>1.9.9</FileVersion>
         <ApplicationIcon>Assets\arbiter.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/Arbiter.App/Behaviors/ScrollToEndBehavior.cs
+++ b/Arbiter.App/Behaviors/ScrollToEndBehavior.cs
@@ -1,4 +1,7 @@
 ﻿using System.Collections.Specialized;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
@@ -10,6 +13,8 @@ namespace Arbiter.App.Behaviors;
 
 public class ScrollToEndBehavior : AvaloniaObject
 {
+    private static readonly ConditionalWeakTable<Interactive, AutoScrollSubscription> AutoScrollSubscriptions = new();
+
     #region AutoScrollToEnd Property
 
     public static readonly AttachedProperty<bool> AutoScrollToEndProperty =
@@ -41,32 +46,36 @@ public class ScrollToEndBehavior : AvaloniaObject
 
     private static void HandleAutoScrollToEndChanged(Interactive element, AvaloniaPropertyChangedEventArgs e)
     {
+        if (e.NewValue is false)
+        {
+            if (AutoScrollSubscriptions.TryGetValue(element, out var existingSubscription))
+            {
+                existingSubscription.Dispose();
+                AutoScrollSubscriptions.Remove(element);
+            }
+
+            return;
+        }
+
+        if (e.NewValue is not true)
+        {
+            return;
+        }
+
         var itemsControl = element as ItemsControl ?? element.FindDescendantOfType<ItemsControl>();
         if (itemsControl is null)
         {
             return;
         }
 
-        if (e.NewValue is true)
+        if (AutoScrollSubscriptions.TryGetValue(element, out _))
         {
-            itemsControl.Items.CollectionChanged += OnCollectionChanged;
-        }
-        else if (e.NewValue is false)
-        {
-            itemsControl.Items.CollectionChanged -= OnCollectionChanged;
+            return;
         }
 
-        return;
-        
-        void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs _)
-        {
-            if (!GetAutoScrollToEnd(element))
-            {
-                return;
-            }
-
-            TryScrollToEnd(element);
-        }
+        var subscription = new AutoScrollSubscription(element, itemsControl);
+        AutoScrollSubscriptions.Add(element, subscription);
+        subscription.Start();
     }
 
     private static void HandleScrollToEndChanged(Interactive element, AvaloniaPropertyChangedEventArgs e)
@@ -76,15 +85,18 @@ public class ScrollToEndBehavior : AvaloniaObject
             return;
         }
 
-        TryScrollToEnd(element, force: true);
+        AutoScrollSubscriptions.TryGetValue(element, out var subscription);
+        TryScrollToEnd(element, force: true, subscription);
         SetScrollToEnd(element, false);
     }
 
-    private static void TryScrollToEnd(Interactive element, bool force = false)
+    private static void TryScrollToEnd(Interactive element, bool force = false,
+        AutoScrollSubscription? subscription = null)
     {
         if (!Dispatcher.UIThread.CheckAccess())
         {
-            Dispatcher.UIThread.Post(() => TryScrollToEnd(element, force), DispatcherPriority.Background);
+            Dispatcher.UIThread.Post(() => TryScrollToEnd(element, force, subscription),
+                DispatcherPriority.Background);
             return;
         }
         
@@ -99,7 +111,110 @@ public class ScrollToEndBehavior : AvaloniaObject
 
         if (force || currentY >= maxY - 1)
         {
-            Dispatcher.UIThread.Post(() => scrollViewer.ScrollToEnd(), DispatcherPriority.Background);
+            if (subscription is not null)
+            {
+                subscription.ScheduleScroll(scrollViewer.ScrollToEnd);
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(scrollViewer.ScrollToEnd, DispatcherPriority.Background);
+            }
+        }
+    }
+
+    private sealed class AutoScrollSubscription : IDisposable
+    {
+        private readonly Interactive _element;
+        private readonly ItemsControl _itemsControl;
+        private bool _isSubscribed;
+        private bool _isDisposed;
+        private int _isScrollScheduled;
+
+        public AutoScrollSubscription(Interactive element, ItemsControl itemsControl)
+        {
+            _element = element;
+            _itemsControl = itemsControl;
+
+            _itemsControl.AttachedToVisualTree += OnAttachedToVisualTree;
+            _itemsControl.DetachedFromVisualTree += OnDetachedFromVisualTree;
+        }
+
+        public void Start()
+        {
+            if (TopLevel.GetTopLevel(_itemsControl) is not null)
+            {
+                Subscribe();
+            }
+        }
+
+        public void ScheduleScroll(Action action)
+        {
+            if (_isDisposed || Interlocked.CompareExchange(ref _isScrollScheduled, 1, 0) != 0)
+            {
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                try
+                {
+                    if (!_isDisposed && TopLevel.GetTopLevel(_itemsControl) is not null)
+                    {
+                        action();
+                    }
+                }
+                finally
+                {
+                    Volatile.Write(ref _isScrollScheduled, 0);
+                }
+            }, DispatcherPriority.Background);
+        }
+
+        private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e) => Subscribe();
+
+        private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) => Unsubscribe();
+
+        private void Subscribe()
+        {
+            if (_isDisposed || _isSubscribed)
+            {
+                return;
+            }
+
+            _itemsControl.Items.CollectionChanged += OnCollectionChanged;
+            _isSubscribed = true;
+        }
+
+        private void Unsubscribe()
+        {
+            if (!_isSubscribed)
+            {
+                return;
+            }
+
+            _itemsControl.Items.CollectionChanged -= OnCollectionChanged;
+            _isSubscribed = false;
+        }
+
+        private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs _)
+        {
+            if (GetAutoScrollToEnd(_element))
+            {
+                TryScrollToEnd(_element, subscription: this);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            Unsubscribe();
+            _itemsControl.AttachedToVisualTree -= OnAttachedToVisualTree;
+            _itemsControl.DetachedFromVisualTree -= OnDetachedFromVisualTree;
         }
     }
 }

--- a/Arbiter.App/Threading/DispatcherBatchQueue.cs
+++ b/Arbiter.App/Threading/DispatcherBatchQueue.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using Avalonia.Threading;
@@ -8,38 +7,80 @@ namespace Arbiter.App.Threading;
 
 public sealed class DispatcherBatchQueue<T>
 {
-    private readonly ConcurrentQueue<T> _queue = new();
+    private readonly Lock _queueLock = new();
+    private readonly Queue<T> _queue = [];
     private readonly Action<IReadOnlyList<T>> _applyBatch;
     private readonly Dispatcher _dispatcher;
     private readonly DispatcherPriority _priority;
     private readonly int _maxBatchSize;
+    private readonly int? _maxPendingItems;
 
     private int _isScheduled;
+    private long _droppedItemCount;
+
+    public int PendingCount
+    {
+        get
+        {
+            using var _ = _queueLock.EnterScope();
+            return _queue.Count;
+        }
+    }
+
+    public long DroppedItemCount => Interlocked.Read(ref _droppedItemCount);
 
     public DispatcherBatchQueue(Action<IReadOnlyList<T>> applyBatch, int maxBatchSize = 256,
-        Dispatcher? dispatcher = null, DispatcherPriority? priority = null)
+        Dispatcher? dispatcher = null, DispatcherPriority? priority = null, int? maxPendingItems = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(maxBatchSize, 1);
+        if (maxPendingItems.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxPendingItems.Value, 1);
+        }
 
         _applyBatch = applyBatch ?? throw new ArgumentNullException(nameof(applyBatch));
         _maxBatchSize = maxBatchSize;
+        _maxPendingItems = maxPendingItems;
         _dispatcher = dispatcher ?? Dispatcher.UIThread;
         _priority = priority ?? DispatcherPriority.Background;
     }
 
-    public void Enqueue(T item)
+    public int Enqueue(T item)
     {
-        _queue.Enqueue(item);
+        var droppedItems = 0;
+        {
+            using var _ = _queueLock.EnterScope();
+            _queue.Enqueue(item);
+
+            while (_maxPendingItems.HasValue && _queue.Count > _maxPendingItems.Value)
+            {
+                _queue.Dequeue();
+                droppedItems++;
+            }
+        }
+
+        if (droppedItems > 0)
+        {
+            Interlocked.Add(ref _droppedItemCount, droppedItems);
+        }
+
         ScheduleDrain();
+        return droppedItems;
     }
 
-    public void Clear() => _queue.Clear();
+    public void Clear()
+    {
+        using var _ = _queueLock.EnterScope();
+        _queue.Clear();
+    }
+
+    public void ResetDroppedItemCount() => Interlocked.Exchange(ref _droppedItemCount, 0);
 
     public void DrainAll()
     {
         _dispatcher.VerifyAccess();
 
-        while (!_queue.IsEmpty)
+        while (HasPendingItems())
         {
             ApplyNextBatch();
         }
@@ -64,7 +105,7 @@ public sealed class DispatcherBatchQueue<T>
         finally
         {
             Volatile.Write(ref _isScheduled, 0);
-            if (!_queue.IsEmpty)
+            if (HasPendingItems())
             {
                 ScheduleDrain();
             }
@@ -74,14 +115,23 @@ public sealed class DispatcherBatchQueue<T>
     private void ApplyNextBatch()
     {
         var batch = new List<T>(_maxBatchSize);
-        while (batch.Count < _maxBatchSize && _queue.TryDequeue(out var item))
         {
-            batch.Add(item);
+            using var _ = _queueLock.EnterScope();
+            while (batch.Count < _maxBatchSize && _queue.TryDequeue(out var item))
+            {
+                batch.Add(item);
+            }
         }
 
         if (batch.Count > 0)
         {
             _applyBatch(batch);
         }
+    }
+
+    private bool HasPendingItems()
+    {
+        using var _ = _queueLock.EnterScope();
+        return _queue.Count > 0;
     }
 }

--- a/Arbiter.App/ViewModels/MainWindowViewModel.cs
+++ b/Arbiter.App/ViewModels/MainWindowViewModel.cs
@@ -135,6 +135,30 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
+    private async Task UpdateRemoteEndpointAsync()
+    {
+        try
+        {
+            var remoteIpAddress = await Dns.GetHostAddressesAsync(Settings.RemoteServerAddress);
+            if (remoteIpAddress.Length == 0)
+            {
+                throw new Exception("Failed to resolve remote server address");
+            }
+
+            Proxy.SetRemoteEndpoint(remoteIpAddress[0], Settings.RemoteServerPort);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update remote server");
+            await _dialogService.ShowMessageBoxAsync(new MessageBoxDetails
+            {
+                Title = "Failed to Update Remote Server",
+                Message = $"An error occurred while updating the remote server:\n\n{ex.Message}",
+                Description = "Check the remote server address and port in Settings."
+            });
+        }
+    }
+
     private void OnPacketSelected(TracePacketViewModel? viewModel)
     {
         if (viewModel is null)
@@ -166,10 +190,21 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
+        var remoteEndpointChanged =
+            !string.Equals(Settings.RemoteServerAddress, newSettings.RemoteServerAddress,
+                StringComparison.OrdinalIgnoreCase) ||
+            Settings.RemoteServerPort != newSettings.RemoteServerPort;
+
         Settings = newSettings;
         Settings.SettingsPanelIndex = vm.SelectedTabIndex;
         
         await _settingsService.SaveToFileAsync(Settings);
+
+        if (remoteEndpointChanged)
+        {
+            await UpdateRemoteEndpointAsync();
+        }
+
         await _gameSpriteService.LoadAsync(Settings.ClientExecutablePath);
         LaunchClientCommand.NotifyCanExecuteChanged();
 

--- a/Arbiter.App/ViewModels/Proxy/ProxyViewModel.cs
+++ b/Arbiter.App/ViewModels/Proxy/ProxyViewModel.cs
@@ -51,6 +51,12 @@ public partial class ProxyViewModel : ViewModelBase
         _logger.LogInformation("Proxy started on 127.0.0.1:{Port}", localPort);
     }
 
+    public void SetRemoteEndpoint(IPAddress remoteIpAddress, int remotePort)
+    {
+        _proxyServer.SetRemoteEndpoint(remoteIpAddress, remotePort);
+        _logger.LogInformation("Proxy remote server updated to {Endpoint}", _proxyServer.RemoteEndpoint);
+    }
+
     private void OnClientConnected(object? sender, ProxyConnectionEventArgs e)
     {
         var name = e.Connection.Name ?? e.Connection.Id.ToString();

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.Filter.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.Filter.cs
@@ -139,16 +139,15 @@ public partial class TraceViewModel
     // Prune any client entries from filter parameters that are no longer present in the packet list
     private void PruneClientsNotInPackets()
     {
-        // Build case-insensitive set of remaining client names from all packets
-        var remaining = _allPackets
-            .Select(p => p.DisplayClientName ?? string.Empty)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
         if (FilterParameters.Clients.Count == 0)
         {
             return;
         }
+
+        // Build case-insensitive set of remaining client names from all packets
+        var remaining = _allPackets
+            .Select(p => p.DisplayClientName ?? string.Empty)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         // Determine which client filter entries are no longer present
         var toRemove = FilterParameters.Clients

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.Queue.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.Queue.cs
@@ -6,17 +6,22 @@ using Arbiter.App.Threading;
 using Arbiter.Net;
 using Arbiter.Net.Filters;
 using Arbiter.Net.Proxy;
+using Microsoft.Extensions.Logging;
 
 namespace Arbiter.App.ViewModels.Tracing;
 
 public partial class TraceViewModel
 {
+    private const int MaxPendingTracePackets = 4096;
+
     private sealed record QueuedTracePacket(long Generation, NetworkPacket Encrypted, NetworkPacket Decrypted,
         NetworkFilterResult? FilterResult, string? ClientName, int ConnectionId, PacketDisplayMode DisplayMode);
 
     private readonly DispatcherBatchQueue<QueuedTracePacket> _packetQueue;
     private long _packetGeneration;
     private int _isAcceptingPackets;
+    private int _hasReportedPacketOverflow;
+    private bool _isApplyingPacketBatch;
 
     private void QueuePacket(ProxyConnectionDataEventArgs e)
     {
@@ -35,32 +40,55 @@ public partial class TraceViewModel
             return;
         }
 
-        _packetQueue.Enqueue(new QueuedTracePacket(generation, e.Encrypted, e.Decrypted, e.FilterResult,
-            name, connection.Id, _packetDisplayMode));
+        var droppedItems = _packetQueue.Enqueue(new QueuedTracePacket(generation, e.Encrypted, e.Decrypted,
+            e.FilterResult, name, connection.Id, _packetDisplayMode));
+        if (droppedItems > 0 && Interlocked.CompareExchange(ref _hasReportedPacketOverflow, 1, 0) == 0)
+        {
+            _logger.LogWarning("Trace processing fell behind; oldest pending packets will be dropped");
+        }
     }
 
     private void ApplyPacketBatch(IReadOnlyList<QueuedTracePacket> packets)
     {
         var generation = Volatile.Read(ref _packetGeneration);
-        foreach (var queued in packets)
+        var removedPackets = false;
+
+        _isApplyingPacketBatch = true;
+        try
         {
-            if (queued.Generation != generation)
+            using (FilteredPackets.DeferRefresh())
             {
-                continue;
+                foreach (var queued in packets)
+                {
+                    if (queued.Generation != generation)
+                    {
+                        continue;
+                    }
+
+                    var vm = new TracePacketViewModel(queued.Encrypted, queued.Decrypted, queued.FilterResult,
+                        queued.ClientName, queued.ConnectionId)
+                    {
+                        DisplayMode = queued.DisplayMode
+                    };
+
+                    AddPacketToTrace(vm, false);
+                }
+
+                while (_allPackets.Count > MaxTraceHistory)
+                {
+                    _allPackets.RemoveAt(0);
+                    removedPackets = true;
+                }
             }
-
-            var vm = new TracePacketViewModel(queued.Encrypted, queued.Decrypted, queued.FilterResult,
-                queued.ClientName, queued.ConnectionId)
-            {
-                DisplayMode = queued.DisplayMode
-            };
-
-            AddPacketToTrace(vm, false);
+        }
+        finally
+        {
+            _isApplyingPacketBatch = false;
         }
 
-        while (_allPackets.Count > MaxTraceHistory)
+        if (removedPackets)
         {
-            _allPackets.RemoveAt(0);
+            RefreshAfterPacketRemoval();
         }
     }
 }

--- a/Arbiter.App/ViewModels/Tracing/TraceViewModel.cs
+++ b/Arbiter.App/ViewModels/Tracing/TraceViewModel.cs
@@ -112,7 +112,8 @@ public partial class TraceViewModel : ViewModelBase
 
         SelectedTraceClient = TraceClients.FirstOrDefault();
         FilteredPackets = new FilteredObservableCollection<TracePacketViewModel>(_allPackets, MatchesFilter);
-        _packetQueue = new DispatcherBatchQueue<QueuedTracePacket>(ApplyPacketBatch);
+        _packetQueue = new DispatcherBatchQueue<QueuedTracePacket>(ApplyPacketBatch,
+            maxPendingItems: MaxPendingTracePackets);
 
         _allPackets.CollectionChanged += OnPacketCollectionChanged;
         SelectedPackets.CollectionChanged += OnSelectedPacketsCollectionChanged;
@@ -173,7 +174,20 @@ public partial class TraceViewModel : ViewModelBase
         // When packets are removed/reset, prune client filters that no longer exist in any remaining packet
         if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Reset)
         {
-            PruneClientsNotInPackets();
+            if (_isApplyingPacketBatch)
+            {
+                return;
+            }
+
+            RefreshAfterPacketRemoval();
+        }
+    }
+
+    private void RefreshAfterPacketRemoval()
+    {
+        PruneClientsNotInPackets();
+        if (IsSearchActive)
+        {
             RefreshSearchResults();
         }
     }
@@ -243,6 +257,8 @@ public partial class TraceViewModel : ViewModelBase
 
         TraceClientName = SelectedTraceClient?.Name;
 
+        _packetQueue.ResetDroppedItemCount();
+        Interlocked.Exchange(ref _hasReportedPacketOverflow, 0);
         Volatile.Write(ref _isAcceptingPackets, 1);
         _proxyServer.PacketReceived += OnPacketReceived;
         _proxyServer.PacketQueued += OnPacketQueued;
@@ -270,6 +286,13 @@ public partial class TraceViewModel : ViewModelBase
         Interlocked.Increment(ref _packetGeneration);
 
         IsRunning = false;
+
+        var droppedPackets = _packetQueue.DroppedItemCount;
+        if (droppedPackets > 0)
+        {
+            _logger.LogWarning("Trace dropped {Count} pending packets to keep the application responsive",
+                droppedPackets);
+        }
 
         PruneClients();
         _logger.LogInformation("Trace stopped");

--- a/Arbiter.Net.Tests/Proxy/ProxyServerTests.cs
+++ b/Arbiter.Net.Tests/Proxy/ProxyServerTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using Arbiter.Net.Proxy;
@@ -25,5 +26,38 @@ public class ProxyServerTests
 
         Assert.That(snapshot, Is.EqualTo(new[] { connection }));
         Assert.That(server.Connections, Is.Empty);
+    }
+
+    [Test]
+    public async Task Should_Use_Updated_Remote_Endpoint_For_New_Connections()
+    {
+        using var firstRemoteListener = new TcpListener(IPAddress.Loopback, 0);
+        using var secondRemoteListener = new TcpListener(IPAddress.Loopback, 0);
+        firstRemoteListener.Start();
+        secondRemoteListener.Start();
+
+        var firstRemoteEndpoint = (IPEndPoint)firstRemoteListener.LocalEndpoint;
+        var secondRemoteEndpoint = (IPEndPoint)secondRemoteListener.LocalEndpoint;
+
+        using var server = new ProxyServer();
+        server.Start(0, firstRemoteEndpoint);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var firstProxyClient = new TcpClient();
+        await firstProxyClient.ConnectAsync(server.LocalEndpoint!, timeout.Token);
+        using var firstRemoteClient = await firstRemoteListener.AcceptTcpClientAsync(timeout.Token);
+
+        server.SetRemoteEndpoint(secondRemoteEndpoint);
+
+        using var secondProxyClient = new TcpClient();
+        await secondProxyClient.ConnectAsync(server.LocalEndpoint!, timeout.Token);
+        using var secondRemoteClient = await secondRemoteListener.AcceptTcpClientAsync(timeout.Token);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstRemoteClient.Connected, Is.True);
+            Assert.That(secondRemoteClient.Connected, Is.True);
+            Assert.That(server.RemoteEndpoint, Is.EqualTo(secondRemoteEndpoint));
+        });
     }
 }

--- a/Arbiter.Net.Tests/Proxy/ProxyServerTests.cs
+++ b/Arbiter.Net.Tests/Proxy/ProxyServerTests.cs
@@ -60,4 +60,41 @@ public class ProxyServerTests
             Assert.That(server.RemoteEndpoint, Is.EqualTo(secondRemoteEndpoint));
         });
     }
+
+    [Test]
+    public async Task Should_Close_Both_Sockets_When_Client_Disconnects()
+    {
+        using var remoteListener = new TcpListener(IPAddress.Loopback, 0);
+        remoteListener.Start();
+
+        var remoteEndpoint = (IPEndPoint)remoteListener.LocalEndpoint;
+        using var server = new ProxyServer();
+        var clientDisconnected = new TaskCompletionSource<ProxyConnection>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        server.ClientDisconnected += (_, e) => clientDisconnected.TrySetResult(e.Connection);
+        server.Start(0, remoteEndpoint);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var proxyClient = new TcpClient();
+        await proxyClient.ConnectAsync(server.LocalEndpoint!, timeout.Token);
+        using var remoteClient = await remoteListener.AcceptTcpClientAsync(timeout.Token);
+
+        proxyClient.Close();
+
+        var disconnectedConnection = await clientDisconnected.Task.WaitAsync(timeout.Token);
+        while (server.Connections.Any())
+        {
+            await Task.Delay(10, timeout.Token);
+        }
+
+        var buffer = new byte[1];
+        var remoteReadCount = await remoteClient.GetStream().ReadAsync(buffer, timeout.Token);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disconnectedConnection.IsClientConnected, Is.False);
+            Assert.That(disconnectedConnection.IsServerConnected, Is.False);
+            Assert.That(remoteReadCount, Is.Zero);
+        });
+    }
 }

--- a/Arbiter.Net/Proxy/ProxyConnection.RecvLoop.cs
+++ b/Arbiter.Net/Proxy/ProxyConnection.RecvLoop.cs
@@ -120,14 +120,6 @@ public partial class ProxyConnection
                 }
             }
             
-            if (direction == ProxyDirection.ClientToServer)
-            {
-                ClientDisconnected?.Invoke(this, EventArgs.Empty);
-            }
-            else
-            {
-                ServerDisconnected?.Invoke(this, EventArgs.Empty);
-            }
         }
         catch when (token.IsCancellationRequested)
         {
@@ -136,6 +128,17 @@ public partial class ProxyConnection
         {
             ArrayPool<byte>.Shared.Return(recvBuffer);
             _sendQueue.Writer.TryComplete();
+
+            if (direction == ProxyDirection.ClientToServer)
+            {
+                Volatile.Write(ref _isClientConnected, 0);
+                ClientDisconnected?.Invoke(this, EventArgs.Empty);
+            }
+            else
+            {
+                Volatile.Write(ref _isServerConnected, 0);
+                ServerDisconnected?.Invoke(this, EventArgs.Empty);
+            }
         }
     }
 }

--- a/Arbiter.Net/Proxy/ProxyConnection.SendLoop.cs
+++ b/Arbiter.Net/Proxy/ProxyConnection.SendLoop.cs
@@ -7,8 +7,9 @@ namespace Arbiter.Net.Proxy;
 
 public partial class ProxyConnection
 {
-    private async Task SendLoopAsync(CancellationToken token = default)
+    private async Task SendLoopAsync(CancellationTokenSource tokenSource)
     {
+        var token = tokenSource.Token;
         var headerBuffer = ArrayPool<byte>.Shared.Rent(NetworkPacket.HeaderSize);
 
         try
@@ -107,8 +108,9 @@ public partial class ProxyConnection
                 }
                 catch (IOException)
                 {
-                    // Socket was disconnected, cancel the send operation
-                    continue;
+                    // Either socket ending tears down the whole proxy connection.
+                    await tokenSource.CancelAsync().ConfigureAwait(false);
+                    break;
                 }
 
                 // Notify that we have sent a packet

--- a/Arbiter.Net/Proxy/ProxyConnection.cs
+++ b/Arbiter.Net/Proxy/ProxyConnection.cs
@@ -34,6 +34,8 @@ public partial class ProxyConnection : IDisposable
 
     private int _clientSequence;
     private int _serverSequence;
+    private int _isClientConnected;
+    private int _isServerConnected;
     private int _isTransferring;
     private readonly Channel<NetworkPacket> _sendQueue = Channel.CreateUnbounded<NetworkPacket>();
     private readonly Channel<NetworkPacket> _prioritySendQueue = Channel.CreateUnbounded<NetworkPacket>();
@@ -48,8 +50,8 @@ public partial class ProxyConnection : IDisposable
     public IPEndPoint? LocalEndpoint => _client.Client.LocalEndPoint as IPEndPoint;
     public IPEndPoint? RemoteEndpoint => _server?.Client.RemoteEndPoint as IPEndPoint;
     public bool IsConnected => IsClientConnected && IsServerConnected;
-    public bool IsClientConnected => _client.Connected;
-    public bool IsServerConnected => _server?.Connected ?? false;
+    public bool IsClientConnected => Volatile.Read(ref _isClientConnected) != 0;
+    public bool IsServerConnected => Volatile.Read(ref _isServerConnected) != 0;
 
     public event EventHandler? ClientAuthenticated;
     public event EventHandler? ClientLoggedIn;
@@ -72,6 +74,7 @@ public partial class ProxyConnection : IDisposable
 
         _client = client;
         _client.NoDelay = true;
+        _isClientConnected = client.Connected ? 1 : 0;
 
         _clientMessageFactory = clientMessageFactory ?? ClientMessageFactory.Default;
         _serverMessageFactory = serverMessageFactory ?? ServerMessageFactory.Default;
@@ -89,30 +92,32 @@ public partial class ProxyConnection : IDisposable
         _clientStream = _client.GetStream();
         _serverStream = _server.GetStream();
 
+        Volatile.Write(ref _isServerConnected, 1);
         ServerConnected?.Invoke(this, EventArgs.Empty);
     }
 
-    internal Task SendRecvLoopAsync(CancellationToken token = default)
+    internal async Task SendRecvLoopAsync(CancellationToken token = default)
     {
-        var linked = CancellationTokenSource.CreateLinkedTokenSource(token);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(token);
 
         // Start the client/server recv and send queue tasks in the background
         var clientRecvTask = RecvLoopAsync(_clientStream!, _clientPacketBuffer, _clientEncryptor,
             ProxyDirection.ClientToServer, linked);
         var serverRecvTask = RecvLoopAsync(_serverStream!, _serverPacketBuffer, _serverEncryptor,
             ProxyDirection.ServerToClient, linked);
-        var senderTask = SendLoopAsync(linked.Token);
+        var senderTask = SendLoopAsync(linked);
 
-        return Task.WhenAll(clientRecvTask, serverRecvTask, senderTask);
+        await Task.WhenAll(clientRecvTask, serverRecvTask, senderTask).ConfigureAwait(false);
     }
 
     public void Disconnect()
     {
-        if (!IsConnected)
+        if (!IsClientConnected)
         {
             return;
         }
 
+        Volatile.Write(ref _isClientConnected, 0);
         _client.Close();
     }
 
@@ -131,6 +136,9 @@ public partial class ProxyConnection : IDisposable
 
         if (isDisposing)
         {
+            Volatile.Write(ref _isClientConnected, 0);
+            Volatile.Write(ref _isServerConnected, 0);
+
             _sendQueue.Writer.TryComplete();
             _prioritySendQueue.Writer.TryComplete();
 

--- a/Arbiter.Net/Proxy/ProxyServer.cs
+++ b/Arbiter.Net/Proxy/ProxyServer.cs
@@ -20,7 +20,7 @@ public partial class ProxyServer : IDisposable
 
     public bool IsRunning => _listener is not null;
     public IPEndPoint? LocalEndpoint => _listener?.LocalEndpoint as IPEndPoint;
-    public IPEndPoint? RemoteEndpoint => _remoteEndpoint;
+    public IPEndPoint? RemoteEndpoint => Volatile.Read(ref _remoteEndpoint);
 
     public event Action? Started;
     public event Action? Stopped;
@@ -59,7 +59,7 @@ public partial class ProxyServer : IDisposable
             throw new InvalidOperationException("Proxy server is already running");
         }
 
-        _remoteEndpoint = remoteEndpoint;
+        SetRemoteEndpoint(remoteEndpoint);
 
         _cancelTokenSource = new CancellationTokenSource();
         _listener = new TcpListener(IPAddress.Loopback, listenPort);
@@ -68,6 +68,17 @@ public partial class ProxyServer : IDisposable
         _ = AcceptLoopAsync(_cancelTokenSource.Token);
 
         Started?.Invoke();
+    }
+
+    public void SetRemoteEndpoint(IPAddress remoteAddress, int remotePort) =>
+        SetRemoteEndpoint(new IPEndPoint(remoteAddress, remotePort));
+
+    public void SetRemoteEndpoint(IPEndPoint remoteEndpoint)
+    {
+        CheckIfDisposed();
+        ArgumentNullException.ThrowIfNull(remoteEndpoint);
+
+        Volatile.Write(ref _remoteEndpoint, remoteEndpoint);
     }
 
     public void Stop()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Apply remote server address and port changes to new proxy connections without restarting Arbiter
+- Prevent runaway memory use and UI stalls while tracing by bounding pending packets, batching updates, and promptly closing disconnected proxy connections
 
 ## [1.9.8] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.9] - 2026-07-31
+
+### Fixed
+
+- Apply remote server address and port changes to new proxy connections without restarting Arbiter
+
 ## [1.9.8] - 2026-07-24
 
 ### Added


### PR DESCRIPTION
## Summary

- Apply remote server address and port changes to new proxy connections without restarting Arbiter
- Bound pending trace work and retain the newest packets when producers outpace the UI
- Batch trace collection, filter, and search maintenance instead of repeating it for every packet
- Coalesce automatic scrolling and release its collection subscription when the trace view detaches
- Tear down both halves of a proxy connection when either socket disconnects or a send fails
- Prepare the app and changelog for the 1.9.9 patch release

## Root causes

The proxy copied its remote endpoint only when it started, so applying new Network settings did not update the running server.

Tracing used an unbounded background-to-UI queue. The configured history limit applied only after queued packets reached the UI, while each removal also repeated filter, search, and scroll work. A disconnected client could leave the remote half of its proxy connection alive, allowing pending trace and dispatcher work to continue growing after the UI no longer showed an active client.

## Impact

New client connections use updated remote settings immediately. Trace backlog is capped at 4,096 pending packets; if that limit is reached, the oldest pending packets are dropped so Arbiter remains responsive and the newest traffic is retained. Disconnecting either side now closes the complete proxy connection promptly.

After this PR is merged to `main`, tag the merge commit as `v1.9.9` to run the existing release workflow.

## Validation

- `dotnet test Arbiter.App.Tests/Arbiter.App.Tests.csproj --configuration Release` (127 passed)
- `dotnet test Arbiter.Net.Tests/Arbiter.Net.Tests.csproj --configuration Release` (54 passed)
- Queue stress regression with 100,000 produced items verifies the pending count remains capped and newest items are retained
- Disconnect regression passed 20 consecutive Release-mode runs
- `dotnet build Arbiter.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- Release metadata validation for `v1.9.9`
- `win-x64` single-file publish with all required release files verified
